### PR TITLE
fix(bench): use std::hint::black_box instead of deprecated criterion::black_box

### DIFF
--- a/cli/benches/build_bench.rs
+++ b/cli/benches/build_bench.rs
@@ -1,5 +1,6 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use std::fs;
+use std::hint::black_box;
 use tempfile::TempDir;
 
 fn setup_build_test(prim_count: usize) -> TempDir {

--- a/cli/benches/validation_bench.rs
+++ b/cli/benches/validation_bench.rs
@@ -1,5 +1,6 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use std::fs;
+use std::hint::black_box;
 use tempfile::TempDir;
 
 fn setup_test_primitives(count: usize) -> TempDir {


### PR DESCRIPTION
Fixes Rust clippy error after criterion 0.8 upgrade - `criterion::black_box` is now deprecated.