### PR TITLE
fix(docs): use static search type for client-side search

### DIFF
--- a/docs-site-fuma/app/layout.tsx
+++ b/docs-site-fuma/app/layout.tsx
@@ -36,6 +36,7 @@ export default function Layout({ children }: { children: ReactNode }) {
           }}
           search={{
             options: {
+              type: 'static',
               api: `${basePath}/api/search`,
             },
           }}

--- a/primitives/v1/skills/docs/fuma/fuma.meta.yaml
+++ b/primitives/v1/skills/docs/fuma/fuma.meta.yaml
@@ -18,7 +18,7 @@ tools:
 versions:
   - version: 1
     file: fuma.prompt.v1.md
-    hash: "blake3:f967698b7b6490b911a8902cb20f49234ee45b3cfea735c2880faf927fe97993"
+    hash: "blake3:100dae1b93b2d48f1558436dd996395e68a5158f407a699278f78484f2ac1497"
     status: active
     created: "2025-12-10"
     notes: "Initial version documenting Fumadocs styling patterns"

--- a/primitives/v1/skills/docs/fuma/fuma.prompt.v1.md
+++ b/primitives/v1/skills/docs/fuma/fuma.prompt.v1.md
@@ -546,6 +546,8 @@ For static export, search must be configured to use the correct API endpoint wit
 
 ### RootProvider Search Configuration
 
+For static export, use `type: 'static'` which downloads the search index once and searches client-side:
+
 ```typescript
 // app/layout.tsx
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
@@ -558,6 +560,7 @@ const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
   }}
   search={{
     options: {
+      type: 'static',  // Required for static export
       api: `${basePath}/api/search`,
     },
   }}
@@ -566,7 +569,10 @@ const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
 </RootProvider>
 ```
 
-**Why this is needed:** Without this configuration, the search dialog will call `/api/search` instead of `/agentic-primitives/api/search` on GitHub Pages.
+**Key points:**
+- `type: 'static'` tells Fumadocs to download the search index and search locally using Orama
+- `api` must include the basePath for GitHub Pages
+- The search route should use `staticGET` which exports the index, not search results
 
 ## LLM-Friendly Documentation
 


### PR DESCRIPTION
## Summary
Fix search functionality by configuring static client-side search

## Problem
Search was crashing with `e?.map is not a function` because:
- The search route returns a static index (via `staticGET`)
- But the client was expecting search results

## Solution
Add `type: 'static'` to RootProvider search options, which:
- Downloads the search index once
- Uses Orama to search locally on the client
- Works properly with static export

## Test
- Build passes
- Primitives validation passes