### PR TITLE
feat(workspace): bump Claude CLI to 2.1.76 + version-tagged images

### DIFF
--- a/.github/workflows/claude-cli-version-check.yml
+++ b/.github/workflows/claude-cli-version-check.yml
@@ -1,0 +1,99 @@
+name: Claude CLI Version Check
+
+on:
+  schedule:
+    # Run daily at 09:00 UTC
+    - cron: "0 9 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get pinned version from Dockerfile
+        id: pinned
+        run: |
+          VERSION=$(grep 'ARG CLAUDE_CLI_VERSION=' providers/workspaces/claude-cli/Dockerfile | cut -d= -f2)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Pinned version: $VERSION"
+
+      - name: Get latest npm version and changelog
+        id: latest
+        run: |
+          VERSION=$(npm view @anthropic-ai/claude-code version)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Latest version: $VERSION"
+
+          # Fetch changelog from npm package metadata (repository URL)
+          REPO_URL=$(npm view @anthropic-ai/claude-code repository.url 2>/dev/null | sed 's|git+||;s|\.git$||;s|ssh://git@|https://|')
+          if [ -n "$REPO_URL" ]; then
+            CHANGELOG_URL="${REPO_URL}/releases"
+            echo "changelog_url=$CHANGELOG_URL" >> "$GITHUB_OUTPUT"
+          else
+            echo "changelog_url=https://www.npmjs.com/package/@anthropic-ai/claude-code?activeTab=versions" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Compare versions
+        if: steps.pinned.outputs.version != steps.latest.outputs.version
+        run: |
+          echo "::warning::Claude CLI updated: ${{ steps.pinned.outputs.version }} -> ${{ steps.latest.outputs.version }}"
+          echo "Review changelog and test JSONL contract before bumping."
+          echo "Key areas: tool names (ClaudeToolName), stream-json schema, hook event names."
+
+      - name: Open issue if version changed
+        if: steps.pinned.outputs.version != steps.latest.outputs.version
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pinned = '${{ steps.pinned.outputs.version }}';
+            const latest = '${{ steps.latest.outputs.version }}';
+            const changelogUrl = '${{ steps.latest.outputs.changelog_url }}';
+            const title = `Claude CLI update available: ${pinned} -> ${latest}`;
+
+            // Check if issue already exists
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'claude-cli-update',
+            });
+
+            if (issues.data.some(i => i.title === title)) {
+              console.log('Issue already exists, skipping.');
+              return;
+            }
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              labels: ['claude-cli-update'],
+              body: [
+                `## Claude CLI Version Update`,
+                ``,
+                `| | Version |`,
+                `|---|---|`,
+                `| **Pinned** | \`${pinned}\` |`,
+                `| **Latest** | \`${latest}\` |`,
+                ``,
+                `### Changelog`,
+                ``,
+                `${changelogUrl}`,
+                ``,
+                `### Before bumping, verify:`,
+                `- [ ] Tool names haven't changed (check \`ClaudeToolName\` in \`agentic_events/types.py\`)`,
+                `- [ ] \`stream-json\` output schema is compatible`,
+                `- [ ] Hook event names (\`SessionStart\`, \`PreToolUse\`, etc.) are unchanged`,
+                `- [ ] Run subagent-demo workflow and confirm \`subagent_started\`/\`subagent_stopped\` events appear`,
+                ``,
+                `### To bump:`,
+                `\`\`\`dockerfile`,
+                `# providers/workspaces/claude-cli/Dockerfile`,
+                `ARG CLAUDE_CLI_VERSION=${latest}`,
+                `\`\`\``,
+                ``,
+                `Then rebuild: \`just workspace-build\``,
+              ].join('\n'),
+            });

--- a/lib/python/agentic_events/agentic_events/fixtures.py
+++ b/lib/python/agentic_events/agentic_events/fixtures.py
@@ -64,6 +64,11 @@ class Recording(str, Enum):
     ARTIFACT_WRITE = "artifact-write"  # Writes to artifacts/output/
     ARTIFACT_READ_WRITE = "artifact-read-write"  # Reads input/, writes output/
 
