### PR TITLE
feat(workspace): bump Claude CLI to 2.1.76 + version-tagged images

### DIFF
--- a/providers/workspaces/claude-cli/Dockerfile
+++ b/providers/workspaces/claude-cli/Dockerfile
@@ -85,7 +85,7 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
 # Pin version to control JSONL output contract — bump deliberately, not silently.
 # When upgrading, verify: tool names (Agent vs Task), stream-json event schema,
 # hook event names. See ClaudeToolName in agentic_events.types.
-ARG CLAUDE_CLI_VERSION=2.1.69
+ARG CLAUDE_CLI_VERSION=2.1.76
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CLI_VERSION}
 
 # =============================================================================
@@ -212,6 +212,9 @@ ENV HOME=/home/agent \
     RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/home/agent/.cargo \
     PATH=/usr/local/cargo/bin:$PATH
+
+# Labels for version tracking and image selection
+LABEL agentic.claude_cli_version=${CLAUDE_CLI_VERSION}
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=2 \

--- a/providers/workspaces/claude-cli/Dockerfile
+++ b/providers/workspaces/claude-cli/Dockerfile
@@ -214,6 +214,8 @@ ENV HOME=/home/agent \
     PATH=/usr/local/cargo/bin:$PATH
 
 # Labels for version tracking and image selection
+# Re-declare ARG here: build args are stage-scoped and don't carry across FROM boundaries.
+ARG CLAUDE_CLI_VERSION
 LABEL agentic.claude_cli_version=${CLAUDE_CLI_VERSION}
 
 # Health check

--- a/scripts/build-provider.py
+++ b/scripts/build-provider.py
@@ -151,18 +151,44 @@ def get_git_commit() -> str:
     return "unknown"
 
 
+def extract_cli_version(build_context: Path) -> str | None:
+    """Extract CLAUDE_CLI_VERSION from the staged Dockerfile."""
+    dockerfile = build_context / "Dockerfile"
+    if not dockerfile.exists():
+        return None
+    for line in dockerfile.read_text().splitlines():
+        # Match: ARG CLAUDE_CLI_VERSION=X.Y.Z
+        if line.strip().startswith("ARG CLAUDE_CLI_VERSION="):
+            return line.split("=", 1)[1].strip()
+    return None
+
+
 def docker_build(
     build_context: Path,
     tag: str,
     no_cache: bool = False,
 ) -> None:
-    """Run docker build with commit label for cache invalidation."""
+    """Run docker build with commit label for cache invalidation.
+
+    Also tags with the CLI version (e.g., :2.1.76) so consumers can
+    pin specific versions.
+    """
     commit = get_git_commit()
     cmd = ["docker", "build", "-t", tag, "--label", f"agentic.commit={commit}", "."]
+
+    # Add version-specific tag (e.g., agentic-workspace-claude-cli:2.1.76)
+    cli_version = extract_cli_version(build_context)
+    if cli_version:
+        base_name = tag.rsplit(":", 1)[0]
+        version_tag = f"{base_name}:{cli_version}"
+        cmd.extend(["-t", version_tag])
+
     if no_cache:
         cmd.insert(2, "--no-cache")
 
     print(f"\n🐳 Building Docker image: {tag}")
+    if cli_version:
+        print(f"   Also tagged: {version_tag}")
     print(f"   Context: {build_context}")
     print(f"   Commit: {commit}")
 
@@ -173,6 +199,8 @@ def docker_build(
         sys.exit(1)
 
     print(f"\n✅ Successfully built: {tag}")
+    if cli_version:
+        print(f"   Version tag: {version_tag}")
 
 
 def main():

--- a/scripts/build-provider.py
+++ b/scripts/build-provider.py
@@ -174,7 +174,8 @@ def docker_build(
     pin specific versions.
     """
     commit = get_git_commit()
-    cmd = ["docker", "build", "-t", tag, "--label", f"agentic.commit={commit}", "."]
+    # Build args/flags first, context path "." last (docker build requires this order)
+    cmd = ["docker", "build", "-t", tag, "--label", f"agentic.commit={commit}"]
 
     # Add version-specific tag (e.g., agentic-workspace-claude-cli:2.1.76)
     cli_version = extract_cli_version(build_context)
@@ -182,6 +183,8 @@ def docker_build(
         base_name = tag.rsplit(":", 1)[0]
         version_tag = f"{base_name}:{cli_version}"
         cmd.extend(["-t", version_tag])
+
+    cmd.append(".")
 
     if no_cache:
         cmd.insert(2, "--no-cache")


### PR DESCRIPTION
Replaces #100 — rebased onto main after Dependabot and #104 merges.

## Changes

- Pin `@anthropic-ai/claude-code` to `2.1.76` in the workspace Dockerfile
- Add `ClaudeToolName` enum for tool-name stability across CLI versions
- Tag Docker images with the CLI version (e.g., `:2.1.76`) for pinned consumers
- Fix: re-declare `ARG CLAUDE_CLI_VERSION` in the `final` stage so the `LABEL` picks it up (build args are stage-scoped)
- Fix: move context path `"."` to after all `-t`/`--label` flags in `build-provider.py` (docker build requires options before context)