### PR TITLE
chore: bump agentic-isolation 0.4.0, agentic-logging 0.1.1

### DIFF
--- a/lib/python/agentic_isolation/pyproject.toml
+++ b/lib/python/agentic_isolation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentic-isolation"
-version = "0.3.0"
+version = "0.4.0"
 description = "Workspace isolation for AI agent execution"
 readme = "README.md"
 license = { text = "MIT" }

--- a/lib/python/agentic_logging/pyproject.toml
+++ b/lib/python/agentic_logging/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentic-logging"
-version = "0.1.0"
+version = "0.1.1"
 description = "Centralized logging system optimized for AI agents and human developers"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Version bumps

| Package | Old | New | Reason |
|---|---|---|---|
| `agentic-isolation` | 0.3.0 | 0.4.0 | New public API: `retry_async`, `CircuitBreaker`, `RetryPolicy`, `retry_with_circuit_breaker` |
| `agentic-logging` | 0.1.0 | 0.1.1 | Bug fix: `HumanFormatter` no longer leaks stdlib `LogRecord` fields as extra tree entries |