### PR TITLE
fix(hooks): address Copilot review comments from PR #24

### DIFF
--- a/.claude/hooks/handlers/notification.py
+++ b/.claude/hooks/handlers/notification.py
@@ -41,9 +41,13 @@ def main() -> None:
 
         event = json.loads(input_data)
 
-        # Get content preview (first 200 chars)
+        # Get content preview (first 200 bytes, safely truncated for UTF-8)
         message = event.get("message", "")
-        content_preview = message[:200] if message else ""
+        content_preview = (
+            message.encode("utf-8")[:200].decode("utf-8", errors="ignore")
+            if message
+            else ""
+        )
 
         log_analytics(
             {

--- a/primitives/v1/hooks/git/README.md
+++ b/primitives/v1/hooks/git/README.md
@@ -11,6 +11,16 @@ These hooks capture git operations and emit JSONL events to `.agentic/analytics/
 - **Code Velocity**: Monitor code reaching stable branches
 - **Workflow Patterns**: Analyze development patterns over time
 
+## Requirements
+
+- **Python 3.8+** - Required for the installer. Also used for JSON escaping in hooks (with bash fallback if unavailable).
+- **Git 2.9+** - For global hooks support via `core.hooksPath`.
+- **Bash** - The hooks are bash scripts.
+
+### Windows Notes
+
+On Windows, these hooks require **Git Bash** (included with Git for Windows) to execute. The hooks are bash scripts and will not run directly in PowerShell or CMD. Git for Windows automatically uses Git Bash to run hooks, so no additional configuration is needed.
+
 ## Installation
 
 ### Single Repository

--- a/primitives/v1/hooks/git/install.py
+++ b/primitives/v1/hooks/git/install.py
@@ -84,10 +84,10 @@ def install_hooks(target_dir: Path, script_dir: Path) -> bool:
         if dst.exists() and not dst.is_symlink() and not is_our_hook(dst):
             backup = dst.with_suffix(".bak")
             print(f"  Backing up existing {hook} to {hook}.bak")
-            shutil.move(str(dst), str(backup))
+            shutil.move(dst, backup)
 
         try:
-            shutil.copy2(str(src), str(dst))
+            shutil.copy2(src, dst)
             # Make executable on Unix-like systems
             if os.name != "nt":
                 dst.chmod(dst.stat().st_mode | 0o111)
@@ -128,7 +128,7 @@ def uninstall_hooks(target_dir: Path) -> bool:
 
         # Restore backup if exists
         if backup.exists():
-            shutil.move(str(backup), str(dst))
+            shutil.move(backup, dst)
             print(f"  Restored {hook} from backup")
 
     print("Done!")

--- a/primitives/v1/hooks/git/post-checkout
+++ b/primitives/v1/hooks/git/post-checkout
@@ -19,10 +19,10 @@ TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 SESSION_ID="${CLAUDE_SESSION_ID:-${AEF_SESSION_ID:-unknown}}"
 
-# Detect if this is a new branch
-# prev_ref is all zeros for new branches in some scenarios
-if [[ "$PREV_REF" == "0000000000000000000000000000000000000000" ]] || \
-   ! git rev-parse --verify "$BRANCH@{1}" >/dev/null 2>&1; then
+# Detect if this is a new branch using reflog
+# A branch is newly created if its reflog has only 1 entry (or none)
+REFLOG_COUNT=$(git reflog show "$BRANCH" --format=%H 2>/dev/null | wc -l | tr -d ' ')
+if [[ "${REFLOG_COUNT:-0}" -le 1 ]]; then
   EVENT_TYPE="git_branch_created"
 else
   EVENT_TYPE="git_branch_switched"

--- a/primitives/v1/hooks/git/post-commit
+++ b/primitives/v1/hooks/git/post-commit
@@ -3,59 +3,75 @@
 #
 # This hook is called after a commit is made. It emits observability events
 # with commit metadata and token estimates for analytics.
+#
+# IMPORTANT: This hook should never fail a commit, so all analytics logic
+# is wrapped in a subshell that can fail independently.
 
-set -euo pipefail
+# Wrap everything in a subshell so analytics failures never abort commits
+(
+  set -uo pipefail
 
-ANALYTICS_PATH="${ANALYTICS_PATH:-.agentic/analytics/events.jsonl}"
-mkdir -p "$(dirname "$ANALYTICS_PATH")"
+  ANALYTICS_PATH="${ANALYTICS_PATH:-.agentic/analytics/events.jsonl}"
+  mkdir -p "$(dirname "$ANALYTICS_PATH")"
 
-# Get commit info
-COMMIT_HASH=$(git rev-parse HEAD)
-COMMIT_MESSAGE=$(git log -1 --pretty=%B | head -1)
-AUTHOR=$(git log -1 --pretty=%an)
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
-TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  # Get commit info
+  COMMIT_HASH=$(git rev-parse HEAD)
+  COMMIT_MESSAGE=$(git log -1 --pretty=%B | head -1)
+  AUTHOR=$(git log -1 --pretty=%an)
+  BRANCH=$(git rev-parse --abbrev-ref HEAD)
+  TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-# Get diff stats (handle first commit case)
-if git rev-parse HEAD~1 >/dev/null 2>&1; then
-  STATS=$(git diff --stat HEAD~1 HEAD 2>/dev/null || echo "")
-  INSERTIONS=$(echo "$STATS" | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo "0")
-  DELETIONS=$(echo "$STATS" | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+' || echo "0")
-  FILES_CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null | wc -l | tr -d ' ')
+  # Get diff stats (handle first commit case)
+  if git rev-parse HEAD~1 >/dev/null 2>&1; then
+    STATS=$(git diff --stat HEAD~1 HEAD 2>/dev/null || echo "")
+    INSERTIONS=$(echo "$STATS" | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo "0")
+    DELETIONS=$(echo "$STATS" | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+' || echo "0")
+    FILES_CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null | wc -l | tr -d ' ')
 
-  # Estimate tokens (chars/4 approximation)
-  DIFF_CONTENT=$(git diff HEAD~1 HEAD 2>/dev/null || echo "")
-  ADDED_CHARS=$(echo "$DIFF_CONTENT" | grep '^+' | grep -v '^+++' | wc -c | tr -d ' ')
-  REMOVED_CHARS=$(echo "$DIFF_CONTENT" | grep '^-' | grep -v '^---' | wc -c | tr -d ' ')
-else
-  # First commit - show all files as added
-  INSERTIONS=$(git diff --cached --stat 2>/dev/null | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo "0")
-  DELETIONS="0"
-  FILES_CHANGED=$(git diff --cached --name-only 2>/dev/null | wc -l | tr -d ' ')
-  ADDED_CHARS=$(git show --format= HEAD | wc -c | tr -d ' ')
-  REMOVED_CHARS="0"
-fi
+    # Estimate tokens (chars/4 approximation)
+    # Use cut -c2- to remove the leading +/- from diff lines before counting
+    DIFF_CONTENT=$(git diff HEAD~1 HEAD 2>/dev/null || echo "")
+    ADDED_CHARS=$(echo "$DIFF_CONTENT" | grep '^+' | grep -v '^+++' | cut -c2- | wc -c | tr -d ' ')
+    REMOVED_CHARS=$(echo "$DIFF_CONTENT" | grep '^-' | grep -v '^---' | cut -c2- | wc -c | tr -d ' ')
+  else
+    # First commit - show all files as added
+    INSERTIONS=$(git diff --cached --stat 2>/dev/null | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo "0")
+    DELETIONS="0"
+    FILES_CHANGED=$(git diff --cached --name-only 2>/dev/null | wc -l | tr -d ' ')
+    ADDED_CHARS=$(git show --format= HEAD | wc -c | tr -d ' ')
+    REMOVED_CHARS="0"
+  fi
 
-# Handle empty values
-INSERTIONS="${INSERTIONS:-0}"
-DELETIONS="${DELETIONS:-0}"
-FILES_CHANGED="${FILES_CHANGED:-0}"
-ADDED_CHARS="${ADDED_CHARS:-0}"
-REMOVED_CHARS="${REMOVED_CHARS:-0}"
+  # Handle empty values
+  INSERTIONS="${INSERTIONS:-0}"
+  DELETIONS="${DELETIONS:-0}"
+  FILES_CHANGED="${FILES_CHANGED:-0}"
+  ADDED_CHARS="${ADDED_CHARS:-0}"
+  REMOVED_CHARS="${REMOVED_CHARS:-0}"
 
-TOKENS_ADDED=$((ADDED_CHARS / 4))
-TOKENS_REMOVED=$((REMOVED_CHARS / 4))
+  TOKENS_ADDED=$((ADDED_CHARS / 4))
+  TOKENS_REMOVED=$((REMOVED_CHARS / 4))
 
-# Get session_id from environment if available
-SESSION_ID="${CLAUDE_SESSION_ID:-${AEF_SESSION_ID:-unknown}}"
+  # Get session_id from environment if available
+  SESSION_ID="${CLAUDE_SESSION_ID:-${AEF_SESSION_ID:-unknown}}"
 
-# Escape JSON strings
-escape_json() {
-  printf '%s' "$1" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'
-}
+  # Escape JSON strings (with fallback if python3 is not available)
+  escape_json() {
+    if command -v python3 >/dev/null 2>&1; then
+      printf '%s' "$1" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'
+    else
+      # Simple fallback: escape quotes, backslashes, and control characters
+      local escaped
+      escaped=$(printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/	/\\t/g' | tr '\n' ' ')
+      printf '"%s"' "$escaped"
+    fi
+  }
 
-COMMIT_MESSAGE_JSON=$(escape_json "$COMMIT_MESSAGE")
-AUTHOR_JSON=$(escape_json "$AUTHOR")
+  COMMIT_MESSAGE_JSON=$(escape_json "$COMMIT_MESSAGE")
+  AUTHOR_JSON=$(escape_json "$AUTHOR")
 
-# Emit JSONL event
-echo "{\"timestamp\":\"$TIMESTAMP\",\"event_type\":\"git_commit\",\"session_id\":\"$SESSION_ID\",\"commit_hash\":\"$COMMIT_HASH\",\"commit_message\":$COMMIT_MESSAGE_JSON,\"author\":$AUTHOR_JSON,\"branch\":\"$BRANCH\",\"files_changed\":$FILES_CHANGED,\"insertions\":$INSERTIONS,\"deletions\":$DELETIONS,\"estimated_tokens_added\":$TOKENS_ADDED,\"estimated_tokens_removed\":$TOKENS_REMOVED}" >> "$ANALYTICS_PATH"
+  # Emit JSONL event
+  echo "{\"timestamp\":\"$TIMESTAMP\",\"event_type\":\"git_commit\",\"session_id\":\"$SESSION_ID\",\"commit_hash\":\"$COMMIT_HASH\",\"commit_message\":$COMMIT_MESSAGE_JSON,\"author\":$AUTHOR_JSON,\"branch\":\"$BRANCH\",\"files_changed\":$FILES_CHANGED,\"insertions\":$INSERTIONS,\"deletions\":$DELETIONS,\"estimated_tokens_added\":$TOKENS_ADDED,\"estimated_tokens_removed\":$TOKENS_REMOVED}" >> "$ANALYTICS_PATH"
+) || true
+
+exit 0

--- a/primitives/v1/hooks/git/post-merge
+++ b/primitives/v1/hooks/git/post-merge
@@ -18,8 +18,13 @@ case "$TARGET_BRANCH" in
   main|master|staging|develop|production|release/*) IS_STABLE="true" ;;
 esac
 
-# Get stats about the merge
-COMMITS_MERGED=$(git log --oneline "$MERGE_HEAD..HEAD" 2>/dev/null | wc -l | tr -d ' ')
+# Get stats about the merge - count commits between merge parents
+# HEAD^1 is the previous tip, HEAD^2 is the merged branch tip
+if git rev-parse HEAD^2 >/dev/null 2>&1; then
+  COMMITS_MERGED=$(git log --oneline HEAD^1..HEAD^2 2>/dev/null | wc -l | tr -d ' ')
+else
+  COMMITS_MERGED="0"
+fi
 COMMITS_MERGED="${COMMITS_MERGED:-0}"
 
 # Emit JSONL event

--- a/primitives/v1/hooks/git/pre-push
+++ b/primitives/v1/hooks/git/pre-push
@@ -21,8 +21,10 @@ UPSTREAM=$(git rev-parse --abbrev-ref "@{upstream}" 2>/dev/null || echo "")
 if [[ -n "$UPSTREAM" ]]; then
   COMMITS_TO_PUSH=$(git log --oneline "$UPSTREAM..HEAD" 2>/dev/null | wc -l | tr -d ' ')
 else
-  COMMITS_TO_PUSH="0"
+  # For new branches without upstream, count all commits on the branch
+  COMMITS_TO_PUSH=$(git rev-list --count HEAD 2>/dev/null || echo "0")
 fi
+COMMITS_TO_PUSH="${COMMITS_TO_PUSH:-0}"
 
 # Emit JSONL event
 echo "{\"timestamp\":\"$TIMESTAMP\",\"event_type\":\"git_push_started\",\"session_id\":\"$SESSION_ID\",\"remote\":\"$REMOTE_NAME\",\"branch\":\"$BRANCH\",\"commits_to_push\":$COMMITS_TO_PUSH}" >> "$ANALYTICS_PATH"


### PR DESCRIPTION
## Summary

Addresses all 11 Copilot code review comments from PR #24 (git observability hooks).

### Key Fixes

- **Resilient post-commit hook**: Wrapped analytics in subshell with `|| true` so failures never abort commits
- **Accurate character counting**: Added `cut -c2-` to remove `+`/`-` prefix before counting diff chars
- **Python3 fallback**: Added bash fallback for JSON escaping when python3 is unavailable
- **Better branch detection**: Use reflog count instead of unreliable zero-ref check
- **Correct merge counting**: Use `HEAD^1..HEAD^2` range for accurate commit counts
- **New branch push counts**: Use `git rev-list --count HEAD` for branches without upstream
- **Safe UTF-8 truncation**: Use byte-boundary safe truncation in notification handler
- **Clean Python code**: Remove unnecessary `str()` wrappers (Python 3.6+ supports Path objects)
- **Documentation**: Added Requirements section with Python 3.8+, Git Bash notes for Windows

## Test plan

- [x] Bash syntax validation (`bash -n`) on all hook scripts
- [x] Python linter passes on modified `.py` files
- [ ] Manual test: Install hooks, make commit, verify JSONL event emitted
- [ ] Manual test: Create branch, verify correct event type
- [ ] Manual test: Merge branch, verify commit count is accurate

## Related

Fixes review comments from #24