### PR TITLE
feat(sdlc): disable Co-Authored-By via plugin settings

### DIFF
--- a/plugins/sdlc/.claude-plugin/plugin.json
+++ b/plugins/sdlc/.claude-plugin/plugin.json
@@ -5,5 +5,11 @@
   "author": {
     "name": "NeuralEmpowerment"
   },
-  "repository": "https://github.com/AgentParadise/agentic-primitives"
+  "repository": "https://github.com/AgentParadise/agentic-primitives",
+  "settings": {
+    "attribution": {
+      "commit": "",
+      "pr": ""
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Adds plugin settings merging to the installer — plugins can now define a `settings` field in `plugin.json` that gets merged into the target `settings.json` on install
- The sdlc plugin now sets `attribution: {commit: "", pr: ""}` which disables Claude Code's Co-Authored-By footer
- Settings are tracked via `_plugin_settings` metadata so `uninstall` cleanly removes only what the plugin added
- 10 new tests covering `merge_plugin_settings`, `remove_plugin_settings`, and end-to-end install/uninstall flows with settings (62 total)

## Test plan
- [x] All 62 tests pass (`uv run pytest` in `tests/unit/scripts/`)
- [x] `just plugin-install sdlc --global` installs with attribution setting
- [x] Verified `~/.claude/settings.json` has `attribution: {commit: "", pr: ""}` after install
- [x] Uninstall path tested — removes attribution and `_plugin_settings` tracker cleanly