### PR TITLE
fix: don't resolve workspace_host_dir — it's a Docker host path

### DIFF
--- a/lib/python/agentic_isolation/agentic_isolation/providers/docker.py
+++ b/lib/python/agentic_isolation/agentic_isolation/providers/docker.py
@@ -85,8 +85,12 @@ class WorkspaceDockerProvider(BaseProvider):
         self._default_image = default_image
         self._default_network = default_network
         self._security = security or SecurityConfig.production()
-        self._workspace_base_dir = Path(workspace_base_dir).resolve() if workspace_base_dir else None
-        self._workspace_host_dir = Path(workspace_host_dir).resolve() if workspace_host_dir else None
+        self._workspace_base_dir = (
+            Path(workspace_base_dir).resolve() if workspace_base_dir else None
+        )
+        self._workspace_host_dir = (
+            Path(workspace_host_dir).resolve() if workspace_host_dir else None
+        )
         self._workspaces: dict[str, Workspace] = {}
         self._lock = asyncio.Lock()
 

--- a/lib/python/agentic_isolation/agentic_isolation/providers/docker.py
+++ b/lib/python/agentic_isolation/agentic_isolation/providers/docker.py
@@ -88,9 +88,12 @@ class WorkspaceDockerProvider(BaseProvider):
         self._workspace_base_dir = (
             Path(workspace_base_dir).resolve() if workspace_base_dir else None
         )
-        self._workspace_host_dir = (
-            Path(workspace_host_dir).resolve() if workspace_host_dir else None
-        )
+        # Host dir is used for Docker -v mounts and must refer to the Docker
+        # *host* filesystem, not this process's filesystem.  When running inside
+        # a container (DinD), resolve() would map to the container's CWD — wrong.
+        # Keep the caller's path as-is; they are responsible for providing an
+        # absolute host path (via SYN_WORKSPACE_HOST_DIR env var).
+        self._workspace_host_dir = Path(workspace_host_dir) if workspace_host_dir else None
         self._workspaces: dict[str, Workspace] = {}
         self._lock = asyncio.Lock()
 

--- a/lib/python/agentic_isolation/agentic_isolation/providers/docker.py
+++ b/lib/python/agentic_isolation/agentic_isolation/providers/docker.py
@@ -85,8 +85,8 @@ class WorkspaceDockerProvider(BaseProvider):
         self._default_image = default_image
         self._default_network = default_network
         self._security = security or SecurityConfig.production()
-        self._workspace_base_dir = Path(workspace_base_dir) if workspace_base_dir else None
-        self._workspace_host_dir = Path(workspace_host_dir) if workspace_host_dir else None
+        self._workspace_base_dir = Path(workspace_base_dir).resolve() if workspace_base_dir else None
+        self._workspace_host_dir = Path(workspace_host_dir).resolve() if workspace_host_dir else None
         self._workspaces: dict[str, Workspace] = {}
         self._lock = asyncio.Lock()
 

--- a/lib/python/agentic_isolation/tests/test_providers.py
+++ b/lib/python/agentic_isolation/tests/test_providers.py
@@ -208,26 +208,40 @@ class TestTerminateProcess:
 class TestDockerProviderPathResolution:
     """Tests for Docker provider path resolution."""
 
-    def test_relative_workspace_dir_resolved_to_absolute(self) -> None:
-        """Relative workspace dirs must be resolved to absolute paths.
+    def test_relative_base_dir_resolved_to_absolute(self) -> None:
+        """Relative workspace_base_dir must be resolved to absolute.
 
