### PR TITLE
fix(logging): exclude stdlib LogRecord fields from HumanFormatter extra

### DIFF
--- a/.github/workflows/claude-cli-version-check.yml
+++ b/.github/workflows/claude-cli-version-check.yml
@@ -1,0 +1,99 @@
+name: Claude CLI Version Check
+
+on:
+  schedule:
+    # Run daily at 09:00 UTC
+    - cron: "0 9 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get pinned version from Dockerfile
+        id: pinned
+        run: |
+          VERSION=$(grep 'ARG CLAUDE_CLI_VERSION=' providers/workspaces/claude-cli/Dockerfile | cut -d= -f2)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Pinned version: $VERSION"
+
+      - name: Get latest npm version and changelog
+        id: latest
+        run: |
+          VERSION=$(npm view @anthropic-ai/claude-code version)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Latest version: $VERSION"
+
+          # Fetch changelog from npm package metadata (repository URL)
+          REPO_URL=$(npm view @anthropic-ai/claude-code repository.url 2>/dev/null | sed 's|git+||;s|\.git$||;s|ssh://git@|https://|')
+          if [ -n "$REPO_URL" ]; then
+            CHANGELOG_URL="${REPO_URL}/releases"
+            echo "changelog_url=$CHANGELOG_URL" >> "$GITHUB_OUTPUT"
+          else
+            echo "changelog_url=https://www.npmjs.com/package/@anthropic-ai/claude-code?activeTab=versions" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Compare versions
+        if: steps.pinned.outputs.version != steps.latest.outputs.version
+        run: |
+          echo "::warning::Claude CLI updated: ${{ steps.pinned.outputs.version }} -> ${{ steps.latest.outputs.version }}"
+          echo "Review changelog and test JSONL contract before bumping."
+          echo "Key areas: tool names (ClaudeToolName), stream-json schema, hook event names."
+
+      - name: Open issue if version changed
+        if: steps.pinned.outputs.version != steps.latest.outputs.version
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pinned = '${{ steps.pinned.outputs.version }}';
+            const latest = '${{ steps.latest.outputs.version }}';
+            const changelogUrl = '${{ steps.latest.outputs.changelog_url }}';
+            const title = `Claude CLI update available: ${pinned} -> ${latest}`;
+
+            // Check if issue already exists
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'claude-cli-update',
+            });
+
+            if (issues.data.some(i => i.title === title)) {
+              console.log('Issue already exists, skipping.');
+              return;
+            }
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              labels: ['claude-cli-update'],
+              body: [
+                `## Claude CLI Version Update`,
+                ``,
+                `| | Version |`,
+                `|---|---|`,
+                `| **Pinned** | \`${pinned}\` |`,
+                `| **Latest** | \`${latest}\` |`,
+                ``,
+                `### Changelog`,
+                ``,
+                `${changelogUrl}`,
+                ``,
+                `### Before bumping, verify:`,
+                `- [ ] Tool names haven't changed (check \`ClaudeToolName\` in \`agentic_events/types.py\`)`,
+                `- [ ] \`stream-json\` output schema is compatible`,
+                `- [ ] Hook event names (\`SessionStart\`, \`PreToolUse\`, etc.) are unchanged`,
+                `- [ ] Run subagent-demo workflow and confirm \`subagent_started\`/\`subagent_stopped\` events appear`,
+                ``,
+                `### To bump:`,
+                `\`\`\`dockerfile`,
+                `# providers/workspaces/claude-cli/Dockerfile`,
+                `ARG CLAUDE_CLI_VERSION=${latest}`,
+                `\`\`\``,
+                ``,
+                `Then rebuild: \`just workspace-build\``,
+              ].join('\n'),
+            });

--- a/lib/python/agentic_events/agentic_events/fixtures.py
+++ b/lib/python/agentic_events/agentic_events/fixtures.py
@@ -64,6 +64,11 @@ class Recording(str, Enum):
     ARTIFACT_WRITE = "artifact-write"  # Writes to artifacts/output/
     ARTIFACT_READ_WRITE = "artifact-read-write"  # Reads input/, writes output/
 
