### PR TITLE
fix(retry): inject clock into CircuitBreaker for deterministic testing

### DIFF
--- a/lib/python/agentic_isolation/agentic_isolation/retry.py
+++ b/lib/python/agentic_isolation/agentic_isolation/retry.py
@@ -319,6 +319,7 @@ class CircuitBreaker:
         success_threshold: int = 1,
         is_failure: Callable[[BaseException], bool] | None = None,
         on_state_change: Callable[[CircuitState, CircuitState], None] | None = None,
+        clock: Callable[[], float] | None = None,
     ) -> None:
         if failure_threshold < 1:
             raise ValueError(f"failure_threshold must be >= 1, got {failure_threshold}")
@@ -340,6 +341,7 @@ class CircuitBreaker:
         self._last_failure_at: float | None = None
         self._total_calls: int = 0
         self._total_failures: int = 0
+        self._clock = clock or time.monotonic
 
     # ------------------------------------------------------------------
     # Public API
@@ -377,7 +379,7 @@ class CircuitBreaker:
 
         if self._state is CircuitState.OPEN:
             assert self._opened_at is not None  # noqa: S101
-            elapsed = time.monotonic() - self._opened_at
+            elapsed = self._clock() - self._opened_at
             remaining = max(0.0, self._reset_timeout_s - elapsed)
             raise CircuitOpenError(reset_at=time.time() + remaining)
 
@@ -406,7 +408,7 @@ class CircuitBreaker:
 
     def _check_reset(self) -> None:
         if self._state is CircuitState.OPEN and self._opened_at is not None:
-            elapsed = time.monotonic() - self._opened_at
+            elapsed = self._clock() - self._opened_at
             if elapsed >= self._reset_timeout_s:
                 self._transition(CircuitState.OPEN, CircuitState.HALF_OPEN)
                 self._successes = 0
@@ -428,15 +430,15 @@ class CircuitBreaker:
 
         self._total_failures += 1
         self._failures += 1
-        self._last_failure_at = time.monotonic()
+        self._last_failure_at = self._clock()
 
         if self._state is CircuitState.HALF_OPEN:
             self._transition(CircuitState.HALF_OPEN, CircuitState.OPEN)
-            self._opened_at = time.monotonic()
+            self._opened_at = self._clock()
             self._failures = 1
         elif self._state is CircuitState.CLOSED and self._failures >= self._failure_threshold:
             self._transition(CircuitState.CLOSED, CircuitState.OPEN)
-            self._opened_at = time.monotonic()
+            self._opened_at = self._clock()
 
     def _transition(self, from_state: CircuitState, to_state: CircuitState) -> None:
         self._state = to_state

--- a/lib/python/agentic_isolation/tests/test_retry.py
+++ b/lib/python/agentic_isolation/tests/test_retry.py
@@ -30,6 +30,19 @@ from agentic_isolation.retry import (
 # ---------------------------------------------------------------------------
 
 
+class FakeClock:
+    """Deterministic clock for testing time-dependent behavior."""
+
+    def __init__(self, start: float = 0.0) -> None:
+        self._now = start
+
+    def __call__(self) -> float:
+        return self._now
+
+    def advance(self, seconds: float) -> None:
+        self._now += seconds
+
+
 class TransientError(Exception):
     """Represents a transient (retryable) error."""
 
@@ -269,20 +282,22 @@ class TestCircuitBreakerStateMachine:
 
     @pytest.mark.asyncio
     async def test_transitions_open_to_half_open_after_timeout(self):
-        cb = CircuitBreaker(failure_threshold=1, reset_timeout_s=0.05)
+        clock = FakeClock()
+        cb = CircuitBreaker(failure_threshold=1, reset_timeout_s=0.05, clock=clock)
         with pytest.raises(TransientError):
             await cb.execute(always_fail())
         assert cb.state is CircuitState.OPEN
 
-        await asyncio.sleep(0.06)
+        clock.advance(0.06)
         assert cb.state is CircuitState.HALF_OPEN
 
     @pytest.mark.asyncio
     async def test_transitions_half_open_to_closed_on_success(self):
-        cb = CircuitBreaker(failure_threshold=1, reset_timeout_s=0.05)
+        clock = FakeClock()
+        cb = CircuitBreaker(failure_threshold=1, reset_timeout_s=0.05, clock=clock)
         with pytest.raises(TransientError):
             await cb.execute(always_fail())
-        await asyncio.sleep(0.06)
+        clock.advance(0.06)
         assert cb.state is CircuitState.HALF_OPEN
 
         result = await cb.execute(AsyncMock(return_value="ok"))
@@ -291,10 +306,11 @@ class TestCircuitBreakerStateMachine:
 
     @pytest.mark.asyncio
     async def test_transitions_half_open_to_open_on_failure(self):
-        cb = CircuitBreaker(failure_threshold=1, reset_timeout_s=0.05)
+        clock = FakeClock()
+        cb = CircuitBreaker(failure_threshold=1, reset_timeout_s=0.05, clock=clock)
         with pytest.raises(TransientError):
             await cb.execute(always_fail())
-        await asyncio.sleep(0.06)
+        clock.advance(0.06)
         assert cb.state is CircuitState.HALF_OPEN
 
         with pytest.raises(TransientError):


### PR DESCRIPTION
## Summary
- Add `clock` parameter to `CircuitBreaker.__init__`, defaulting to `time.monotonic`
- Replace all `time.monotonic()` calls with `self._clock()` for testability
- Enables `FakeClock` injection in tests, eliminating flaky `asyncio.sleep()` calls

## Test plan
- [x] Existing tests pass
- [x] Used in syntropic137/syntropic137 to eliminate 3 flaky sleeps in test_retry.py