### PR TITLE
feat: consistent sha/branch/repo in all git event emitters

### DIFF
--- a/lib/python/agentic_events/agentic_events/__init__.py
+++ b/lib/python/agentic_events/agentic_events/__init__.py
@@ -26,6 +26,14 @@ Recording and playback for testing (ADR-030):
 
 from agentic_events.buffer import BatchBuffer, enrich_event, parse_jsonl_line
 from agentic_events.emitter import EventEmitter
+from agentic_events.fixtures import (
+    Recording,
+    get_recordings_dir,
+    list_recordings,
+    load_recording,
+    load_recording_by_name,
+    load_recording_by_path,
+)
 from agentic_events.payloads import (
     GitBranchChangedPayload,
     GitCheckoutPayload,
@@ -35,14 +43,6 @@ from agentic_events.payloads import (
     GitPayload,
     GitPushPayload,
     GitRewritePayload,
-)
-from agentic_events.fixtures import (
-    Recording,
-    get_recordings_dir,
-    list_recordings,
-    load_recording,
-    load_recording_by_name,
-    load_recording_by_path,
 )
 from agentic_events.player import RecordingMetadata, SessionPlayer
 from agentic_events.recorder import SessionRecorder

--- a/lib/python/agentic_events/agentic_events/__init__.py
+++ b/lib/python/agentic_events/agentic_events/__init__.py
@@ -26,6 +26,16 @@ Recording and playback for testing (ADR-030):
 
 from agentic_events.buffer import BatchBuffer, enrich_event, parse_jsonl_line
 from agentic_events.emitter import EventEmitter
+from agentic_events.payloads import (
+    GitBranchChangedPayload,
+    GitCheckoutPayload,
+    GitCommitPayload,
+    GitMergePayload,
+    GitOperationPayload,
+    GitPayload,
+    GitPushPayload,
+    GitRewritePayload,
+)
 from agentic_events.fixtures import (
     Recording,
     get_recordings_dir,
@@ -45,6 +55,15 @@ __all__ = [
     # Types
     "SecurityDecision",
     "SessionSource",
+    # Git event payloads (typed dataclasses)
+    "GitBranchChangedPayload",
+    "GitCheckoutPayload",
+    "GitCommitPayload",
+    "GitMergePayload",
+    "GitOperationPayload",
+    "GitPayload",
+    "GitPushPayload",
+    "GitRewritePayload",
     # Buffer utilities (for AEF)
     "BatchBuffer",
     "parse_jsonl_line",

--- a/lib/python/agentic_events/agentic_events/emitter.py
+++ b/lib/python/agentic_events/agentic_events/emitter.py
@@ -11,6 +11,15 @@ import time
 from datetime import UTC, datetime
 from typing import IO, Any
 
+from agentic_events.payloads import (
+    GitBranchChangedPayload,
+    GitCheckoutPayload,
+    GitCommitPayload,
+    GitMergePayload,
+    GitOperationPayload,
+    GitPushPayload,
+    GitRewritePayload,
+)
 from agentic_events.types import EventType, SecurityDecision
 
 
@@ -435,18 +444,24 @@ class EventEmitter:
             message: Commit message preview.
             sha: Commit SHA (short or full).
             branch: Branch the commit was made on.
-            **metadata: Additional metadata.
+            **metadata: Additional metadata (repo, files_changed, insertions,
+                deletions, author, estimated_tokens_added, estimated_tokens_removed).
         """
-        context: dict[str, Any] = {"operation": "commit"}
-        if message:
-            context["message"] = message[:200]
-        if sha:
-            context["sha"] = sha
-        if branch:
-            context["branch"] = branch
+        payload = GitCommitPayload(
+            message=message[:200] if message else "",
+            sha=sha,
+            branch=branch,
+            repo=str(metadata.pop("repo", "")),
+            author=str(metadata.pop("author", "")),
+            files_changed=int(metadata.pop("files_changed", 0)),
+            insertions=int(metadata.pop("insertions", 0)),
+            deletions=int(metadata.pop("deletions", 0)),
+            estimated_tokens_added=int(metadata.pop("estimated_tokens_added", 0)),
+            estimated_tokens_removed=int(metadata.pop("estimated_tokens_removed", 0)),
+        )
         return self.emit(
             EventType.GIT_COMMIT,
-            context=context,
+            context={"git": payload.to_dict()},
             metadata=metadata if metadata else None,
         )
 
@@ -465,18 +480,20 @@ class EventEmitter:
             branch: Branch being pushed.
             sha: HEAD commit SHA at push time.
             repo: Repository name.
-            **metadata: Additional metadata.
+            **metadata: Additional metadata (remote_url, commits_count, commit_range).
         """
-        context: dict[str, Any] = {"operation": "push", "remote": remote}
-        if branch:
-            context["branch"] = branch
-        if sha:
-            context["sha"] = sha
-        if repo:
-            context["repo"] = repo
+        payload = GitPushPayload(
+            remote=remote,
+            branch=branch,
+            sha=sha,
+            repo=repo,
+            remote_url=str(metadata.pop("remote_url", "")),
+            commits_count=int(metadata.pop("commits_count", 0)),
+            commit_range=str(metadata.pop("commit_range", "")),
+        )
         return self.emit(
             EventType.GIT_PUSH,
-            context=context,
+            context={"git": payload.to_dict()},
             metadata=metadata if metadata else None,
         )
 
@@ -493,13 +510,13 @@ class EventEmitter:
             to_branch: New branch name.
             **metadata: Additional metadata.
         """
+        payload = GitBranchChangedPayload(
+            from_branch=from_branch,
+            to_branch=to_branch,
+        )
         return self.emit(
             EventType.GIT_BRANCH_CHANGED,
-            context={
-                "operation": "branch_change",
-                "from_branch": from_branch,
-                "to_branch": to_branch,
-            },
+            context={"git": payload.to_dict()},
             metadata=metadata if metadata else None,
         )
 
@@ -518,16 +535,14 @@ class EventEmitter:
             repo: Repository name.
             **metadata: Additional metadata (commits_merged, is_squash, etc.).
         """
-        context: dict[str, Any] = {"operation": "merge"}
-        if branch:
-            context["branch"] = branch
-        if merge_sha:
-            context["sha"] = merge_sha
-        if repo:
-            context["repo"] = repo
+        payload = GitMergePayload(
+            branch=branch,
+            sha=merge_sha,
+            repo=repo,
+        )
         return self.emit(
             EventType.GIT_MERGE,
-            context=context,
+            context={"git": payload.to_dict()},
             metadata=metadata if metadata else None,
         )
 
@@ -548,16 +563,15 @@ class EventEmitter:
             repo: Repository name.
             **metadata: Additional metadata (mappings, commits_folded, etc.).
         """
-        context: dict[str, Any] = {"operation": rewrite_type}
-        if sha:
-            context["sha"] = sha
-        if branch:
-            context["branch"] = branch
-        if repo:
-            context["repo"] = repo
+        payload = GitRewritePayload(
+            operation=rewrite_type,
+            sha=sha,
+            branch=branch,
+            repo=repo,
+        )
         return self.emit(
             EventType.GIT_REWRITE,
-            context=context,
+            context={"git": payload.to_dict()},
             metadata=metadata if metadata else None,
         )
 
@@ -580,21 +594,17 @@ class EventEmitter:
             repo: Repository name.
             **metadata: Additional metadata.
         """
-        context: dict[str, Any] = {
-            "operation": "clone" if is_clone else "checkout",
-            "is_clone": is_clone,
-        }
-        if branch:
-            context["branch"] = branch
-        if prev_branch:
-            context["prev_branch"] = prev_branch
-        if sha:
-            context["sha"] = sha
-        if repo:
-            context["repo"] = repo
+        payload = GitCheckoutPayload(
+            operation="clone" if is_clone else "checkout",
+            branch=branch,
+            prev_branch=prev_branch,
+            sha=sha,
+            is_clone=is_clone,
+            repo=repo,
+        )
         return self.emit(
             EventType.GIT_CHECKOUT,
-            context=context,
+            context={"git": payload.to_dict()},
             metadata=metadata if metadata else None,
         )
 
@@ -611,11 +621,12 @@ class EventEmitter:
             details: Command details or arguments preview.
             **metadata: Additional metadata.
         """
-        context: dict[str, Any] = {"operation": operation}
-        if details:
-            context["details"] = details[:500]
+        payload = GitOperationPayload(
+            operation=operation,
+            details=details[:500] if details else "",
+        )
         return self.emit(
             EventType.GIT_OPERATION,
-            context=context,
+            context={"git": payload.to_dict()},
             metadata=metadata if metadata else None,
         )

--- a/lib/python/agentic_events/agentic_events/emitter.py
+++ b/lib/python/agentic_events/agentic_events/emitter.py
@@ -454,6 +454,8 @@ class EventEmitter:
         self,
         remote: str = "origin",
         branch: str = "",
+        sha: str = "",
+        repo: str = "",
         **metadata: Any,
     ) -> dict[str, Any]:
         """Emit a git push event.
@@ -461,11 +463,20 @@ class EventEmitter:
         Args:
             remote: Remote name.
             branch: Branch being pushed.
+            sha: HEAD commit SHA at push time.
+            repo: Repository name.
             **metadata: Additional metadata.
         """
+        context: dict[str, Any] = {"operation": "push", "remote": remote}
+        if branch:
+            context["branch"] = branch
+        if sha:
+            context["sha"] = sha
+        if repo:
+            context["repo"] = repo
         return self.emit(
             EventType.GIT_PUSH,
-            context={"operation": "push", "remote": remote, "branch": branch},
+            context=context,
             metadata=metadata if metadata else None,
         )
 
@@ -496,6 +507,7 @@ class EventEmitter:
         self,
         branch: str = "",
         merge_sha: str = "",
+        repo: str = "",
         **metadata: Any,
     ) -> dict[str, Any]:
         """Emit a git merge event (also fires on git pull).
@@ -503,6 +515,7 @@ class EventEmitter:
         Args:
             branch: Branch the merge landed on.
             merge_sha: SHA of the resulting merge commit.
+            repo: Repository name.
             **metadata: Additional metadata (commits_merged, is_squash, etc.).
         """
         context: dict[str, Any] = {"operation": "merge"}
@@ -510,6 +523,8 @@ class EventEmitter:
             context["branch"] = branch
         if merge_sha:
             context["sha"] = merge_sha
+        if repo:
+            context["repo"] = repo
         return self.emit(
             EventType.GIT_MERGE,
             context=context,
@@ -519,17 +534,30 @@ class EventEmitter:
     def git_rewrite(
         self,
         rewrite_type: str = "rebase",
+        sha: str = "",
+        branch: str = "",
+        repo: str = "",
         **metadata: Any,
     ) -> dict[str, Any]:
         """Emit a git rewrite event (rebase or amend).
 
         Args:
             rewrite_type: "rebase" or "amend".
+            sha: HEAD SHA after rewrite.
+            branch: Current branch.
+            repo: Repository name.
             **metadata: Additional metadata (mappings, commits_folded, etc.).
         """
+        context: dict[str, Any] = {"operation": rewrite_type}
+        if sha:
+            context["sha"] = sha
+        if branch:
+            context["branch"] = branch
+        if repo:
+            context["repo"] = repo
         return self.emit(
             EventType.GIT_REWRITE,
-            context={"operation": rewrite_type},
+            context=context,
             metadata=metadata if metadata else None,
         )
 
@@ -539,6 +567,7 @@ class EventEmitter:
         prev_branch: str = "",
         sha: str = "",
         is_clone: bool = False,
+        repo: str = "",
         **metadata: Any,
     ) -> dict[str, Any]:
         """Emit a git checkout event (checkout, switch, or clone).
@@ -548,6 +577,7 @@ class EventEmitter:
             prev_branch: Previous branch (empty if clone or unknown).
             sha: New HEAD SHA.
             is_clone: True if this is the initial checkout after git clone.
+            repo: Repository name.
             **metadata: Additional metadata.
         """
         context: dict[str, Any] = {
@@ -560,6 +590,8 @@ class EventEmitter:
             context["prev_branch"] = prev_branch
         if sha:
             context["sha"] = sha
+        if repo:
+            context["repo"] = repo
         return self.emit(
             EventType.GIT_CHECKOUT,
             context=context,

--- a/lib/python/agentic_events/agentic_events/payloads.py
+++ b/lib/python/agentic_events/agentic_events/payloads.py
@@ -1,0 +1,150 @@
+"""Typed event payloads for git observability hooks.
+
+Zero external dependencies - stdlib dataclasses only.
+These types are the single source of truth for git event structure.
+Downstream consumers (syn-domain, syn-adapters, syn-api, dashboard) depend
+on these field names flowing through the pipeline unchanged.
+
+Usage:
+    >>> payload = GitCommitPayload(sha="abc123", branch="main", message="fix bug")
+    >>> payload.to_dict()
+    {'operation': 'commit', 'sha': 'abc123', 'branch': 'main', 'message': 'fix bug'}
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+
+
+def _strip_empty(dc: object) -> dict[str, object]:
+    """Serialize a dataclass, omitting falsy fields (empty string, 0, False, None).
+
+    This matches the existing emitter behavior where the git hook methods
+    only include fields that have truthy values in the JSONL context dict.
+    The ``operation`` field is always included as it serves as the event
+    type discriminator.
+    """
+    result: dict[str, object] = {}
+    for f in fields(dc):  # type: ignore[arg-type]
+        val = getattr(dc, f.name)
+        if f.name == "operation" or val:
+            result[f.name] = val
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Git event payloads
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class GitCommitPayload:
+    """Payload for git_commit events."""
+
+    operation: str = "commit"
+    sha: str = ""
+    branch: str = ""
+    repo: str = ""
+    message: str = ""
+    author: str = ""
+    files_changed: int = 0
+    insertions: int = 0
+    deletions: int = 0
+    estimated_tokens_added: int = 0
+    estimated_tokens_removed: int = 0
+
+    def to_dict(self) -> dict[str, object]:
+        return _strip_empty(self)
+
+
+@dataclass(frozen=True, slots=True)
+class GitPushPayload:
+    """Payload for git_push events."""
+
+    operation: str = "push"
+    remote: str = "origin"
+    branch: str = ""
+    sha: str = ""
+    repo: str = ""
+    remote_url: str = ""
+    commits_count: int = 0
+    commit_range: str = ""
+
+    def to_dict(self) -> dict[str, object]:
+        return _strip_empty(self)
+
+
+@dataclass(frozen=True, slots=True)
+class GitCheckoutPayload:
+    """Payload for git_checkout events."""
+
+    operation: str = "checkout"
+    branch: str = ""
+    prev_branch: str = ""
+    sha: str = ""
+    is_clone: bool = False
+    repo: str = ""
+
+    def to_dict(self) -> dict[str, object]:
+        return _strip_empty(self)
+
+
+@dataclass(frozen=True, slots=True)
+class GitBranchChangedPayload:
+    """Payload for git_branch_changed events."""
+
+    operation: str = "branch_change"
+    from_branch: str = ""
+    to_branch: str = ""
+
+    def to_dict(self) -> dict[str, object]:
+        return _strip_empty(self)
+
+
+@dataclass(frozen=True, slots=True)
+class GitMergePayload:
+    """Payload for git_merge events."""
+
+    operation: str = "merge"
+    branch: str = ""
+    sha: str = ""
+    repo: str = ""
+
+    def to_dict(self) -> dict[str, object]:
+        return _strip_empty(self)
+
+
+@dataclass(frozen=True, slots=True)
+class GitRewritePayload:
+    """Payload for git_rewrite events."""
+
+    operation: str = "rebase"
+    sha: str = ""
+    branch: str = ""
+    repo: str = ""
+
+    def to_dict(self) -> dict[str, object]:
+        return _strip_empty(self)
+
+
+@dataclass(frozen=True, slots=True)
+class GitOperationPayload:
+    """Payload for generic git_operation events."""
+
+    operation: str = ""
+    details: str = ""
+
+    def to_dict(self) -> dict[str, object]:
+        return _strip_empty(self)
+
+
+# Union of all git payload types for type annotations
+GitPayload = (
+    GitCommitPayload
+    | GitPushPayload
+    | GitCheckoutPayload
+    | GitBranchChangedPayload
+    | GitMergePayload
+    | GitRewritePayload
+    | GitOperationPayload
+)

--- a/lib/python/agentic_events/tests/test_git_events.py
+++ b/lib/python/agentic_events/tests/test_git_events.py
@@ -6,6 +6,15 @@ import json
 import pytest
 
 from agentic_events import EventEmitter, EventType
+from agentic_events.payloads import (
+    GitBranchChangedPayload,
+    GitCheckoutPayload,
+    GitCommitPayload,
+    GitMergePayload,
+    GitOperationPayload,
+    GitPushPayload,
+    GitRewritePayload,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -26,6 +35,73 @@ class TestGitEventTypes:
         assert EventType.GIT_OPERATION == "git_operation"
 
 
+class TestGitPayloads:
+    """Tests for typed payload dataclasses."""
+
+    def test_commit_payload_to_dict_strips_defaults(self):
+        payload = GitCommitPayload(sha="abc123", branch="main", message="fix bug")
+        d = payload.to_dict()
+        assert d == {"operation": "commit", "sha": "abc123", "branch": "main", "message": "fix bug"}
+        assert "repo" not in d
+        assert "files_changed" not in d
+
+    def test_commit_payload_with_metadata(self):
+        payload = GitCommitPayload(
+            sha="abc",
+            branch="main",
+            repo="myrepo",
+            files_changed=3,
+            insertions=10,
+            deletions=2,
+        )
+        d = payload.to_dict()
+        assert d["files_changed"] == 3
+        assert d["insertions"] == 10
+        assert d["deletions"] == 2
+        assert d["repo"] == "myrepo"
+
+    def test_push_payload_strips_defaults(self):
+        payload = GitPushPayload(branch="main", sha="abc123")
+        d = payload.to_dict()
+        assert d == {"operation": "push", "remote": "origin", "branch": "main", "sha": "abc123"}
+
+    def test_checkout_payload(self):
+        payload = GitCheckoutPayload(branch="feat", sha="abc", is_clone=True, operation="clone")
+        d = payload.to_dict()
+        assert d["operation"] == "clone"
+        assert d["is_clone"] is True
+
+    def test_branch_changed_payload(self):
+        payload = GitBranchChangedPayload(from_branch="main", to_branch="feat")
+        d = payload.to_dict()
+        assert d == {"operation": "branch_change", "from_branch": "main", "to_branch": "feat"}
+
+    def test_merge_payload(self):
+        payload = GitMergePayload(branch="main", sha="abc")
+        d = payload.to_dict()
+        assert d == {"operation": "merge", "branch": "main", "sha": "abc"}
+
+    def test_rewrite_payload(self):
+        payload = GitRewritePayload(operation="amend", sha="abc")
+        d = payload.to_dict()
+        assert d == {"operation": "amend", "sha": "abc"}
+
+    def test_generic_operation_payload(self):
+        payload = GitOperationPayload(operation="stash")
+        d = payload.to_dict()
+        assert d == {"operation": "stash"}
+
+    def test_empty_payload_only_has_operation(self):
+        payload = GitCommitPayload()
+        d = payload.to_dict()
+        assert d == {"operation": "commit"}
+
+    def test_payloads_are_frozen(self):
+        payload = GitCommitPayload(sha="abc")
+        with pytest.raises(AttributeError):
+            payload.sha = "def"  # type: ignore[misc]
+
+
 class TestGitCommitEmitter:
     """Tests for git_commit emitter method."""
 
@@ -36,8 +112,9 @@ class TestGitCommitEmitter:
         event = emitter.git_commit(message="fix: resolve bug")
 
         assert event["event_type"] == "git_commit"
-        assert event["context"]["operation"] == "commit"
-        assert event["context"]["message"] == "fix: resolve bug"
+        git = event["context"]["git"]
+        assert git["operation"] == "commit"
+        assert git["message"] == "fix: resolve bug"
 
     def test_commit_with_sha_and_branch(self):
         output = io.StringIO()
@@ -45,8 +122,9 @@ class TestGitCommitEmitter:
 
         event = emitter.git_commit(message="feat: add feature", sha="abc1234", branch="main")
 
-        assert event["context"]["sha"] == "abc1234"
-        assert event["context"]["branch"] == "main"
+        git = event["context"]["git"]
+        assert git["sha"] == "abc1234"
+        assert git["branch"] == "main"
 
     def test_commit_message_truncated(self):
         output = io.StringIO()
@@ -55,7 +133,7 @@ class TestGitCommitEmitter:
         long_msg = "x" * 500
         event = emitter.git_commit(message=long_msg)
 
-        assert len(event["context"]["message"]) == 200
+        assert len(event["context"]["git"]["message"]) == 200
 
     def test_commit_empty_message(self):
         output = io.StringIO()
@@ -64,7 +142,8 @@ class TestGitCommitEmitter:
         event = emitter.git_commit()
 
         assert event["event_type"] == "git_commit"
-        assert "message" not in event["context"]
+        git = event["context"]["git"]
+        assert "message" not in git  # empty string stripped by to_dict()
 
     def test_commit_jsonl_output(self):
         output = io.StringIO()
@@ -75,6 +154,39 @@ class TestGitCommitEmitter:
         output.seek(0)
         parsed = json.loads(output.readline())
         assert parsed["event_type"] == "git_commit"
+        assert "git" in parsed["context"]
+
+    def test_commit_metadata_flows_to_payload(self):
+        output = io.StringIO()
+        emitter = EventEmitter(session_id="test-git", output=output)
+
+        event = emitter.git_commit(
+            message="fix",
+            sha="abc",
+            branch="main",
+            repo="myrepo",
+            files_changed=3,
+            insertions=10,
+            deletions=2,
+            author="neural",
+        )
+
+        git = event["context"]["git"]
+        assert git["repo"] == "myrepo"
+        assert git["files_changed"] == 3
+        assert git["insertions"] == 10
+        assert git["deletions"] == 2
+        assert git["author"] == "neural"
+
+    def test_commit_unknown_metadata_goes_to_metadata_key(self):
+        output = io.StringIO()
+        emitter = EventEmitter(session_id="test-git", output=output)
+
+        event = emitter.git_commit(message="fix", custom_field="custom_value")
+
+        # Unknown kwargs should flow to metadata, not context.git
+        assert event.get("metadata", {}).get("custom_field") == "custom_value"
+        assert "custom_field" not in event["context"]["git"]
 
 
 class TestGitPushEmitter:
@@ -87,9 +199,10 @@ class TestGitPushEmitter:
         event = emitter.git_push(remote="origin", branch="main")
 
         assert event["event_type"] == "git_push"
-        assert event["context"]["operation"] == "push"
-        assert event["context"]["remote"] == "origin"
-        assert event["context"]["branch"] == "main"
+        git = event["context"]["git"]
+        assert git["operation"] == "push"
+        assert git["remote"] == "origin"
+        assert git["branch"] == "main"
 
     def test_push_defaults(self):
         output = io.StringIO()
@@ -97,8 +210,20 @@ class TestGitPushEmitter:
 
         event = emitter.git_push()
 
-        assert event["context"]["remote"] == "origin"
-        assert event["context"]["branch"] == ""
+        git = event["context"]["git"]
+        assert git["remote"] == "origin"
+        # branch="" is stripped by to_dict()
+        assert "branch" not in git
+
+    def test_push_with_sha_and_repo(self):
+        output = io.StringIO()
+        emitter = EventEmitter(session_id="test-git", output=output)
+
+        event = emitter.git_push(branch="main", sha="abc123", repo="myrepo")
+
+        git = event["context"]["git"]
+        assert git["sha"] == "abc123"
+        assert git["repo"] == "myrepo"
 
 
 class TestGitBranchChangedEmitter:
@@ -111,9 +236,10 @@ class TestGitBranchChangedEmitter:
         event = emitter.git_branch_changed(from_branch="main", to_branch="feature-x")
 
         assert event["event_type"] == "git_branch_changed"
-        assert event["context"]["operation"] == "branch_change"
-        assert event["context"]["from_branch"] == "main"
-        assert event["context"]["to_branch"] == "feature-x"
+        git = event["context"]["git"]
+        assert git["operation"] == "branch_change"
+        assert git["from_branch"] == "main"
+        assert git["to_branch"] == "feature-x"
 
     def test_branch_change_partial(self):
         output = io.StringIO()
@@ -121,8 +247,9 @@ class TestGitBranchChangedEmitter:
 
         event = emitter.git_branch_changed(to_branch="develop")
 
-        assert event["context"]["to_branch"] == "develop"
-        assert event["context"]["from_branch"] == ""
+        git = event["context"]["git"]
+        assert git["to_branch"] == "develop"
+        assert "from_branch" not in git  # empty string stripped
 
 
 class TestGitOperationEmitter:
@@ -135,8 +262,9 @@ class TestGitOperationEmitter:
         event = emitter.git_operation(operation="pull", details="git pull origin main")
 
         assert event["event_type"] == "git_operation"
-        assert event["context"]["operation"] == "pull"
-        assert event["context"]["details"] == "git pull origin main"
+        git = event["context"]["git"]
+        assert git["operation"] == "pull"
+        assert git["details"] == "git pull origin main"
 
     def test_operation_details_truncated(self):
         output = io.StringIO()
@@ -145,7 +273,7 @@ class TestGitOperationEmitter:
         long_details = "x" * 1000
         event = emitter.git_operation(operation="log", details=long_details)
 
-        assert len(event["context"]["details"]) == 500
+        assert len(event["context"]["git"]["details"]) == 500
 
     def test_operation_no_details(self):
         output = io.StringIO()
@@ -153,7 +281,7 @@ class TestGitOperationEmitter:
 
         event = emitter.git_operation(operation="stash")
 
-        assert "details" not in event["context"]
+        assert "details" not in event["context"]["git"]
 
     @pytest.mark.parametrize(
         "op", ["pull", "merge", "rebase", "stash", "fetch", "clone", "log", "diff", "status"]
@@ -164,7 +292,7 @@ class TestGitOperationEmitter:
 
         event = emitter.git_operation(operation=op)
 
-        assert event["context"]["operation"] == op
+        assert event["context"]["git"]["operation"] == op
 
 
 class TestGitEventsIntegration:
@@ -199,3 +327,23 @@ class TestGitEventsIntegration:
         assert "git_push" in types
         assert "session_started" in types
         assert "session_completed" in types
+
+    def test_git_events_have_structured_context(self):
+        """All git events must have context.git sub-object."""
+        output = io.StringIO()
+        emitter = EventEmitter(session_id="test-struct", output=output)
+
+        emitter.git_commit(sha="a1b2", message="fix")
+        emitter.git_push(branch="main", sha="a1b2")
+        emitter.git_checkout(branch="feat", sha="c3d4")
+        emitter.git_branch_changed(from_branch="main", to_branch="feat")
+        emitter.git_merge(branch="main", merge_sha="e5f6")
+        emitter.git_rewrite(rewrite_type="rebase", sha="g7h8")
+        emitter.git_operation(operation="stash")
+
+        output.seek(0)
+        for line in output.readlines():
+            event = json.loads(line)
+            assert "git" in event["context"], f"{event['event_type']} missing context.git"
+            git = event["context"]["git"]
+            assert "operation" in git, f"{event['event_type']} missing git.operation"

--- a/plugins/observability/.claude-plugin/plugin.json
+++ b/plugins/observability/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "observability",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Full-spectrum agent observability — hooks every Claude Code lifecycle event and emits structured JSONL events via agentic_events. Composable with other plugins.",
   "author": {"name": "NeuralEmpowerment"},
   "repository": "https://github.com/AgentParadise/agentic-primitives"

--- a/plugins/observability/CHANGELOG.md
+++ b/plugins/observability/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog — observability plugin
 
+## 0.2.2
+- Git hooks (post-merge, post-rewrite, pre-push) now emit structured sha/branch/repo context via the typed git event payloads in agentic_events
+
 ## 0.1.0 (2026-02-18)
 - Initial release: full-spectrum observability across all 14 Claude Code hook events
 - Single generic handler (`observe.py`) dispatches all events

--- a/plugins/observability/hooks/git/post-merge
+++ b/plugins/observability/hooks/git/post-merge
@@ -27,6 +27,10 @@ def main():
         branch = run(["git", "rev-parse", "--abbrev-ref", "HEAD"])
         merge_sha = run(["git", "rev-parse", "HEAD"])
 
+        # Get repo name from remote
+        remote = run(["git", "remote", "get-url", "origin"])
+        repo = remote.rstrip("/").rsplit("/", 1)[-1].replace(".git", "") if remote else ""
+
         # Count merged commits
         commits_merged = 0
         check = run(["git", "rev-parse", "HEAD^2"])
@@ -41,6 +45,7 @@ def main():
         emitter.git_merge(
             branch=branch,
             merge_sha=merge_sha,
+            repo=repo,
             commits_merged=commits_merged,
             is_squash=is_squash,
         )

--- a/plugins/observability/hooks/git/post-rewrite
+++ b/plugins/observability/hooks/git/post-rewrite
@@ -9,7 +9,16 @@ Args: $1 = "rebase" or "amend"
 """
 
 import os
+import subprocess
 import sys
+
+
+def run(cmd, **kwargs):
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=5, **kwargs)
+        return r.stdout.strip()
+    except Exception:
+        return ""
 
 
 def main():
@@ -20,6 +29,12 @@ def main():
         emitter = EventEmitter(session_id=session_id, provider="claude", output=sys.stderr)
 
         rewrite_type = sys.argv[1] if len(sys.argv) > 1 else "unknown"
+        sha = run(["git", "rev-parse", "HEAD"])
+        branch = run(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+
+        # Get repo name from remote
+        remote = run(["git", "remote", "get-url", "origin"])
+        repo = remote.rstrip("/").rsplit("/", 1)[-1].replace(".git", "") if remote else ""
 
         # Read old-sha new-sha pairs from stdin
         mappings = []
@@ -31,6 +46,9 @@ def main():
 
         emitter.git_rewrite(
             rewrite_type=rewrite_type,
+            sha=sha,
+            branch=branch,
+            repo=repo,
             mappings=mappings,
             commits_folded=len(mappings),
         )

--- a/plugins/observability/hooks/git/pre-push
+++ b/plugins/observability/hooks/git/pre-push
@@ -31,6 +31,11 @@ def main():
         remote = sys.argv[1] if len(sys.argv) > 1 else "origin"
         remote_url = sys.argv[2] if len(sys.argv) > 2 else ""
         branch = run(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+        sha = run(["git", "rev-parse", "HEAD"])
+
+        # Get repo name from remote
+        origin = run(["git", "remote", "get-url", "origin"])
+        repo = origin.rstrip("/").rsplit("/", 1)[-1].replace(".git", "") if origin else ""
 
         # Count commits to push
         upstream = run(["git", "rev-parse", "--abbrev-ref", "@{upstream}"])
@@ -46,6 +51,8 @@ def main():
             branch=branch,
             remote=remote,
             remote_url=remote_url,
+            sha=sha,
+            repo=repo,
             commits_count=commits_count,
             commit_range=commit_range,
         )


### PR DESCRIPTION
## Summary

- All git observability hooks (pre-push, post-merge, post-rewrite) now capture SHA, branch, and repo name consistently, matching post-commit and post-checkout
- Emitter methods (git_push, git_merge, git_rewrite, git_checkout) accept sha/branch/repo as named params and store them in the context dict, not **metadata
- Fixes downstream dashboard showing incomplete git sub-headers (missing SHA/repo on push, merge, rewrite events)

## Test plan

- [ ] Run a workflow that triggers push, merge, rewrite operations
- [ ] Verify all git events in the dashboard show SHA, branch, and repo consistently