-        Docker interprets relative paths in -v= as named volumes. Volume names
-        cannot contain "/" so "workspaces/ws-abc" fails. Resolving to absolute
-        paths ensures Docker treats them as bind mounts instead.
+        workspace_base_dir is where this process does file I/O.  Docker
+        interprets relative paths in -v= as named volumes, and volume names
+        can't contain "/", so relative multi-segment paths fail.
         """
         from agentic_isolation import WorkspaceDockerProvider
 
         provider = WorkspaceDockerProvider(
             workspace_base_dir="./workspaces",
-            workspace_host_dir="./host-workspaces",
         )
         assert provider._workspace_base_dir is not None
         assert provider._workspace_base_dir.is_absolute()
-        assert provider._workspace_host_dir is not None
-        assert provider._workspace_host_dir.is_absolute()
 
-    def test_absolute_workspace_dir_unchanged(self) -> None:
-        """Absolute paths should remain absolute after resolution."""
+    def test_host_dir_preserved_as_is(self) -> None:
+        """workspace_host_dir must NOT be resolved — it's a host path.
+
+        When running in Docker-in-Docker, workspace_host_dir refers to the
+        Docker *host* filesystem.  resolve() would map it to the container's
+        CWD, producing the wrong path for -v mounts.
+        """
+        from pathlib import Path
+
+        from agentic_isolation import WorkspaceDockerProvider
+
+        provider = WorkspaceDockerProvider(
+            workspace_host_dir="./host-workspaces",
+        )
+        assert provider._workspace_host_dir is not None
+        assert provider._workspace_host_dir == Path("./host-workspaces")
+
+    def test_absolute_base_dir_unchanged(self) -> None:
+        """Absolute base_dir should remain absolute after resolution."""
         from agentic_isolation import WorkspaceDockerProvider
 
         provider = WorkspaceDockerProvider(

--- a/lib/python/agentic_isolation/tests/test_providers.py
+++ b/lib/python/agentic_isolation/tests/test_providers.py
@@ -205,6 +205,41 @@ class TestTerminateProcess:
         await BaseProvider._terminate_process(proc)
 
 
+class TestDockerProviderPathResolution:
+    """Tests for Docker provider path resolution."""
+
+    def test_relative_workspace_dir_resolved_to_absolute(self) -> None:
+        """Relative workspace dirs must be resolved to absolute paths.
+
+        Docker interprets relative paths in -v= as named volumes. Volume names
+        cannot contain "/" so "workspaces/ws-abc" fails. Resolving to absolute
+        paths ensures Docker treats them as bind mounts instead.
+        """
+        from agentic_isolation import WorkspaceDockerProvider
+
+        provider = WorkspaceDockerProvider(
+            workspace_base_dir="./workspaces",
+            workspace_host_dir="./host-workspaces",
+        )
+        assert provider._workspace_base_dir is not None
+        assert provider._workspace_base_dir.is_absolute()
+        assert provider._workspace_host_dir is not None
+        assert provider._workspace_host_dir.is_absolute()
+
+    def test_absolute_workspace_dir_unchanged(self) -> None:
+        """Absolute paths should remain absolute after resolution."""
+        from agentic_isolation import WorkspaceDockerProvider
+
+        provider = WorkspaceDockerProvider(
+            workspace_base_dir="/workspaces",
+            workspace_host_dir="/host/workspaces",
+        )
+        assert provider._workspace_base_dir is not None
+        assert str(provider._workspace_base_dir) == "/workspaces"
+        assert provider._workspace_host_dir is not None
+        assert str(provider._workspace_host_dir) == "/host/workspaces"
+
+
 class TestWorkspaceProviderProtocol:
     """Tests for WorkspaceProvider protocol."""
 

--- a/lib/python/agentic_isolation/tests/test_retry.py
+++ b/lib/python/agentic_isolation/tests/test_retry.py
@@ -10,7 +10,7 @@ Covers:
 
 from __future__ import annotations
 
-import asyncio
+import asyncio  # noqa: F401 — used in patch("asyncio.sleep") string refs
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest


### PR DESCRIPTION
## Summary
- Follow-up to #130 — `workspace_host_dir` should NOT be resolved via `Path.resolve()`
- In Docker-in-Docker setups, `workspace_host_dir` refers to the Docker *host* filesystem
- `resolve()` maps it to the container's CWD, producing `/app/workspaces/ws-xxx` instead of the actual host path
- Only `workspace_base_dir` (used for local file I/O) should be resolved

## Test plan
- [x] `test_relative_base_dir_resolved_to_absolute` — base dir resolves to absolute
- [x] `test_host_dir_preserved_as_is` — host dir kept as caller provided
- [x] `test_absolute_base_dir_unchanged` — absolute paths unchanged
- [x] All 18 provider tests pass