### PR TITLE
fix: don't resolve workspace_host_dir — it's a Docker host path

### DIFF
--- a/lib/python/agentic_isolation/agentic_isolation/providers/docker.py
+++ b/lib/python/agentic_isolation/agentic_isolation/providers/docker.py
@@ -88,9 +88,10 @@ class WorkspaceDockerProvider(BaseProvider):
         self._workspace_base_dir = (
             Path(workspace_base_dir).resolve() if workspace_base_dir else None
         )
-        self._workspace_host_dir = (
-            Path(workspace_host_dir).resolve() if workspace_host_dir else None
-        )
+        # Host dir is used for Docker -v mounts and must refer to the Docker
+        # *host* filesystem, not this process's filesystem.  When running inside
+        # a container (DinD), resolve() would map to the container's CWD — wrong.
+        self._workspace_host_dir = Path(workspace_host_dir) if workspace_host_dir else None
         self._workspaces: dict[str, Workspace] = {}
         self._lock = asyncio.Lock()
 

--- a/lib/python/agentic_isolation/tests/test_providers.py
+++ b/lib/python/agentic_isolation/tests/test_providers.py
@@ -208,25 +208,35 @@ class TestTerminateProcess:
 class TestDockerProviderPathResolution:
     """Tests for Docker provider path resolution."""
 
-    def test_relative_workspace_dir_resolved_to_absolute(self) -> None:
-        """Relative workspace dirs must be resolved to absolute paths.
+    def test_relative_base_dir_resolved_to_absolute(self) -> None:
+        """Relative workspace_base_dir must be resolved to absolute.
 
-        Docker interprets relative paths in -v= as named volumes. Volume names
-        cannot contain "/" so "workspaces/ws-abc" fails. Resolving to absolute
-        paths ensures Docker treats them as bind mounts instead.
+        workspace_base_dir is where this process does file I/O.  Docker
+        interprets relative paths in -v= as named volumes, and volume names
+        can't contain "/", so relative multi-segment paths fail.
         """
         from agentic_isolation import WorkspaceDockerProvider
 
-        provider = WorkspaceDockerProvider(
-            workspace_base_dir="./workspaces",
-            workspace_host_dir="./host-workspaces",
-        )
+        provider = WorkspaceDockerProvider(workspace_base_dir="./workspaces")
         assert provider._workspace_base_dir is not None
         assert provider._workspace_base_dir.is_absolute()
-        assert provider._workspace_host_dir is not None
-        assert provider._workspace_host_dir.is_absolute()
 
-    def test_absolute_workspace_dir_unchanged(self) -> None:
+    def test_host_dir_preserved_as_is(self) -> None:
+        """workspace_host_dir must NOT be resolved — it's a host path.
+
+        When running in Docker-in-Docker, workspace_host_dir refers to the
+        Docker *host* filesystem.  resolve() would map it to the container's
+        CWD, producing the wrong path for -v mounts.
+        """
+        from pathlib import Path
+
+        from agentic_isolation import WorkspaceDockerProvider
+
+        provider = WorkspaceDockerProvider(workspace_host_dir="./host-workspaces")
+        assert provider._workspace_host_dir is not None
+        assert provider._workspace_host_dir == Path("./host-workspaces")
+
+    def test_absolute_paths_unchanged(self) -> None:
         """Absolute paths should remain absolute after resolution."""
         from agentic_isolation import WorkspaceDockerProvider
 


### PR DESCRIPTION
## Summary
Supersedes #131 (had merge conflicts from rebase).

- Follow-up to #130 — `workspace_host_dir` must NOT be resolved via `Path.resolve()`
- In Docker-in-Docker, `workspace_host_dir` refers to the Docker **host** filesystem
- `resolve()` inside the API container maps `./workspaces` → `/app/workspaces` instead of the actual host path
- Error: `mounts denied: The path /app/workspaces/ws-xxx is not shared from the host`
- Fix: only resolve `workspace_base_dir` (local file I/O), keep `workspace_host_dir` as-is

## Test plan
- [x] `test_relative_base_dir_resolved_to_absolute` — base dir resolves
- [x] `test_host_dir_preserved_as_is` — host dir kept as caller provided
- [x] `test_absolute_paths_unchanged` — absolute paths unchanged
- [x] All 18 provider tests pass