### PR TITLE
fix(docs): configure search API with basePath and update skill

### DIFF
--- a/docs-site-fuma/app/layout.tsx
+++ b/docs-site-fuma/app/layout.tsx
@@ -2,6 +2,7 @@ import { RootProvider } from 'fumadocs-ui/provider/next';
 import './global.css';
 import { Inter } from 'next/font/google';
 import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
 
 const inter = Inter({
   subsets: ['latin'],
@@ -23,7 +24,7 @@ export const metadata: Metadata = {
   metadataBase: new URL('https://agentparadise.github.io/agentic-primitives'),
 };
 
-export default function Layout({ children }: LayoutProps<'/'>) {
+export default function Layout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" className={inter.className} suppressHydrationWarning>
       <body className="flex flex-col min-h-screen">
@@ -32,6 +33,11 @@ export default function Layout({ children }: LayoutProps<'/'>) {
             defaultTheme: 'dark',
             attribute: 'class',
             enableSystem: true,
+          }}
+          search={{
+            options: {
+              api: `${basePath}/api/search`,
+            },
           }}
         >
           {children}

--- a/primitives/v1/skills/docs/fuma/fuma.meta.yaml
+++ b/primitives/v1/skills/docs/fuma/fuma.meta.yaml
@@ -18,7 +18,7 @@ tools:
 versions:
   - version: 1
     file: fuma.prompt.v1.md
-    hash: "blake3:8eb1e3439f7315674e3b27ed69554b0273b47d21453fe3e674446e659d3d721c"
+    hash: "blake3:f967698b7b6490b911a8902cb20f49234ee45b3cfea735c2880faf927fe97993"
     status: active
     created: "2025-12-10"
     notes: "Initial version documenting Fumadocs styling patterns"


### PR DESCRIPTION
## Summary
- Fix search not working on GitHub Pages by adding basePath to search API endpoint
- Comprehensive update to the `docs/fuma` skill with all learnings

## Changes

### Search Fix
- Configure `search.options.api` with basePath in RootProvider
- Search now correctly calls `/agentic-primitives/api/search` instead of `/api/search`

### Skill Documentation Updates
- Search configuration with basePath
- LLM-friendly documentation export (`/llms-full.txt`)
- Updated common issues & solutions table
- Complete checklist for new Fumadocs sites

## Test
- Build passes with `NEXT_PUBLIC_BASE_PATH=/agentic-primitives npm run build`
- Primitives validation passes