### PR TITLE
fix(docs): add favicon basePath and update fuma skill

### DIFF
--- a/docs-site-fuma/app/layout.tsx
+++ b/docs-site-fuma/app/layout.tsx
@@ -7,6 +7,9 @@ const inter = Inter({
   subsets: ['latin'],
 });
 
+// Get basePath for static export (GitHub Pages)
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+
 export const metadata: Metadata = {
   title: {
     template: '%s | agentic-primitives',
@@ -14,10 +17,10 @@ export const metadata: Metadata = {
   },
   description: 'Manage agentic primitives for AI agents across providers',
   icons: {
-    icon: '/favicon.svg',
-    apple: '/favicon.svg',
+    icon: `${basePath}/favicon.svg`,
+    apple: `${basePath}/favicon.svg`,
   },
-  metadataBase: new URL('https://agentic-primitives.dev'),
+  metadataBase: new URL('https://agentparadise.github.io/agentic-primitives'),
 };
 
 export default function Layout({ children }: LayoutProps<'/'>) {

--- a/primitives/v1/skills/docs/fuma/fuma.meta.yaml
+++ b/primitives/v1/skills/docs/fuma/fuma.meta.yaml
@@ -18,7 +18,7 @@ tools:
 versions:
   - version: 1
     file: fuma.prompt.v1.md
-    hash: "blake3:9672f4680b3931523ffbbd23d17d4e8decc385fa2b07fd7a640b000265631ea1"
+    hash: "blake3:8eb1e3439f7315674e3b27ed69554b0273b47d21453fe3e674446e659d3d721c"
     status: active
     created: "2025-12-10"
     notes: "Initial version documenting Fumadocs styling patterns"


### PR DESCRIPTION
## Summary
- Fix favicon not loading on GitHub Pages by adding basePath prefix
- Update fuma skill with GitHub Pages deployment documentation

## Changes
- `app/layout.tsx`: Add basePath prefix to favicon paths
- `fuma.prompt.v1.md`: Add comprehensive GitHub Pages deployment guide
  - Static export configuration
  - Asset path handling (logo, favicon)
  - Search API configuration
  - GitHub Actions workflow
  - Common issues & solutions

## Test
- Build passes with `NEXT_PUBLIC_BASE_PATH=/agentic-primitives npm run build`
- Primitives validation passes