+    # Subagent and advanced recordings
+    SUBAGENT_CONCURRENT = "subagent-concurrent"
+    CONTEXT_TRACKING = "context-tracking"
+    MULTI_MODEL_USAGE = "multi-model-usage"
+
 
 def get_recordings_dir() -> Path:
     """Get the canonical recordings directory.

--- a/lib/python/agentic_events/agentic_events/types.py
+++ b/lib/python/agentic_events/agentic_events/types.py
@@ -67,6 +67,14 @@ class SecurityDecision(StrEnum):
     WARN = "warn"
 
 
+class ClaudeToolName(StrEnum):
+    """Claude CLI built-in tool names used for lifecycle detection."""
+
+    SUBAGENT = "Agent"
+    # Pre-2026 name for the subagent tool (Claude CLI renamed Task → Agent)
+    SUBAGENT_LEGACY = "Task"
+
+
 class SessionSource(StrEnum):
     """How a session was started."""
 

--- a/providers/workspaces/claude-cli/Dockerfile
+++ b/providers/workspaces/claude-cli/Dockerfile
@@ -82,7 +82,11 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
     && rm -rf /root/.local
 
 # Install Claude CLI globally via npm
-RUN npm install -g @anthropic-ai/claude-code
+# Pin version to control JSONL output contract — bump deliberately, not silently.
+# When upgrading, verify: tool names (Agent vs Task), stream-json event schema,
+# hook event names. See ClaudeToolName in agentic_events.types.
+ARG CLAUDE_CLI_VERSION=2.1.69
+RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CLI_VERSION}
 
 # =============================================================================
 # LSP: Language Servers for code intelligence

--- a/providers/workspaces/claude-cli/Dockerfile
+++ b/providers/workspaces/claude-cli/Dockerfile
@@ -85,7 +85,7 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
 # Pin version to control JSONL output contract — bump deliberately, not silently.
 # When upgrading, verify: tool names (Agent vs Task), stream-json event schema,
 # hook event names. See ClaudeToolName in agentic_events.types.
-ARG CLAUDE_CLI_VERSION=2.1.69
+ARG CLAUDE_CLI_VERSION=2.1.76
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CLI_VERSION}
 
 # =============================================================================
@@ -212,6 +212,9 @@ ENV HOME=/home/agent \
     RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/home/agent/.cargo \
     PATH=/usr/local/cargo/bin:$PATH
+
+# Labels for version tracking and image selection
+LABEL agentic.claude_cli_version=${CLAUDE_CLI_VERSION}
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=2 \

--- a/providers/workspaces/claude-cli/Dockerfile
+++ b/providers/workspaces/claude-cli/Dockerfile
@@ -214,6 +214,8 @@ ENV HOME=/home/agent \
     PATH=/usr/local/cargo/bin:$PATH
 
 # Labels for version tracking and image selection
+# Re-declare ARG here: build args are stage-scoped and don't carry across FROM boundaries.
+ARG CLAUDE_CLI_VERSION
 LABEL agentic.claude_cli_version=${CLAUDE_CLI_VERSION}
 
 # Health check

--- a/scripts/build-provider.py
+++ b/scripts/build-provider.py
@@ -151,18 +151,44 @@ def get_git_commit() -> str:
     return "unknown"
 
 
+def extract_cli_version(build_context: Path) -> str | None:
+    """Extract CLAUDE_CLI_VERSION from the staged Dockerfile."""
+    dockerfile = build_context / "Dockerfile"
+    if not dockerfile.exists():
+        return None
+    for line in dockerfile.read_text().splitlines():
+        # Match: ARG CLAUDE_CLI_VERSION=X.Y.Z
+        if line.strip().startswith("ARG CLAUDE_CLI_VERSION="):
+            return line.split("=", 1)[1].strip()
+    return None
+
+
 def docker_build(
     build_context: Path,
     tag: str,
     no_cache: bool = False,
 ) -> None:
-    """Run docker build with commit label for cache invalidation."""
+    """Run docker build with commit label for cache invalidation.
+
+    Also tags with the CLI version (e.g., :2.1.76) so consumers can
+    pin specific versions.
+    """
     commit = get_git_commit()
     cmd = ["docker", "build", "-t", tag, "--label", f"agentic.commit={commit}", "."]
+
+    # Add version-specific tag (e.g., agentic-workspace-claude-cli:2.1.76)
+    cli_version = extract_cli_version(build_context)
+    if cli_version:
+        base_name = tag.rsplit(":", 1)[0]
+        version_tag = f"{base_name}:{cli_version}"
+        cmd.extend(["-t", version_tag])
+
     if no_cache:
         cmd.insert(2, "--no-cache")
 
     print(f"\n🐳 Building Docker image: {tag}")
+    if cli_version:
+        print(f"   Also tagged: {version_tag}")
     print(f"   Context: {build_context}")
     print(f"   Commit: {commit}")
 
@@ -173,6 +199,8 @@ def docker_build(
         sys.exit(1)
 
     print(f"\n✅ Successfully built: {tag}")
+    if cli_version:
+        print(f"   Version tag: {version_tag}")
 
 
 def main():

--- a/scripts/build-provider.py
+++ b/scripts/build-provider.py
@@ -174,7 +174,8 @@ def docker_build(
     pin specific versions.
     """
     commit = get_git_commit()
-    cmd = ["docker", "build", "-t", tag, "--label", f"agentic.commit={commit}", "."]
+    # Build args/flags first, context path "." last (docker build requires this order)
+    cmd = ["docker", "build", "-t", tag, "--label", f"agentic.commit={commit}"]
 
     # Add version-specific tag (e.g., agentic-workspace-claude-cli:2.1.76)
     cli_version = extract_cli_version(build_context)
@@ -182,6 +183,8 @@ def docker_build(
         base_name = tag.rsplit(":", 1)[0]
         version_tag = f"{base_name}:{cli_version}"
         cmd.extend(["-t", version_tag])
+
+    cmd.append(".")
 
     if no_cache:
         cmd.insert(2, "--no-cache")


### PR DESCRIPTION
## Summary
- Bump Claude CLI from 2.1.69 → 2.1.76 in workspace image, fixing auth failures when using `CLAUDE_CODE_OAUTH_TOKEN` (not recognized by older CLI versions)
- Build script now produces both `:latest` and `:X.Y.Z` tags (e.g., `agentic-workspace-claude-cli:2.1.76`) so consumers can pin specific CLI versions
- Added `agentic.claude_cli_version` Docker label for image introspection
- Added `ClaudeToolName` enum for JSONL tool name mapping

## Motivation
CLI 2.1.69 didn't recognize `CLAUDE_CODE_OAUTH_TOKEN` and only saw it when passed as `ANTHROPIC_API_KEY` — which it rejected as invalid. This caused every workspace execution to fail with "Invalid API key" immediately after the init event.

## Test plan
- [x] `build-provider.py claude-cli` produces both `:latest` and `:2.1.76` tags
- [x] `docker run --rm agentic-workspace-claude-cli:latest claude --version` → `2.1.76`
- [ ] Workspace execution with OAuth token authenticates successfully