### PR TITLE
feat(workspace): bake LSP language servers into Docker image

### DIFF
--- a/playground/scenarios/code-review.yaml
+++ b/playground/scenarios/code-review.yaml
@@ -27,6 +27,6 @@ headless:
 
 isolation:
   provider: docker
-  image: agentic-workspace:latest
+  image: agentic-workspace-claude-cli:latest
   timeout: 600
   memory_mb: 2048

--- a/playground/scenarios/default.yaml
+++ b/playground/scenarios/default.yaml
@@ -14,7 +14,7 @@ headless:
 
 isolation:
   provider: docker
-  image: agentic-workspace:latest
+  image: agentic-workspace-claude-cli:latest
   timeout: 300
   memory_mb: 2048
   cpu_cores: 2.0

--- a/playground/scenarios/quick-task.yaml
+++ b/playground/scenarios/quick-task.yaml
@@ -12,7 +12,7 @@ headless:
 
 isolation:
   provider: docker
-  image: agentic-workspace:latest
+  image: agentic-workspace-claude-cli:latest
   timeout: 120
   memory_mb: 1024
   cpu_cores: 1.0

--- a/playground/scenarios/security-audit.yaml
+++ b/playground/scenarios/security-audit.yaml
@@ -27,6 +27,6 @@ headless:
 
 isolation:
   provider: docker
-  image: agentic-workspace:latest
+  image: agentic-workspace-claude-cli:latest
   timeout: 600
   memory_mb: 2048

--- a/playground/src/config.py
+++ b/playground/src/config.py
@@ -92,7 +92,7 @@ class IsolationConfig:
     provider: Literal["docker", "local"] = "docker"
 
     # Docker-specific
-    image: str = "agentic-workspace:latest"
+    image: str = "agentic-workspace-claude-cli:latest"
 
     # Resource limits
     timeout: int = 300  # seconds
