### PR TITLE
fix(logging): exclude stdlib LogRecord fields from HumanFormatter extra

### DIFF
--- a/lib/python/agentic_logging/agentic_logging/formatters.py
+++ b/lib/python/agentic_logging/agentic_logging/formatters.py
@@ -58,12 +58,33 @@ class JSONFormatter(jsonlogger.JsonFormatter):  # type: ignore[name-defined, mis
 # logging.LogRecord.__dict__ is the *class* dict and does not contain these —
 # they are set as instance attributes in LogRecord.__init__ — so we maintain an
 # explicit exclusion set rather than relying on class-dict membership checks.
-_STDLIB_LOG_RECORD_FIELDS = frozenset({
-    "name", "msg", "args", "created", "filename", "funcName",
-    "levelname", "levelno", "lineno", "module", "msecs", "pathname",
-    "process", "processName", "relativeCreated", "stack_info", "exc_info",
-    "exc_text", "thread", "threadName", "taskName", "message", "asctime",
-})
+_STDLIB_LOG_RECORD_FIELDS = frozenset(
+    {
+        "name",
+        "msg",
+        "args",
+        "created",
+        "filename",
+        "funcName",
+        "levelname",
+        "levelno",
+        "lineno",
+        "module",
+        "msecs",
+        "pathname",
+        "process",
+        "processName",
+        "relativeCreated",
+        "stack_info",
+        "exc_info",
+        "exc_text",
+        "thread",
+        "threadName",
+        "taskName",
+        "message",
+        "asctime",
+    }
+)
 
 
 class HumanFormatter(logging.Formatter):

--- a/lib/python/agentic_logging/agentic_logging/formatters.py
+++ b/lib/python/agentic_logging/agentic_logging/formatters.py
@@ -54,6 +54,18 @@ class JSONFormatter(jsonlogger.JsonFormatter):  # type: ignore[name-defined, mis
             log_record["exc_info"] = self.formatException(record.exc_info)
 
 
+# Standard LogRecord instance attributes that should never appear as extra fields.
+# logging.LogRecord.__dict__ is the *class* dict and does not contain these —
+# they are set as instance attributes in LogRecord.__init__ — so we maintain an
+# explicit exclusion set rather than relying on class-dict membership checks.
+_STDLIB_LOG_RECORD_FIELDS = frozenset({
+    "name", "msg", "args", "created", "filename", "funcName",
+    "levelname", "levelno", "lineno", "module", "msecs", "pathname",
+    "process", "processName", "relativeCreated", "stack_info", "exc_info",
+    "exc_text", "thread", "threadName", "taskName", "message", "asctime",
+})
+
+
 class HumanFormatter(logging.Formatter):
     """Human-readable formatter with minimal color and structure.
 
@@ -151,11 +163,13 @@ class HumanFormatter(logging.Formatter):
         # Message on next line with indent
         lines = [first_line, f"  {record.getMessage()}"]
 
-        # Add extra fields if present
+        # Add extra fields if present (caller-supplied via extra={...}).
+        # Exclude the standard LogRecord instance attributes — they are not in
+        # logging.LogRecord.__dict__ (class dict) so we use an explicit set.
         extra_fields = {
             k: v
             for k, v in record.__dict__.items()
-            if k not in logging.LogRecord.__dict__ and k != "session_id"
+            if k not in _STDLIB_LOG_RECORD_FIELDS and k != "session_id"
         }
 
         # Add session_id first if present

--- a/lib/python/agentic_logging/tests/test_formatters.py
+++ b/lib/python/agentic_logging/tests/test_formatters.py
@@ -272,6 +272,34 @@ class TestHumanFormatter:
         assert "Line 2" in output
         assert "Line 3" in output
 
+    def test_stdlib_fields_not_rendered_as_extra(self) -> None:
+        """Stdlib LogRecord fields must not appear as ├─ tree entries.
+
+        LogRecord instance attributes (pathname, lineno, thread, etc.) are NOT
+        in logging.LogRecord.__dict__ (class dict), so a class-dict membership
+        check incorrectly lets them through.  The explicit _STDLIB_LOG_RECORD_FIELDS
+        exclusion set in HumanFormatter must block all of them.
+        """
+        formatter = HumanFormatter(use_color=False)
+        record = logging.LogRecord(
+            name="test.module",
+            level=logging.INFO,
+            pathname="/some/path/module.py",
+            lineno=42,
+            msg="Test message",
+            args=(),
+            exc_info=None,
+        )
+        record.host = "localhost"  # type: ignore[attr-defined]  # genuine extra field
+
+        output = formatter.format(record)
+
+        # Genuine extra field should appear
+        assert "host:" in output
+        # Stdlib fields must NOT appear as tree entries
+        for field in ("pathname", "lineno", "thread", "threadName", "process", "processName"):
+            assert f"{field}:" not in output
+
     def test_timestamp_includes_milliseconds(self) -> None:
         """Test that timestamp includes milliseconds."""
         formatter = HumanFormatter(use_color=False)


### PR DESCRIPTION
Replaces #107 (closed — rebased onto main after Dependabot merge).

## Problem

`HumanFormatter.format()` was dumping every standard `LogRecord` field (`name`, `msg`, `pathname`, `lineno`, `thread`, `processName`, etc.) as `├─` tree lines alongside genuine caller-supplied `extra={}` fields.

## Root Cause

The extra-fields filter used `k not in logging.LogRecord.__dict__`, intending to skip standard fields. But standard LogRecord attributes are **instance** attributes set in `LogRecord.__init__` — not class-level — so the check never excluded them.

## Fix

Add an explicit `_STDLIB_LOG_RECORD_FIELDS` frozenset and use it for the exclusion check. Also adds a test asserting that stdlib fields (`pathname`, `lineno`, `thread`, etc.) do NOT appear as tree entries while genuine `extra={}` fields do.

Fixes syntropic137/syntropic137#183.