+    # Subagent and advanced recordings
+    SUBAGENT_CONCURRENT = "subagent-concurrent"
+    CONTEXT_TRACKING = "context-tracking"
+    MULTI_MODEL_USAGE = "multi-model-usage"
+
 
 def get_recordings_dir() -> Path:
     """Get the canonical recordings directory.

--- a/lib/python/agentic_events/agentic_events/types.py
+++ b/lib/python/agentic_events/agentic_events/types.py
@@ -67,6 +67,14 @@ class SecurityDecision(StrEnum):
     WARN = "warn"
 
 
+class ClaudeToolName(StrEnum):
+    """Claude CLI built-in tool names used for lifecycle detection."""
+
+    SUBAGENT = "Agent"
+    # Pre-2026 name for the subagent tool (Claude CLI renamed Task → Agent)
+    SUBAGENT_LEGACY = "Task"
+
+
 class SessionSource(StrEnum):
     """How a session was started."""
 

--- a/lib/python/agentic_logging/agentic_logging/formatters.py
+++ b/lib/python/agentic_logging/agentic_logging/formatters.py
@@ -58,12 +58,33 @@ class JSONFormatter(jsonlogger.JsonFormatter):  # type: ignore[name-defined, mis
 # logging.LogRecord.__dict__ is the *class* dict and does not contain these —
 # they are set as instance attributes in LogRecord.__init__ — so we maintain an
 # explicit exclusion set rather than relying on class-dict membership checks.
-_STDLIB_LOG_RECORD_FIELDS = frozenset({
-    "name", "msg", "args", "created", "filename", "funcName",
-    "levelname", "levelno", "lineno", "module", "msecs", "pathname",
-    "process", "processName", "relativeCreated", "stack_info", "exc_info",
-    "exc_text", "thread", "threadName", "taskName", "message", "asctime",
-})
+_STDLIB_LOG_RECORD_FIELDS = frozenset(
+    {
+        "name",
+        "msg",
+        "args",
+        "created",
+        "filename",
+        "funcName",
+        "levelname",
+        "levelno",
+        "lineno",
+        "module",
+        "msecs",
+        "pathname",
+        "process",
+        "processName",
+        "relativeCreated",
+        "stack_info",
+        "exc_info",
+        "exc_text",
+        "thread",
+        "threadName",
+        "taskName",
+        "message",
+        "asctime",
+    }
+)
 
 
 class HumanFormatter(logging.Formatter):

--- a/lib/python/agentic_logging/agentic_logging/formatters.py
+++ b/lib/python/agentic_logging/agentic_logging/formatters.py
@@ -54,6 +54,18 @@ class JSONFormatter(jsonlogger.JsonFormatter):  # type: ignore[name-defined, mis
             log_record["exc_info"] = self.formatException(record.exc_info)
 
 
+# Standard LogRecord instance attributes that should never appear as extra fields.
+# logging.LogRecord.__dict__ is the *class* dict and does not contain these —
+# they are set as instance attributes in LogRecord.__init__ — so we maintain an
+# explicit exclusion set rather than relying on class-dict membership checks.
+_STDLIB_LOG_RECORD_FIELDS = frozenset({
+    "name", "msg", "args", "created", "filename", "funcName",
+    "levelname", "levelno", "lineno", "module", "msecs", "pathname",
+    "process", "processName", "relativeCreated", "stack_info", "exc_info",
+    "exc_text", "thread", "threadName", "taskName", "message", "asctime",
+})
+
+
 class HumanFormatter(logging.Formatter):
     """Human-readable formatter with minimal color and structure.
 
@@ -151,11 +163,13 @@ class HumanFormatter(logging.Formatter):
         # Message on next line with indent
         lines = [first_line, f"  {record.getMessage()}"]
 
-        # Add extra fields if present
+        # Add extra fields if present (caller-supplied via extra={...}).
+        # Exclude the standard LogRecord instance attributes — they are not in
+        # logging.LogRecord.__dict__ (class dict) so we use an explicit set.
         extra_fields = {
             k: v
             for k, v in record.__dict__.items()
-            if k not in logging.LogRecord.__dict__ and k != "session_id"
+            if k not in _STDLIB_LOG_RECORD_FIELDS and k != "session_id"
         }
 
         # Add session_id first if present

--- a/lib/python/agentic_logging/tests/test_formatters.py
+++ b/lib/python/agentic_logging/tests/test_formatters.py
@@ -272,6 +272,34 @@ class TestHumanFormatter:
         assert "Line 2" in output
         assert "Line 3" in output
 
+    def test_stdlib_fields_not_rendered_as_extra(self) -> None:
+        """Stdlib LogRecord fields must not appear as ├─ tree entries.
+
+        LogRecord instance attributes (pathname, lineno, thread, etc.) are NOT
+        in logging.LogRecord.__dict__ (class dict), so a class-dict membership
+        check incorrectly lets them through.  The explicit _STDLIB_LOG_RECORD_FIELDS
+        exclusion set in HumanFormatter must block all of them.
+        """
+        formatter = HumanFormatter(use_color=False)
+        record = logging.LogRecord(
+            name="test.module",
+            level=logging.INFO,
+            pathname="/some/path/module.py",
+            lineno=42,
+            msg="Test message",
+            args=(),
+            exc_info=None,
+        )
+        record.host = "localhost"  # type: ignore[attr-defined]  # genuine extra field
+
+        output = formatter.format(record)
+
+        # Genuine extra field should appear
+        assert "host:" in output
+        # Stdlib fields must NOT appear as tree entries
+        for field in ("pathname", "lineno", "thread", "threadName", "process", "processName"):
+            assert f"{field}:" not in output
+
     def test_timestamp_includes_milliseconds(self) -> None:
         """Test that timestamp includes milliseconds."""
         formatter = HumanFormatter(use_color=False)