@@ -148,7 +148,7 @@ class ScenarioConfig:
         # Use environment variable or fallback to agentic-primitives default
         default_image = os.environ.get(
             "PLAYGROUND_WORKSPACE_IMAGE",
-            "agentic-workspace:latest"
+            "agentic-workspace-claude-cli:latest"
         )
 
         headless = HeadlessConfig(

--- a/playground/workspace/Dockerfile
+++ b/playground/workspace/Dockerfile
@@ -1,43 +1,4 @@
-# Playground Workspace Image
-# A minimal Docker image with Claude CLI for playground testing
-#
-# Build:
-#   docker build -t agentic-workspace:latest ./workspace
-#
-# This image provides:
-# - Node.js (for Claude CLI)
-# - Claude CLI installed globally
-# - Python 3.12 (for hook scripts)
-# - Common utilities (git, curl, jq)
-
-FROM node:22-slim
-
-# Install system dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 \
-    python3-pip \
-    python3-venv \
-    git \
-    curl \
-    jq \
-    ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install Claude CLI globally
-RUN npm install -g @anthropic-ai/claude-code
-
-# Create workspace directory
-WORKDIR /workspace
-
-# Create non-root user for security
-RUN useradd -m -s /bin/bash agent && \
-    chown -R agent:agent /workspace
-
-# Switch to non-root user
-USER agent
-
-# Verify installations
-RUN claude --version && python3 --version
-
-# Default command
-CMD ["bash"]
+# DEPRECATED: Use the production workspace image instead.
+# Build: just build-provider claude-cli
+# See: providers/workspaces/claude-cli/Dockerfile
+FROM agentic-workspace-claude-cli:latest

--- a/providers/workspaces/claude-cli/Dockerfile
+++ b/providers/workspaces/claude-cli/Dockerfile
@@ -168,7 +168,7 @@ RUN claude --version && python3 --version && node --version && uv --version && g
 
 # Verify LSP server installations
 RUN typescript-language-server --version \
-    && pyright --version \
+    && pyright-langserver --version \
     && rust-analyzer --version \
     && rustc --version \
     && cargo --version
@@ -193,9 +193,12 @@ ENV HOME=/home/agent \
     ANTHROPIC_NO_ATTRIBUTION=1 \
     # Use uv for Python execution (faster, better caching)
     UV_SYSTEM_PYTHON=1 \
-    # Rust toolchain paths (must match build stage)
+    # Rust toolchain paths
+    # RUSTUP_HOME: read-only toolchain installed during build
+    # CARGO_HOME: writable location for agent user (registry index, git checkouts)
+    # /usr/local/cargo/bin stays on PATH for pre-installed binaries (cargo, rustc, rust-analyzer)
     RUSTUP_HOME=/usr/local/rustup \
-    CARGO_HOME=/usr/local/cargo \
+    CARGO_HOME=/home/agent/.cargo \
     PATH=/usr/local/cargo/bin:$PATH
 
 # Health check

--- a/providers/workspaces/claude-cli/Dockerfile
+++ b/providers/workspaces/claude-cli/Dockerfile
@@ -9,7 +9,17 @@
 #   - Python 3.12 + uv (for hooks and agentic packages)
 #   - Claude CLI with JSONL event emission to stdout
 #   - Pre-bundled primitive hooks with agentic_events
+#   - LSP language servers (pyright, typescript-language-server, rust-analyzer)
 #   - Security hardening (non-root, no setuid)
+#
+# LSP Architecture:
+#   The image bundles LSP binaries and pre-enables the official Claude Code LSP
+#   plugins (pyright-lsp, typescript-lsp, rust-analyzer-lsp) in settings.json.
+#   LSP servers are LAZY — they only start when Claude encounters files in the
+#   matching language. An agent working on a Python-only repo will NOT start
+#   rust-analyzer or typescript-language-server. This means the image is safe
+#   for multi-agent orchestration: only the LSP servers actually needed per-task
+#   consume memory at runtime.
 #
 # Events are emitted as JSONL to stdout, captured by the agent runner.
 #
@@ -67,6 +77,37 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
 RUN npm install -g @anthropic-ai/claude-code
 
 # =============================================================================
+# LSP: Language Servers for code intelligence
+# Plugins: pyright-lsp, typescript-lsp, rust-analyzer-lsp (claude-plugins-official)
+# =============================================================================
+
+# TypeScript + Python LSP servers (via npm, same PATH as Claude CLI)
+# Provides: typescript-language-server, pyright-langserver
+RUN npm install -g typescript typescript-language-server pyright
+
+# Rust: build deps for toolchain and cargo builds at runtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    pkg-config \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+# Rust toolchain + rust-analyzer
+# Installed to /usr/local (not /home) to survive tmpfs mounts at runtime
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
+    -y \
+    --default-toolchain stable \
+    --profile minimal \
+    --no-modify-path \
+    && rustup component add rust-analyzer \
+    && chmod -R a+rX /usr/local/rustup /usr/local/cargo
+
+# =============================================================================
 # Stage 3: Install Python packages from staged wheels
 # =============================================================================
 FROM tooling AS packages
@@ -122,8 +163,15 @@ RUN chmod -R 755 /opt/agentic/hooks \
     && chmod 755 /opt/agentic/entrypoint.sh \
     && chown -R agent:agent /opt/agentic
 
-# Verify installations (before security hardening)
+# Verify core installations (before security hardening)
 RUN claude --version && python3 --version && node --version && uv --version && gh --version
+
+# Verify LSP server installations
+RUN typescript-language-server --version \
+    && pyright --version \
+    && rust-analyzer --version \
+    && rustc --version \
+    && cargo --version
 
 # Security: Remove setuid/setgid binaries (exclude /usr/local)
 RUN find / -path /usr/local -prune -o -perm /6000 -type f -exec chmod a-s {} \; 2>/dev/null || true
@@ -144,7 +192,11 @@ ENV HOME=/home/agent \
     # Disable Claude Code attribution in commits/PRs
     ANTHROPIC_NO_ATTRIBUTION=1 \
     # Use uv for Python execution (faster, better caching)
-    UV_SYSTEM_PYTHON=1
+    UV_SYSTEM_PYTHON=1 \
+    # Rust toolchain paths (must match build stage)
+    RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=2 \

--- a/providers/workspaces/claude-cli/manifest.yaml
+++ b/providers/workspaces/claude-cli/manifest.yaml
@@ -4,7 +4,7 @@
 # See ADR-027: Provider-Based Workspace Images
 
 name: claude-cli
-version: "1.0.0"
+version: "1.1.0"
 description: Claude CLI workspace with native OpenTelemetry support
 
 # Image build configuration
@@ -90,6 +90,33 @@ security:
     enabled: true
     # Empty means all hosts (restricted at runtime)
     allowed_hosts: []
+
+# Capabilities: language servers and runtimes available in the image
+#
+# LSP servers are pre-installed and plugins pre-enabled in settings.json.
+# Servers are LAZY: they only start when Claude encounters files in the matching
+# language. Safe for multi-agent orchestration — only active languages consume memory.
+capabilities:
+  lsp_servers:
+    - name: typescript-language-server
+      languages: [typescript, javascript]
+      binary: typescript-language-server
+      plugin: typescript-lsp@claude-plugins-official
+    - name: pyright
+      languages: [python]
+      binary: pyright-langserver
+      plugin: pyright-lsp@claude-plugins-official
+    - name: rust-analyzer
+      languages: [rust]
+      binary: rust-analyzer
+      plugin: rust-analyzer-lsp@claude-plugins-official
+  runtimes:
+    - name: node
+      version: "22"
+    - name: python
+      version: "3.12"
+    - name: rust
+      version: stable
 
 # Health check configuration
 health:

--- a/providers/workspaces/claude-cli/scripts/entrypoint.sh
+++ b/providers/workspaces/claude-cli/scripts/entrypoint.sh
@@ -23,9 +23,14 @@ set -e
 # -----------------------------------------------------------------------------
 # 1. Claude CLI Configuration
 # -----------------------------------------------------------------------------
-# Create ~/.claude/settings.json with attribution disabled.
+# Create ~/.claude/settings.json with attribution disabled and LSP plugins enabled.
 # This must be done HERE because /home/agent is a tmpfs mount that wipes
 # anything baked into the Docker image.
+#
+# LSP plugins (pyright-lsp, typescript-lsp, rust-analyzer-lsp) are enabled by
+# default. The LSP servers are LAZY — they only start when Claude encounters
+# files in the matching language, so enabling all three does not waste memory
+# when only a subset of languages is present in the workspace.
 
 mkdir -p ~/.claude
 
@@ -80,6 +85,11 @@ cat > ~/.claude/settings.json << 'EOF'
         "timeout": 5
       }]
     }]
