### PR TITLE
fix(ui): add padding to prevent logo text descender clipping

### DIFF
--- a/docs-site-fuma/lib/layout.shared.tsx
+++ b/docs-site-fuma/lib/layout.shared.tsx
@@ -23,7 +23,7 @@ export function baseOptions(): BaseLayoutProps {
             height={28}
             className="block dark:hidden"
           />
-          <span className="font-semibold bg-gradient-to-r from-indigo-400 to-purple-400 bg-clip-text text-transparent dark:from-indigo-300 dark:to-purple-300">
+          <span className="font-semibold bg-gradient-to-r from-indigo-400 to-purple-400 bg-clip-text text-transparent dark:from-indigo-300 dark:to-purple-300 pb-0.5">
             agentic-primitives
           </span>
         </div>


### PR DESCRIPTION
Adds pb-0.5 padding to the agentic-primitives logo text to prevent the descender of 'g' from being clipped by the gradient text styling.