### PR TITLE
fix(ui): use leading-normal for proper text descender display

### DIFF
--- a/docs-site-fuma/lib/layout.shared.tsx
+++ b/docs-site-fuma/lib/layout.shared.tsx
@@ -23,7 +23,7 @@ export function baseOptions(): BaseLayoutProps {
             height={28}
             className="block dark:hidden"
           />
-          <span className="font-semibold bg-gradient-to-r from-indigo-400 to-purple-400 bg-clip-text text-transparent dark:from-indigo-300 dark:to-purple-300 pb-0.5">
+          <span className="font-semibold bg-gradient-to-r from-indigo-400 to-purple-400 bg-clip-text text-transparent dark:from-indigo-300 dark:to-purple-300 inline-block leading-normal">
             agentic-primitives
           </span>
         </div>


### PR DESCRIPTION
Uses inline-block with leading-normal instead of pb-0.5 for proper descender clearance on the logo text.