+  },
+  "enabledPlugins": {
+    "pyright-lsp@claude-plugins-official": true,
+    "typescript-lsp@claude-plugins-official": true,
+    "rust-analyzer-lsp@claude-plugins-official": true
   }
 }
 EOF

--- a/providers/workspaces/claude-cli/scripts/entrypoint.sh
+++ b/providers/workspaces/claude-cli/scripts/entrypoint.sh
@@ -150,6 +150,11 @@ mkdir -p /workspace/artifacts/input
 mkdir -p /workspace/artifacts/output
 mkdir -p /workspace/repos
 
+# Create writable CARGO_HOME for the agent user
+# The Rust toolchain binaries live in /usr/local/cargo/bin (read-only, on PATH),
+# but cargo needs a writable CARGO_HOME for registry index, git checkouts, etc.
+mkdir -p ~/.cargo
+
 # -----------------------------------------------------------------------------
 # 5. Execute CMD
 # -----------------------------------------------------------------------------

--- a/tests/integration/test_entrypoint_lsp_settings.py
+++ b/tests/integration/test_entrypoint_lsp_settings.py
@@ -1,0 +1,146 @@
+"""
+Integration test for entrypoint-generated LSP plugin settings.
+
+Validates that the workspace entrypoint writes ~/.claude/settings.json
+with the expected LSP plugins enabled by default.
+
+The entrypoint is the source of truth for runtime settings because
+/home/agent is a tmpfs mount that wipes anything baked into the image.
+"""
+
+import json
+import subprocess
+
+import pytest
+
+
+@pytest.mark.integration
+def test_entrypoint_enables_lsp_plugins():
+    """
+    Test that the entrypoint creates settings.json with LSP plugins enabled.
+
+    This test starts the container (which runs entrypoint.sh), then
+    inspects the generated ~/.claude/settings.json to verify the expected
+    plugins are present and enabled.
+    """
+    result = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--tmpfs=/home/agent:rw,exec,nosuid,size=128m,uid=1000,gid=1000",
+            "agentic-workspace-claude-cli:latest",
+            "cat",
+            "/home/agent/.claude/settings.json",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, f"Container failed: {result.stderr}"
+
+    settings = json.loads(result.stdout.strip())
+
+    # Verify enabledPlugins section exists
+    assert "enabledPlugins" in settings, (
+        "Missing 'enabledPlugins' in settings.json. "
+        "The entrypoint must write LSP plugin enables."
+    )
+
+    # Verify all three LSP plugins are enabled
+    expected_plugins = {
+        "pyright-lsp@claude-plugins-official": True,
+        "typescript-lsp@claude-plugins-official": True,
+        "rust-analyzer-lsp@claude-plugins-official": True,
+    }
+
+    for plugin, expected_value in expected_plugins.items():
+        assert settings["enabledPlugins"].get(plugin) == expected_value, (
+            f"Plugin '{plugin}' should be {expected_value} in enabledPlugins. "
+            f"Got: {settings['enabledPlugins'].get(plugin)}"
+        )
+
+
+@pytest.mark.integration
+def test_entrypoint_settings_has_hooks():
+    """
+    Test that the entrypoint creates settings.json with hooks configured.
+
+    This ensures the hooks section is present and contains the expected
+    lifecycle hooks (PreToolUse, PostToolUse, etc.).
+    """
+    result = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--tmpfs=/home/agent:rw,exec,nosuid,size=128m,uid=1000,gid=1000",
+            "agentic-workspace-claude-cli:latest",
+            "cat",
+            "/home/agent/.claude/settings.json",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, f"Container failed: {result.stderr}"
+
+    settings = json.loads(result.stdout.strip())
+
+    assert "hooks" in settings, "Missing 'hooks' in settings.json"
+
+    expected_hooks = [
+        "PreToolUse",
+        "PostToolUse",
+        "SessionStart",
+        "SessionEnd",
+        "Stop",
+        "SubagentStop",
+    ]
+
+    for hook in expected_hooks:
+        assert hook in settings["hooks"], (
+            f"Missing '{hook}' in settings.json hooks. "
+            f"Found: {list(settings['hooks'].keys())}"
+        )
+
+
+@pytest.mark.integration
+def test_entrypoint_creates_cargo_home():
+    """
+    Test that the entrypoint creates a writable CARGO_HOME for the agent user.
+
+    CARGO_HOME must be writable so cargo can manage its registry index
+    and git checkouts at runtime.
+    """
+    result = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--tmpfs=/home/agent:rw,exec,nosuid,size=128m,uid=1000,gid=1000",
+            "agentic-workspace-claude-cli:latest",
+            "sh",
+            "-c",
+            "test -d ~/.cargo && test -w ~/.cargo && echo 'writable'",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, f"Container failed: {result.stderr}"
+    assert "writable" in result.stdout, (
+        "~/.cargo is not writable by the agent user. "
+        "Rust builds will fail without a writable CARGO_HOME."
+    )
+
+
+if __name__ == "__main__":
+    print("Running entrypoint LSP settings tests...")
+    test_entrypoint_enables_lsp_plugins()
+    test_entrypoint_settings_has_hooks()
+    test_entrypoint_creates_cargo_home()
+    print("\nAll entrypoint settings tests passed!")


