### PR TITLE
fix(docker): use pyright --version for version check in Dockerfile

### DIFF
--- a/providers/workspaces/claude-cli/Dockerfile
+++ b/providers/workspaces/claude-cli/Dockerfile
@@ -178,7 +178,7 @@ RUN claude --version && python3 --version && node --version && uv --version && g
 
 # Verify LSP server installations
 RUN typescript-language-server --version \
-    && pyright-langserver --version \
+    && pyright --version \
     && rust-analyzer --version \
     && rustc --version \
     && cargo --version


### PR DESCRIPTION
\`pyright-langserver\` is the LSP server binary and requires a connection mode argument (\`--node-ipc\`, \`--stdio\`, or \`--socket\`) to start — calling it with no args exits 1.

Use \`pyright --version\` (the CLI) instead, which works correctly and confirms the package is installed.

Fixes the \`just dev\` workspace image build failure introduced by the observability plugin submodule bump.