--- a/providers/workspaces/claude-cli/Dockerfile
+++ b/providers/workspaces/claude-cli/Dockerfile
@@ -82,7 +82,11 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
     && rm -rf /root/.local
 
 # Install Claude CLI globally via npm
-RUN npm install -g @anthropic-ai/claude-code
+# Pin version to control JSONL output contract — bump deliberately, not silently.
+# When upgrading, verify: tool names (Agent vs Task), stream-json event schema,
+# hook event names. See ClaudeToolName in agentic_events.types.
+ARG CLAUDE_CLI_VERSION=2.1.69
+RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CLI_VERSION}
 
 # =============================================================================
 # LSP: Language Servers for code intelligence

--- a/providers/workspaces/claude-cli/Dockerfile
+++ b/providers/workspaces/claude-cli/Dockerfile
@@ -85,7 +85,7 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
 # Pin version to control JSONL output contract — bump deliberately, not silently.
 # When upgrading, verify: tool names (Agent vs Task), stream-json event schema,
 # hook event names. See ClaudeToolName in agentic_events.types.
-ARG CLAUDE_CLI_VERSION=2.1.69
+ARG CLAUDE_CLI_VERSION=2.1.76
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CLI_VERSION}
 
 # =============================================================================
@@ -212,6 +212,9 @@ ENV HOME=/home/agent \
     RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/home/agent/.cargo \
     PATH=/usr/local/cargo/bin:$PATH
+
+# Labels for version tracking and image selection
+LABEL agentic.claude_cli_version=${CLAUDE_CLI_VERSION}
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=2 \

--- a/scripts/build-provider.py
+++ b/scripts/build-provider.py
@@ -151,18 +151,44 @@ def get_git_commit() -> str:
     return "unknown"
 
 
+def extract_cli_version(build_context: Path) -> str | None:
+    """Extract CLAUDE_CLI_VERSION from the staged Dockerfile."""
+    dockerfile = build_context / "Dockerfile"
+    if not dockerfile.exists():
+        return None
+    for line in dockerfile.read_text().splitlines():
+        # Match: ARG CLAUDE_CLI_VERSION=X.Y.Z
+        if line.strip().startswith("ARG CLAUDE_CLI_VERSION="):
+            return line.split("=", 1)[1].strip()
+    return None
+
+
 def docker_build(
     build_context: Path,
     tag: str,
     no_cache: bool = False,
 ) -> None:
-    """Run docker build with commit label for cache invalidation."""
+    """Run docker build with commit label for cache invalidation.
+
+    Also tags with the CLI version (e.g., :2.1.76) so consumers can
+    pin specific versions.
+    """
     commit = get_git_commit()
     cmd = ["docker", "build", "-t", tag, "--label", f"agentic.commit={commit}", "."]
+
+    # Add version-specific tag (e.g., agentic-workspace-claude-cli:2.1.76)
+    cli_version = extract_cli_version(build_context)
+    if cli_version:
+        base_name = tag.rsplit(":", 1)[0]
+        version_tag = f"{base_name}:{cli_version}"
+        cmd.extend(["-t", version_tag])
+
     if no_cache:
         cmd.insert(2, "--no-cache")
 
     print(f"\n🐳 Building Docker image: {tag}")
+    if cli_version:
+        print(f"   Also tagged: {version_tag}")
     print(f"   Context: {build_context}")
     print(f"   Commit: {commit}")
 
@@ -173,6 +199,8 @@ def docker_build(
         sys.exit(1)
 
     print(f"\n✅ Successfully built: {tag}")
+    if cli_version:
+        print(f"   Version tag: {version_tag}")
 
 
 def main():


### PR DESCRIPTION
## Problem

`HumanFormatter.format()` was dumping every standard `LogRecord` field (`name`, `msg`, `pathname`, `lineno`, `thread`, `processName`, etc.) as `├─` tree lines alongside genuine caller-supplied `extra={}` fields.

## Root Cause

The extra-fields filter used `k not in logging.LogRecord.__dict__`, intending to skip standard fields. But standard LogRecord attributes (`name`, `msg`, `levelname`, `pathname`, `lineno`, `thread`, etc.) are **instance** attributes set in `LogRecord.__init__` — they are not in the **class** `__dict__` — so the check never excluded them.

## Fix

Add an explicit `_STDLIB_LOG_RECORD_FIELDS` frozenset containing all known standard LogRecord field names, and use that for the exclusion check instead.

## Impact

Fixes the noisy dev-stack output reported in syntropic137/syntropic137#183.