### PR DESCRIPTION
## Summary

- Installs **pyright**, **typescript-language-server**, and **rust-analyzer** into the production workspace Docker image
- Pre-enables the official Claude Code LSP plugins (`pyright-lsp`, `typescript-lsp`, `rust-analyzer-lsp` from `claude-plugins-official`) in `settings.json` via the entrypoint
- Consolidates playground scenarios onto `agentic-workspace-claude-cli:latest`, deprecates the standalone `playground/workspace/Dockerfile`
- Bumps manifest to v1.1.0 with new `capabilities` section documenting LSP servers and runtimes

## Why

Claude Code's native LSP support (v2.0.74+) gives agents automatic diagnostics after every edit and ~50ms symbol lookups vs 45s grep-based search. This eliminates the need for agents to `Read` entire files for type info, massively reducing token usage. The plugins require binaries on PATH — this bakes them in so agents get code intelligence with zero setup.

## LSP servers are lazy

Servers only start when Claude encounters files in the matching language. An agent working on a Python-only repo will **not** start `rust-analyzer` or `typescript-language-server`. This makes the image safe for multi-agent orchestration without needing per-language image variants.

## Image size

| Component | Size |
|-----------|------|
| Previous image | 877MB |
| + typescript + typescript-language-server | ~80MB |
| + pyright | ~30MB |
| + build-essential + pkg-config + libssl-dev | ~100MB |
| + Rust toolchain (minimal profile) | ~900MB |
| **New total** | **~2.1GB** |

## Test plan

- [x] `uv run scripts/build-provider.py claude-cli` — image builds successfully
- [x] LSP binaries verified as `agent` user: `typescript-language-server 5.1.3`, `pyright 1.1.408`, `rust-analyzer 1.93.0`
- [x] Rust paths survive user switch: `/usr/local/cargo/bin/{rustc,cargo,rust-analyzer}`
- [x] Entrypoint writes all 3 LSP plugins to `~/.claude/settings.json`
- [x] All playground scenarios point to `agentic-workspace-claude-cli:latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)