### PR TITLE
chore(skills): port authoring-skills as a meta-skill, twice

### DIFF
--- a/.claude/skills/authoring-skills/SKILL.md
+++ b/.claude/skills/authoring-skills/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: authoring-skills
+description: Use when authoring or auditing a Claude skill (`SKILL.md` with YAML frontmatter), refining an existing skill, or reviewing a skill against a chassis. Trigger phrases include "write a skill", "author a skill", "audit this skill", "review the skill", "skill structure", "skill shape", "SKILL.md template", "skill description", "skill frontmatter", "skill not triggering". Covers Claude Code skills, plugin skills, personal `~/.claude/skills`, and project-local `.claude/skills/`. Applies to principle-doc skills (durable knowledge about a concern) and procedural skills (workflow with input/output). Do NOT use for slash commands, hooks, or MCP servers; those have different shapes.
+placement: "Meta-skill. Install in `.claude/skills/<skill-name>/` (repo-local meta scope) or `plugins/<meta-plugin>/skills/<skill-name>/` (when exported via a meta plugin). NOT alongside domain-specific skills under `skills/` or `plugins/<domain-plugin>/skills/`. The rule: skills that teach how to author other skills live at the meta level, separate from skills that teach a specific domain concern."
+---
+
+# Authoring Skills
+
+## Overview
+
+A skill is a `SKILL.md` file (plus optional bundled resources) that teaches Claude how to handle a concern by being loaded into context when relevant. Two things determine whether a skill works: whether Claude routes the right tasks to it (the description's job), and whether the body actually helps once loaded (the content's job). Most skill problems are one of those two; this chassis exists to make both reliable.
+
+This skill is the canonical authoring contract. Follow it whenever writing a new skill or auditing an existing one, both inside this plugin and in any other Claude project. It distills Anthropic's official skill-creator guidance and adds two opinionated additions: **Outcomes** as a durable north-star section, and an **anti-yellow-flag** posture that prefers observation over command-form rules.
+
+## Outcomes we are looking for
+
+Goals are durable. Tools and tactics will change; these will not. Each outcome has 1-2 evidence signals you can check later to see whether the goal is being met.
+
+### Outcome 1: skills route correctly
+
+Claude invokes the right skill for the task without prompting from the user.
+
+- *Signal:* the user gives a task that matches the skill's domain, and Claude reaches for the skill on its own.
+- *Signal:* unrelated tasks do NOT trigger the skill (no false-positive activations cluttering the session).
+
+### Outcome 2: the body earns its lines
+
+Every paragraph in a loaded skill pulls weight. The agent can act faster and more correctly with the skill than without it.
+
+- *Signal:* if a paragraph were removed, behavior would measurably degrade.
+- *Signal:* the skill body fits comfortably under 500 lines; depth lives in `references/`.
+
+### Outcome 3: durable content does not rot with the tool layer
+
+Principles and outcomes outlive specific tool recommendations. When a recommended library is replaced, only the dated tools-and-practices section needs editing.
+
+- *Signal:* the date on `## Recommended tools and practices (as of YYYY-MM-DD)` matches the last edit to that section; everything above it is unaffected by tool churn.
+
+### Outcome 4: auditing is mechanical, not opinion-shaped
+
+A reviewer following this chassis can decide if a skill conforms without making aesthetic judgments. Gaps are checkable.
+
+- *Signal:* the audit checklist in `references/audit-checklist.md` returns a clean pass-fail per criterion.
+
+### Outcome 5: the chassis demonstrates itself
+
+This skill obeys its own rules. If you read this file looking for a violation of the chassis, you will not find one. Drift in this file is an outage of the entire authoring discipline.
+
+- *Signal:* `authoring-skills` itself passes the audit checklist with zero findings.
+
+## Principles
+
+1. **Structure is two-axis: type and shape.** A skill is either a **principle doc** (durable knowledge about a concern, consulted not invoked) or a **procedural skill** (a workflow with input, steps, and output). The two have different section orders; pick one consciously. See `references/skill-template.md` for both canonical shapes.
+
+2. **The description carries the routing.** Triggering is a separate problem from execution. The description must list explicit trigger phrases, common synonyms, file extensions when applicable, adjacent intents users phrase casually, and explicit non-triggers ("Do NOT use for X"). Description content lives in the description, not the body. See `references/description-trigger-rules.md`.
+
+3. **Outcomes are the north star, recommendations ladder up.** Every principle-doc skill carries a `## Outcomes we are looking for` section near the top, before any "how." The `## Recommended tools and practices (as of YYYY-MM-DD)` section groups recommendations under the outcome each one serves, with a one-line rationale linking the tool to the goal. When a tool rots, the outcome above survives. See `references/outcomes-laddering.md`.
+
+4. **Progressive disclosure across three levels.** Metadata (always in context) → SKILL.md body (loaded on trigger, lean, ~500 lines max) → bundled resources in `references/`, `scripts/`, `assets/` (loaded only when the body points to them). If the body grows past ~500 lines, move material to `references/`.
+
+5. **Imperative voice, explained why.** Tell Claude what to do, but explain the reasoning. Skills are read by an agent that can reason; rote MUSTs and ALWAYS/NEVER paragraphs are less effective than "do X because Y." Heavy command-form rule lists are a yellow flag; see `references/anti-yellow-flags.md`.
+
+6. **Observations beat shouting.** Anti-patterns are described as observations the auditor sees in real codebases ("the agent must read user-pasted screenshots manually because no programmatic capture path exists"). They are not commandments dressed up in caps ("NEVER read user-pasted screenshots"). The former is checkable; the latter performs discipline without actually enforcing it.
+
+7. **General, not example-specific.** A skill gets used across many prompts. Do not overfit the body to two or three test cases. Worked examples belong in `references/` where they can be skipped when not relevant.
+
+8. **Iterate, do not write-once.** Draft → write 2-3 realistic test prompts → run Claude with the skill → review what it did → revise. Trigger problems are a separate iteration loop from body problems. Do not co-fix them. For the full empirical methodology (live `claude -p` routing tests, body-usefulness paired runs, flake handling), see the sibling [`skill-testing`](../skill-testing/SKILL.md) skill and its references.
+
+9. **Encode opinions the baseline would not produce.** A skill earns its lines most strongly when its body contains opinions, recommendations, or framings that baseline Claude (no skill loaded) would not produce on its own. Dated, hard-won, project-specific recommendations (validated stack versions, rejected alternatives with rationale, cross-skill handoff patterns) deliver more value than well-known best practices the model already knows. When auditing a skill, ask: if the user fired this prompt without the skill loaded, would they get a meaningfully different answer? If the answer is no, the skill is anchoring framing only; consider whether that justifies its lines or whether the content belongs as a one-line cross-reference. See `docs/superpowers/specs/2026-05-14-routing-test-results.md` for the empirical study that produced this principle.
+
+## Anti-patterns
+
+Observations from skill audits. Each one names a specific failure mode; see `references/anti-yellow-flags.md` for the longer list.
+
+- **Description describes the topic, not the trigger.** "This skill is about telemetry pipelines." The agent does not know when to reach for it. The description should list phrases users actually type.
+- **Body opens with `## When to Use` instead of `## Overview`.** Routing logic in the body is wasted bytes; routing logic is the description's job. Body opens with what the skill is and what the outcomes are.
+- **Heavy ALWAYS / NEVER / MUST blocks.** Reads like a policy document; degrades to noise once the agent has seen the third one. Reframe as "do X because Y."
+- **`## Red Flags - STOP` formatted as commandments.** Observational shape works better: name what the auditor sees, name what it means, name what to do.
+- **Tools listed without rationale.** "Use Playwright." Why? For what outcome? When the tool rots, the next reader has no anchor.
+- **Outcomes section absent.** Without it, the skill is a list of patterns with no north star, and tool drift kills the whole body over time.
+- **Body over 500 lines with no `references/`.** Loaded weight is too high; the agent's context budget is spent on detail that was not relevant to this turn.
+- **Skill describes its own existence in the body.** "This skill helps with X." The frontmatter description already said that. The body's first sentence should be useful content.
+- **Audit mode mixed into authoring mode without separation.** Reviewers and authors have different jobs. Either ship two skills, or clearly split the body into "to write a skill" and "to audit a skill" sections.
+
+## Recommended tools and practices (as of 2026-05-13)
+
+The structural recommendations are tool-independent. The drafting and review loop suggests specific tools.
+
+### Outcome: skills route correctly
+
+- **Description-first drafting.** Write the description before the body. If you cannot list 5-10 trigger phrases the user might type, the skill is either too narrow or not yet understood. Ladders up by forcing routing logic into the field that carries it.
+- **Explicit non-triggers in the description.** State "Do NOT use for X, Y" when adjacent skills exist. Ladders up by suppressing false-positive activations.
+- **Run 2-3 realistic test prompts before declaring done.** Ladders up by surfacing routing gaps before deployment.
+
+### Outcome: the body earns its lines
+
+- **500-line soft cap on `SKILL.md`.** When the body grows past that, move material to `references/<topic>.md` and reference it from the body. Ladders up by keeping loaded weight low.
+- **`references/`, `scripts/`, `assets/` subdirectories** for progressive-disclosure bundling. Ladders up by giving Claude a place to fetch depth only when the task requires it.
+- **Cut-the-fat editing pass.** After draft, re-read and delete any paragraph that does not change agent behavior. Ladders up by removing rationalization-shaped filler.
+
+### Outcome: durable content does not rot
+
+- **`## Outcomes we are looking for` section near the top.** Tool-free, goal-shaped. Ladders up by giving the rest of the body something stable to ladder up to.
+- **`## Recommended tools and practices (as of YYYY-MM-DD)` section.** Dated. Grouped under outcomes. Each recommendation cites the outcome it serves. Ladders up by isolating the high-churn layer to one section.
+- **Citation discipline.** Source articles, RFCs, official docs, named practitioners. Ladders up by letting the next reader verify a recommendation against its source.
+
+### Outcome: auditing is mechanical
+
+- **`references/audit-checklist.md`** with binary pass-fail criteria per section. Ladders up by making "is this skill compliant?" answerable without aesthetic judgment.
+- **A periodic skill sweep.** Audit every skill in the plugin against the chassis whenever the chassis itself changes. Ladders up by preventing chassis drift across the corpus.
+
+### Outcome: the chassis demonstrates itself
+
+- **Apply the chassis to this skill.** This `SKILL.md` follows the principle-doc shape it documents, has Outcomes near the top, has dated recommendations, has anti-patterns as observations. Ladders up by making the chassis falsifiable.
+
+## How to use this skill: authoring mode
+
+1. Decide the skill's **type**: principle doc (durable knowledge) or procedural (workflow). See `references/skill-template.md` for both shapes.
+2. Draft the **description** first. List 5-10 trigger phrases, common synonyms, file extensions if relevant, explicit non-triggers. See `references/description-trigger-rules.md`.
+3. Draft the **Outcomes** section before any other body content. Each outcome is a durable goal with 1-2 evidence signals.
+4. Draft the **Principles** (for principle docs) or **Workflow** (for procedural). Lean. Imperative, with the why.
+5. Draft the **Anti-patterns** as observations, not commandments.
+6. Draft the **Recommended tools and practices** section. Group recommendations under outcomes. Each recommendation cites the outcome it ladders up to.
+7. Move overflow detail to `references/<topic>.md` files.
+8. Audit the draft against `references/audit-checklist.md`.
+9. Run 2-3 realistic test prompts. Iterate description for routing problems, body for execution problems. Do not co-fix.
+
+## How to use this skill: audit mode
+
+1. Open the target `SKILL.md` and its `references/` directory.
+2. Walk `references/audit-checklist.md` top to bottom. For each criterion, mark pass or fail.
+3. For each fail, identify the smallest change that closes the gap. Prefer moving content over rewriting.
+4. Apply the changes in one editing pass per skill. Do not bundle audit fixes for multiple skills into one commit; one skill per commit so the diff stays reviewable.
+5. Re-run the checklist. If still failing on the same criterion, the criterion may need refinement; flag in `references/audit-checklist.md` rather than working around it in the audited skill.
+
+## References
+
+- `references/anthropic-skill-creator.md`: Anthropic's official skill-creator playbook, distilled.
+- `references/skill-template.md`: canonical shapes for principle-doc and procedural skills, with every section explained and example openings.
+- `references/outcomes-laddering.md`: the durable-outcomes-to-rotting-tools pattern with worked examples from real harness-engineering skills.
+- `references/description-trigger-rules.md`: how to write descriptions that route correctly; trigger-phrase patterns; non-trigger declarations.
+- `references/audit-checklist.md`: binary pass-fail criteria, walkable top to bottom.
+- `references/anti-yellow-flags.md`: longer list of skill anti-patterns, observational style.
+
+## Continual improvement
+
+This skill is maintained at:
+https://github.com/AgentParadise/harness-engineering/blob/main/skills/authoring-skills/SKILL.md
+
+Improvements to the chassis must be applied to this file first, then propagated to every other skill in the plugin via a sweep. Chassis drift is the most expensive kind of drift; do not let it land without the sweep.

--- a/.claude/skills/authoring-skills/references/anthropic-skill-creator.md
+++ b/.claude/skills/authoring-skills/references/anthropic-skill-creator.md
@@ -1,0 +1,100 @@
+# anthropic-skill-creator
+
+Distilled reference for the official Anthropic guidance on authoring Claude skills.
+
+Distilled from Anthropic's skill-creator guidance, accessed 2026-05-13.
+
+## Anatomy
+
+A skill is a directory whose contents Claude can selectively pull into context:
+
+```
+skill-name/
+├── SKILL.md          (required)
+│   ├── YAML frontmatter: name, description
+│   └── Markdown body of instructions
+└── (optional bundled resources)
+    ├── scripts/      executable code for repetitive or deterministic work
+    ├── references/   docs that load into context only when needed
+    └── assets/       templates, fonts, icons, and other artifacts used in output
+```
+
+Bundled resource conventions:
+
+- `scripts/`: executable code Claude can run for deterministic or repetitive work. Scripts can execute without being read into context, which keeps token usage low.
+- `references/`: longer-form documentation that Claude loads only when the body of SKILL.md instructs it to. Good home for spec-level detail, API surface tables, or domain background.
+- `assets/`: files copied into the user's output, such as templates, fonts, or icons. Not instructions to Claude, ingredients for the result.
+
+## Progressive disclosure across three levels
+
+Skills are designed so that detail unfolds only when relevant. There are three levels:
+
+1. **Metadata (name + description).** Always present in Claude's context. Roughly 100 words total. This is the trigger surface, what tells Claude the skill is the right tool for the current task.
+2. **SKILL.md body.** Loaded when the skill triggers. Keep it under roughly 500 lines as a soft cap. Past that, comprehension degrades and the prompt starts to compete with itself.
+3. **Bundled resources.** Loaded only when the body explicitly directs Claude to read them, or when scripts are invoked. Effectively unlimited in size, because most of it never enters the model's working context.
+
+Knowing you are hitting the soft cap:
+
+- SKILL.md is creeping past ~500 lines.
+- Sections describe edge cases, file format minutiae, or long enumerations that most invocations will not need.
+- You catch yourself adding "if you encounter X, here is the full background on X."
+
+Fix: move the detail into `references/` and have SKILL.md point at the file by relative path. The body should read like a table of contents into the deeper material, not a copy of it.
+
+## The description is routing
+
+The `description` field in frontmatter is the single biggest determinant of whether a skill gets invoked at all. Treat it as a routing problem distinct from the execution problem solved by the body.
+
+Why this matters:
+
+- Claude tends to undertrigger skills. A description that is too narrow, too humble, or too abstract leaves the skill dormant.
+- The body of SKILL.md is irrelevant if routing never selects the skill in the first place.
+
+What to include in the description:
+
+- What the skill does, stated plainly.
+- Specific contexts where it should fire: trigger phrases the user is likely to say, file extensions the skill applies to, synonyms for the core concept, and adjacent intents that look like the core use case.
+- Optional non-triggers when there is a sibling skill that overlaps. Naming what this skill is not for helps the router disambiguate.
+
+All "when to use" content belongs in the description, not the body. The body is for "how to do it once selected."
+
+Shape to aim for (informally, in the spirit of skills like the public `docx` skill): a sentence on capability, a sentence or clause listing trigger contexts and file types, and an optional clause on adjacent intents that should also pull this skill in. Slightly pushy beats slightly shy.
+
+## Writing style
+
+For the body of SKILL.md:
+
+- Use imperative voice for instructions. "Read the manifest before editing" beats "the manifest should be read."
+- Explain the why, not just the what. Modern models reason well about intent. A short rationale ("we read the manifest first because downstream steps assume its schema") generalizes better than a bare command.
+- Treat heavy ALWAYS, NEVER, and MUST capitalization as a yellow flag. If a rule needs shouting to land, it usually needs explanation instead. Reframe as reasoning where you can, and reserve emphatic prohibitions for cases where the failure mode is severe and non-obvious.
+- Keep the prompt lean. Cut sentences that do not change behavior. Cut examples that only restate the rule.
+- Stay general. Example-specific instructions ("when the file is named `foo.json`...") tend to mislead on the next case. Prefer principles plus one illustrative example.
+- Bundle repeated work. If the skill keeps walking Claude through the same five-step sequence, factor it into a script or a referenced procedure.
+
+## The development loop
+
+Skills are written iteratively. The loop:
+
+1. Draft SKILL.md, frontmatter first.
+2. Write two or three realistic test prompts. These should be the kinds of requests a real user would make, not idealized phrasings.
+3. Run Claude against the skill on those prompts.
+4. Review qualitatively. Did the skill trigger? Did it execute well once triggered? Where did it drift, over-explain, or miss?
+5. Rewrite based on what failed. If triggering failed, edit the description. If execution failed, edit the body or push detail into references.
+6. Repeat.
+
+Optimize triggering and execution separately. They are different problems with different fixes:
+
+- Triggering failures: change the description, add trigger phrases, add file extensions, add adjacent intents.
+- Execution failures: tighten the body, add a missing step, factor a script, move noisy detail into `references/`.
+
+Mixing the two slows the loop.
+
+## Project additions on top of Anthropic guidance
+
+The harness-engineering chassis layers two opinionated extensions on top of the official guidance. Both are conventions enforced by sibling references, not Anthropic requirements.
+
+1. **Outcomes section.** Every skill in this plugin includes an `## Outcomes we are looking for` section near the top of SKILL.md. This anchors the skill to durable goals (what success looks like for the user) and separates those goals from the tools and procedures used to reach them. Tools rot. Outcomes do not. When a skill drifts, the outcomes section is the fixed point you re-derive from. See [outcomes-laddering.md](outcomes-laddering.md).
+
+2. **Observational anti-patterns.** Where the conventional pattern is a "Red Flags - STOP" block in command form ("NEVER do X"), this chassis uses auditable observations: "If you observe X in the output, that is a signal that Y went wrong." This keeps the language descriptive rather than prohibitive, makes the signals checkable after the fact, and aligns with the "explain the why" guidance above. See [anti-yellow-flags.md](anti-yellow-flags.md).
+
+Both extensions are compatible with the three-level disclosure model: the outcomes section sits in the body of SKILL.md (loaded on trigger), and the anti-pattern observations either sit inline or live in a referenced file depending on length.

--- a/.claude/skills/authoring-skills/references/anti-yellow-flags.md
+++ b/.claude/skills/authoring-skills/references/anti-yellow-flags.md
@@ -1,0 +1,203 @@
+# Anti-Yellow-Flags: Observed Failure Modes in Skill Authoring
+
+Distilled from Anthropic's skill-creator guidance (the "yellow flags" they call out for skills that look disciplined but read as brittle) and from observed failure modes in this plugin's own skill corpus. The Anthropic list names a handful of stylistic tells; this document expands that list with patterns surfaced during audits of skills authored in this repository.
+
+This is a catalog of observations, not a list of commandments. Each item describes what the failure mode looks like when it shows up in a `SKILL.md`, why it degrades the skill's effectiveness, and how to rework it.
+
+## Why observations beat commandments
+
+Anti-patterns work better when stated as "this is what I see in the wild" rather than "you shall not do X." The agent reads the skill and parses observations more effectively than imperatives because observations carry context: what triggered the pattern, what it looks like on the page, and what it means for the reader. An imperative strips that context down to the rule itself, and in doing so it loses discriminative power on edge cases. The agent confronted with a near-match cannot tell whether the rule applies, because the rule no longer carries the signal that distinguishes its in-scope cases from adjacent ones.
+
+The second reason is tonal. A skill saturated with "NEVER" reads like a policy document, and policy documents teach readers to skim. An observation invites the reader to check the artifact against the description, which is the behavior the skill actually wants. The shift from "you must" to "this is what a healthy version looks like" turns the skill into a diagnostic instrument rather than a tribunal.
+
+## Yellow flags Anthropic explicitly names
+
+### Heavy ALWAYS / NEVER / MUST blocks
+
+Reads like a policy document. After three imperatives in a row, the agent stops parsing each one and starts skimming the block as a unit. The third NEVER carries no more weight than the first; in practice it carries less, because attention is already gone. Reframe as "do X because Y," with the rationale carrying the discriminative weight. The reader who understands the Y can apply the X to cases the author did not anticipate.
+
+### Rigid structures dressed up as discipline
+
+Excessive section headers with one-sentence bodies. Each header promises a topic; each body delivers a sentence; the cumulative effect is a table of contents pretending to be a document. The ritual of structure substitutes for the content the structure was meant to organize. A skill with eight `##` headers and forty lines of body is, in almost every case, four headers and forty lines of body wearing a costume.
+
+### Test-overfit content
+
+The skill solves the two examples the author ran during drafting and falls apart on the third real task. Symptom: every example in the body refers to the same domain, the same tools, or the same shape of problem. The skill is a transcript of the debugging session that produced it, not a general guide. The fix is to write at the level of pattern (what is true across cases) and demote the specific examples to one or two illustrations.
+
+### Description that describes the topic, not the trigger
+
+"This skill is about X." The agent does not learn when to invoke; the user does not see the routing signal. The description's job is to fire on the right requests and stay silent on adjacent ones. A description that names the topic without naming the trigger phrases will either over-fire (matching anything in the topic neighborhood) or under-fire (failing to match phrasings the author did not consider). See `description-trigger-rules.md`.
+
+## Yellow flags from this plugin's own audit
+
+### `## When to Use` section in a principle-doc body
+
+Routing logic in the wrong place. "When to use" belongs in the description (frontmatter), where the harness reads it to decide whether to load the skill. Putting it in the body means the harness already loaded the skill before the reader learned whether to use it. Body should open with `## Overview` or the first content section, not a re-litigation of the routing decision.
+
+### Body's first sentence is "This skill is for X."
+
+The frontmatter already said that. The first body sentence is the most valuable real estate in the file; spending it on a re-introduction wastes the slot. First sentence should deliver useful content: the central observation, the load-bearing principle, the thing the reader came for.
+
+### `## Red Flags - STOP` as commandments
+
+Each entry starts with "NEVER" or has an imperative shape. The auditor reading the skill against an artifact cannot mark "NEVER make the agent read pasted screenshots" as present or absent, because "NEVER" is a rule, not a property. Reframe each entry as an observation about the artifact: "the agent is required to read pasted screenshots to debug UI bugs," or "the workflow lacks a programmatic screenshot capture step." These can be checked against the codebase; rules cannot.
+
+### Rationalization-prevention tables that double as "I told you so" lists
+
+Useful in moderation. Over-deployed, they perform discipline without enforcing it: the reader sees a long table, recognizes the pattern, and skips it. Cap at 5 to 7 rows in the body. If the catalog needs more entries, move the long form to `references/rationalizations.md` and leave a pointer.
+
+### Growth examples that drift specific-to-the-domain
+
+Skills sometimes ladder examples through POC / Growing / Production / Safety-critical. When the production tier just says "in production, add tools," it adds no information; "more rigor" is not a maturity level. The example must distinguish what changes at each maturity level beyond a vague increase in discipline. If the author cannot articulate the change, the tier should be cut.
+
+### Key Patterns blocks with too many checkmark and cross pairs
+
+Two or three pairs is instructive. Ten is noise. The signal-to-context-cost drops fast past three. If the patterns are genuinely ten distinct lessons, they belong in a `references/patterns.md` file with room to breathe; if they are variations on a theme, three representative pairs carry the meaning.
+
+### Tools listed without rationale
+
+"Use Playwright." The next reader cannot tell whether the recommendation is still valid when Playwright is replaced by something else, because the recommendation was tied to the tool name rather than the outcome the tool delivered. Every recommendation cites the outcome it ladders up to. See `outcomes-laddering.md`.
+
+### Outcomes section absent
+
+The skill is a pile of tactics with no north star. When the tools rot, the whole body rots with them, because nothing in the document tells the reader what the tactics were trying to achieve. The outcomes section is what survives a tool migration; without it, the skill has a half-life equal to the half-life of its tooling.
+
+### Outcomes that name tools or metrics
+
+"Page load under 800ms" is a metric, not an outcome. "Agent can detect performance regression without human intervention" is an outcome. The metric is a signal that the outcome is being met; promoting the signal to the goal causes the reader to optimize the number rather than the capability.
+
+### Body over 500 lines with no `references/`
+
+Loaded context budget is being wasted on detail the current task does not need. The body is for the load-bearing 20 percent; the references hold the depth. A skill that refuses to split is a skill that has not decided what its central claim is.
+
+### Em-dashes
+
+This plugin's house rule. The em-dash (U+2014) is a stylistic tell of LLM-written prose, and its presence indicates the author has not edited the model's output. Use colons, commas, periods, parentheses, or restructure the sentence.
+
+### Marketing language
+
+"Powerful," "comprehensive," "best-in-class," "advanced." Adds no information; degrades signal. The reader skips these words automatically, which means anything load-bearing positioned next to them is also at risk of being skipped.
+
+### Cross-references with absolute paths
+
+`/Users/neural/...` or `~/Code/...` in a cross-reference. Breaks the moment the skill is installed in a different location. Cross-references inside a skill use paths relative to the skill root (`references/foo.md`), and cross-references between skills use the plugin-qualified form documented in `anthropic-skill-creator.md`.
+
+### Continual improvement section pointing at a stale URL
+
+A common pattern: the skill ends with a "feedback welcome" link to a GitHub issue tracker, and the URL is wrong, dead, or pointing at the author's personal fork. The link must resolve. If there is no place to send feedback, omit the section.
+
+## How to fix each, with examples
+
+### Heavy NEVER block
+
+Before:
+
+```markdown
+## Red Flags - STOP
+
+- NEVER skip the test suite.
+- NEVER push without review.
+- NEVER commit generated artifacts.
+- NEVER use force-push on shared branches.
+```
+
+After:
+
+```markdown
+## Observed failure modes
+
+- The test suite is skipped, because the author believed the change was
+  trivial. Trivial changes are the modal source of regressions in this repo,
+  so the suite runs on every push.
+- A commit lands without review, because the author had merge rights and a
+  deadline. The review gate exists because the modal author has both.
+```
+
+The rule survives, but the rationale carries it; the reader who understands the rationale can apply the rule to cases the author did not list.
+
+### Topical description
+
+Before:
+
+```yaml
+description: This skill is about writing good skills.
+```
+
+After:
+
+```yaml
+description: |
+  Use when creating, editing, or auditing a SKILL.md file in this plugin.
+  Triggers on phrases like "write a skill", "audit my skill", "skill yellow
+  flags", "skill anti-patterns". Does not trigger on general writing or
+  documentation tasks unrelated to the skill format.
+```
+
+The trigger phrases are explicit, and the non-triggers prevent over-firing. See `description-trigger-rules.md`.
+
+### Red Flags as commandments
+
+Before:
+
+```markdown
+- NEVER make the agent read pasted screenshots.
+```
+
+After:
+
+```markdown
+- The workflow requires the agent to read pasted screenshots to diagnose UI
+  bugs. The agent has no programmatic screenshot capture step.
+```
+
+The auditor can check the second version against the artifact and mark it true or false; the first version is a rule that the artifact cannot satisfy or violate, only ignore.
+
+### Outcomes that name tools
+
+Before:
+
+```markdown
+## Outcomes
+
+- Playwright runs on every PR.
+- Page load under 800ms.
+```
+
+After:
+
+```markdown
+## Outcomes
+
+- The agent can detect UI regressions without human intervention on every
+  pull request.
+- The agent can detect performance regressions before they reach production.
+
+## Current recommendations (2026-05)
+
+- Playwright is the current browser automation tool.
+- 800ms is the current page-load budget; see `references/performance.md`.
+```
+
+The outcomes name the capability; the dated recommendations name the tool that currently delivers it. When the tool changes, the outcomes survive.
+
+### Body over 500 lines
+
+Before: a single SKILL.md with sections on history, philosophy, tooling, examples, edge cases, and a glossary, totaling 700 lines.
+
+After: a SKILL.md of 200 lines covering the load-bearing principles and routing, with pointers to `references/history.md`, `references/tooling.md`, `references/examples.md`, `references/edge-cases.md`, and `references/glossary.md`. The body loads on every invocation; the references load only when the task needs them.
+
+## When a yellow flag is actually correct
+
+Discipline has its place. Heavy NEVER blocks are appropriate for safety-critical rules where the cost of misinterpretation is real, and where the rule is the kind a competent reader might reasonably ignore. "NEVER commit secrets" is the canonical example: the reader will, in the wild, encounter situations where committing a secret feels expedient ("it is only a test key," "the repo is private"), and the imperative form is doing real work against a real rationalization.
+
+The test is this: is the rule the kind a competent reader might reasonably ignore in the absence of the imperative? If yes (secrets, destructive git operations, prod-database writes), the NEVER form is appropriate and the cost of stylistic stiffness is worth paying. If no (formatting conventions, structural preferences, style choices), the "do X because Y" form is more effective, because the reader is not in danger of ignoring the rule, only of misapplying it, and the rationale is what enables correct application.
+
+The chassis allows imperative form in narrow cases. The audit catches it when it has spread beyond those cases.
+
+## Cross-references
+
+- `audit-checklist.md`: the checklist the auditor walks when reviewing a skill against this catalog.
+- `outcomes-laddering.md`: how to write an outcomes section that survives tool migration.
+- `description-trigger-rules.md`: how to write a description that fires on the right requests and stays silent on adjacent ones.
+- `anthropic-skill-creator.md`: the upstream guidance this catalog extends.
+- `skill-template.md`: the starting structure that already encodes the fixes for the most common anti-patterns.

--- a/.claude/skills/authoring-skills/references/audit-checklist.md
+++ b/.claude/skills/authoring-skills/references/audit-checklist.md
@@ -1,0 +1,183 @@
+# Audit checklist for skills
+
+A binary pass-fail checklist a reviewer walks top to bottom when auditing a skill against the `authoring-skills` chassis. Each criterion is checkable without aesthetic judgment: "Did the author follow the rule?" not "Is the writing good?"
+
+## Source attribution
+
+This checklist consolidates rules defined in sibling references:
+
+- `skill-template.md` (canonical section ordering)
+- `description-trigger-rules.md` (frontmatter routing)
+- `outcomes-laddering.md` (outcomes and recommendation grouping)
+- `anti-yellow-flags.md` (tone and prohibited constructs)
+- `anthropic-skill-creator.md` (upstream Anthropic guidance)
+
+## How to use this checklist
+
+1. Open the target `SKILL.md` and its bundled `references/`, `scripts/`, and `assets/` (if present).
+2. Walk this document top to bottom. Mark each numbered criterion pass or fail.
+3. For each fail, identify the smallest change that closes the gap. Do not redesign the skill.
+4. Apply audit fixes one skill per commit. Do not bundle multiple skills into a single audit commit; per-skill commits keep blame and rollback clean.
+5. After fixes, re-run the checklist on the changed skill to confirm every criterion now passes.
+
+A criterion that does not apply (for example, procedural-skill checks against a principle-doc skill) is marked N/A. N/A is not a failure, but the reviewer must record why it does not apply.
+
+---
+
+## Section 1: Frontmatter and routing
+
+1. **Frontmatter present and well-formed.** Pass if YAML frontmatter sits at the top of `SKILL.md` enclosed in `---` fences, containing exactly two fields: `name` and `description`. No extra fields, no trailing whitespace inside the fences.
+   - *Common failure:* author adds `version`, `author`, or `tags`. Strip them; the harness ignores everything beyond `name` and `description`.
+
+2. **`name` matches the directory.** Pass if `name: foo-bar` and the skill file lives at `skills/foo-bar/SKILL.md`. A mismatch breaks routing and discovery.
+   - *Common failure:* renamed directory but did not update frontmatter, or vice versa.
+
+3. **`description` includes 5 or more trigger phrases.** Pass if the description names at least five concrete situations, file types, keywords, or user intents that should activate the skill. See `description-trigger-rules.md`.
+   - *Common failure:* description states what the skill *is* rather than when it should fire.
+
+4. **`description` includes at least one explicit non-trigger when adjacent skills exist.** Pass if the description names what the skill is *not* for, in cases where a sibling skill could be confused with it. See `description-trigger-rules.md`.
+   - *Common failure:* two adjacent skills both claim "use when reviewing code" and the harness cannot disambiguate.
+
+5. **No marketing language in the description.** Pass if the description contains none of: "best", "powerful", "advanced", "comprehensive", "world-class", "cutting-edge". Marketing tokens are routing noise.
+   - *Common failure:* description opens with "A powerful skill for ..." which tells the router nothing useful.
+
+---
+
+## Section 2: Body structure (principle-doc skills)
+
+Apply this section when the skill documents principles, outcomes, and recommendations rather than a step-by-step procedure.
+
+6. **`## Overview` present and approximately one paragraph.** Pass if Overview frames what the skill is about in durable language. Fail if Overview is a bullet list, a table of contents, or longer than three paragraphs.
+   - *Common failure:* Overview restates the description verbatim instead of framing the underlying domain.
+
+7. **`## Outcomes we are looking for` present and near the top.** Pass if Outcomes appears between Overview and Principles. See `outcomes-laddering.md`.
+   - *Common failure:* outcomes appear at the bottom of the file as an afterthought, making the principle list read like floating advice.
+
+8. **3 to 5 outcomes.** Pass if the count is 3, 4, or 5. Occasionally 6 or 7 is acceptable for broad skills. Fail if the count is 1, 2, or greater than 7.
+   - *Common failure:* a single bloated "Outcome 1: do everything well" that cannot be evaluated.
+
+9. **Each outcome has 1 or 2 evidence signals.** Pass if every outcome names a concrete observation a reviewer could make to confirm the outcome holds. A goal without a signal cannot be checked.
+   - *Common failure:* outcomes phrased aspirationally ("write good code") with no signal naming what good looks like in this skill's context.
+
+10. **Outcomes are goals, not tools or metrics.** Pass examples: "Agent can perceive UI state without human translation." Fail examples: "Use Playwright" (tool), "Page load under 800ms" (raw metric without goal context).
+    - *Common failure:* the recommendations section migrated upward and now sits in the outcomes slot.
+
+11. **`## Principles` present and lean.** Pass if Principles contains 5 to 8 entries, each 2 to 5 sentences. Each principle is written in the imperative and includes the why, not only the what.
+    - *Common failure:* 15 principles, each one sentence long. Consolidate or move detail into a reference file.
+
+12. **`## Anti-patterns` present and observational.** Pass if Anti-patterns lists 6 to 12 entries written as observations of what auditors see in the wild. Fail if entries lean on heavy ALWAYS/NEVER blocks. See `anti-yellow-flags.md`.
+    - *Common failure:* anti-patterns written as commands ("Never use X") rather than descriptions of the failure mode and its consequence.
+
+13. **`## Recommended tools and practices (as of YYYY-MM-DD)` present and dated.** Pass if the heading carries a date and that date falls within the most recent release cycle of the plugin. Stale dates signal abandoned recommendations.
+    - *Common failure:* the date was set at skill creation and never refreshed when tools were swapped.
+
+14. **Recommendations are grouped under outcomes with explicit laddering.** Pass if each recommendation block names which outcome it serves. See `outcomes-laddering.md`.
+    - *Common failure:* a flat list of tools with no link back to the outcome each serves.
+
+15. **`## References` section present if the skill has bundled references.** Pass if the body links every file under `references/` at least once, with a one-line description of when to consult that reference.
+    - *Common failure:* a reference file exists on disk but is never linked from the body, so readers never discover it.
+
+16. **`## Continual improvement` section present with the canonical GitHub link.** Pass if the section invites contributions and points at the plugin repository so readers know where to file follow-ups.
+    - *Common failure:* the link points at a personal fork or a closed-source mirror.
+
+---
+
+## Section 3: Body structure (procedural skills)
+
+Apply this section when the skill is procedural: an orchestrator, a maintenance routine, a setup wizard, or any skill whose primary output is "the user did the steps".
+
+17. **`## When to Use` and `## When NOT to Use` present.** Pass if both sections exist and each lists concrete situations. The pair calibrates routing for procedural skills the way the description does for principle-doc skills.
+    - *Common failure:* "When NOT to Use" is omitted because the author could not think of a counter-example. Force the question: what skill or path supersedes this one?
+
+18. **`## Input` section names parameters explicitly.** Pass if every input the procedure consumes (arguments, files, environment variables) is named with its type and whether it is required.
+    - *Common failure:* the workflow references `$ARGUMENTS` or environment variables that are never declared in Input.
+
+19. **`## Workflow` is numbered steps.** Pass if the workflow is a numbered list, each step a single sentence or short paragraph. Sub-steps allowed at one level of nesting. Prose-paragraph workflows fail.
+    - *Common failure:* an unordered bullet list. Order matters; ordering must be explicit.
+
+20. **`## Output` describes the artifact(s) produced.** Pass if Output names what files, commits, branches, messages, or state changes exist after the procedure completes successfully.
+    - *Common failure:* Output is missing entirely, leaving the agent unable to verify the procedure ran to completion.
+
+21. **Outcomes and recommendations sections present when the procedure has a clear north star.** Pass if the procedure ladders to outcomes (see `outcomes-laddering.md`). Optional and may be omitted for thin procedural wrappers (for example, a 5-step utility).
+    - *Common failure:* an orchestrator that drives many sub-skills omits outcomes, so the reader cannot tell what success looks like end to end.
+
+---
+
+## Section 4: Body content quality
+
+22. **Imperative voice with explained why.** Spot-check three paragraphs at random. Pass if each answers "why" alongside "what". Fail if the paragraphs read as command lists with no rationale.
+    - *Common failure:* a principle that says "Validate input at the boundary" without saying why the boundary is the right place.
+
+23. **No heavy ALWAYS/NEVER blocks.** Pass if the body avoids capitalised commandment lists. See `anti-yellow-flags.md`. Targeted use of "never" inside a single sentence is acceptable; multi-bullet ALWAYS/NEVER walls are not.
+    - *Common failure:* a six-bullet "NEVER do X" list that reads like a warning sign rather than guidance.
+
+24. **No "this skill helps with..." opener.** Pass if the Overview does not restate the frontmatter description. The description already states what the skill helps with; repeating it wastes the top of the body.
+    - *Common failure:* Overview begins "This skill helps you ..." which is exactly what the description already conveyed.
+
+25. **No `## When to Use` in the body for principle-doc skills.** Pass if principle-doc skills route entirely from the frontmatter description. Procedural skills are exempt (see Section 3).
+    - *Common failure:* principle-doc skill duplicates routing rules in the body, creating two places that drift apart.
+
+26. **Citations present for source-derived claims.** Pass if each principle either names its source (paper, post, internal doc, observable practice) or rests on a fact a reviewer can verify directly. Unsourced assertions fail.
+    - *Common failure:* "Studies show that ..." with no study named. Either name it or drop the claim.
+
+---
+
+## Section 5: Bundled resources
+
+27. **SKILL.md is under 500 lines.** Pass if `wc -l SKILL.md` reports fewer than 500. If over, body content must have been moved into `references/` and the body must point at those references.
+    - *Common failure:* a 900-line SKILL.md that buries the routing-relevant top section under a long appendix. Move the appendix to `references/`.
+
+28. **`references/` directory present if SKILL.md is over approximately 300 lines or has depth that does not fit cleanly in the body.** Pass if depth has been externalised rather than crammed inline. A 280-line skill without references is acceptable; a 280-line skill that links five external blog posts inline is not.
+    - *Common failure:* deep technical detail inlined in SKILL.md that would be a clean reference file.
+
+29. **Each `references/` file has a clear topic and a one-line header description.** Pass if every reference file opens with a header that states what the file covers and when to read it. Reference files without orientation headers fail.
+    - *Common failure:* a reference file that opens straight into content with no orientation, leaving the reader unsure what context to bring.
+
+30. **`scripts/` if present contains executable, deterministic helpers and is referenced from SKILL.md.** Pass if scripts have shebangs, run without manual edits, and are mentioned in the body where they apply. Per Anthropic guidance, scripts replace narrative steps that the agent should execute deterministically.
+    - *Common failure:* scripts ship without shebangs or with hard-coded paths that only work on the author's machine.
+
+31. **`assets/` if present contains templates, fonts, fixtures, or fixed artifacts the skill produces or compares against.** Pass if every asset is referenced by name from SKILL.md or from a reference file. Orphan assets fail.
+    - *Common failure:* an `assets/` directory that accumulates over time and is never pruned, with files no skill section ever links.
+
+---
+
+## Section 6: Style hygiene
+
+32. **No em-dashes (U+2014).** Pass if `grep -cP "\x{2014}" SKILL.md` returns 0 (Perl-mode regex expands `\x{2014}` to the em-dash byte sequence at runtime so this rule file itself stays em-dash-free). This plugin's house rule. Use colons, commas, periods, parentheses, or restructure the sentence. Run the same check on every file under `references/`.
+
+33. **Cross-references use relative paths.** Pass if links between SKILL.md and bundled files use paths like `references/foo.md`, not absolute paths or `file://` URLs. Absolute paths break when the skill is installed under a different root.
+
+34. **No marketing language.** Pass if "powerful", "comprehensive", "best-in-class", "cutting-edge", "next-generation", and similar superlatives do not appear in body prose. Quoting a third-party name that contains these words is acceptable.
+
+35. **Tone is observational, not promotional.** Spot-check the anti-patterns and recommendations sections. Pass if each entry describes (what is observed, what happens, what the consequence is) rather than advocates (why this approach is great).
+
+---
+
+## Section 7: Demonstration test
+
+36. **2 to 3 realistic test prompts run before the skill is declared done.** Pass if the author has invoked the skill via realistic user prompts and recorded what triggered and what did not. The notes do not need to ship with the skill, but the author should be able to produce them on request.
+    - *Common failure:* the skill was written, committed, and never invoked. The first real user is the first test, and routing bugs surface in production.
+    - *What good looks like:* three prompts including one that should fire the skill, one that is adjacent but should not fire it, and one borderline case that exercises the non-trigger rule from criterion 4.
+
+---
+
+## What to do with findings
+
+For each failed criterion:
+
+1. Identify the smallest change that closes the gap. Do not redesign the skill in the same pass.
+2. Open a commit that touches only this skill. The commit message should name the skill and the criteria addressed (for example, "authoring-skills: fix criteria 11, 13, 32").
+3. Re-run the checklist against the changed skill to confirm the failed criteria now pass and no previously passing criteria regressed.
+4. If multiple skills failed the same criterion, audit each one in its own commit. Bundling masks per-skill regressions.
+
+A skill that fails three or fewer criteria can usually be fixed in one pass. A skill that fails ten or more criteria is a candidate for a deeper rewrite using `skill-template.md` as the starting point rather than incremental patching.
+
+---
+
+## Cross-references
+
+- `skill-template.md` for the canonical body skeleton to copy when starting a new skill or rewriting a failing one.
+- `description-trigger-rules.md` for the rules governing criteria 3, 4, and 5.
+- `outcomes-laddering.md` for the rules governing criteria 7, 8, 9, 10, and 14.
+- `anti-yellow-flags.md` for the rules governing criteria 12, 23, and 35.
+- `anthropic-skill-creator.md` for the upstream guidance that informs criteria 27 through 31.

--- a/.claude/skills/authoring-skills/references/description-trigger-rules.md
+++ b/.claude/skills/authoring-skills/references/description-trigger-rules.md
@@ -1,0 +1,152 @@
+# Description Trigger Rules
+
+How to write the `description:` field in a skill's frontmatter so the skill actually gets invoked when it should be, and only when it should be.
+
+**Source attribution:** Distilled from Anthropic's official skill-authoring guidance (see `anthropic-skill-creator.md` in this directory) and from observed routing behavior in Claude Code and agent harnesses. Per Anthropic, the description is the single biggest determinant of whether a skill triggers. Claude undertriggers by default, so descriptions need to be slightly "pushy."
+
+## Why descriptions matter most
+
+The description is always in context for routing decisions. The body is not. The body is only loaded after the description has already triggered the skill.
+
+This means triggering and body content are two different problems:
+
+- **Triggering** is solved by the description.
+- **Execution quality** is solved by the body.
+
+Most "this skill doesn't fire when I expect it to" complaints are description problems, not body problems. Authors instinctively reach for the body when their skill misfires; that is the wrong lever.
+
+Target roughly 100 words for the description, but length follows clarity, not the other way around. A 40-word description that lists the right trigger phrases beats a 200-word description that paraphrases the skill's mission statement.
+
+## What goes in a good description
+
+A description carries four loads. In order of routing weight:
+
+1. **What the skill does**, in one short clause. Not a thesis. A clause.
+2. **Specific contexts when to use it**, phrased the way a user actually phrases tasks. Trigger phrases include:
+   - Verbs: `audit`, `write`, `review`, `refactor`, `set up`, `cut`, `bump`, `sync`.
+   - Nouns: `pipeline`, `test`, `dashboard`, `release`, `manifest`.
+   - Tool names users would say out loud: `Playwright`, `Vector`, `OTLP`, `Grafana`, `Prometheus`.
+   - File extensions when applicable: `.docx`, `SKILL.md`, `compose.yaml`, `pyproject.toml`.
+   - Symptoms users describe rather than the cause: `my skill is not triggering`, `this PR is breaking`, `the deploy is stuck`, `the agent can't see logs`.
+3. **Synonyms.** Users phrase things differently than skill authors. "Browser debugging" and "UI debugging" and "frontend troubleshooting" might all route to the same skill. List the variants. Do not assume the user will speak your taxonomy.
+4. **Adjacent intents** users phrase casually that map to this skill: "see what the page looks like", "find the slow request", "check the logs from yesterday", "why did this fail last night". These are the lowest-confidence inputs and they need explicit help.
+
+Then add the suppression load:
+
+5. **Explicit non-triggers** when adjacent skills exist:
+   ```
+   Do NOT use for X (use sibling skill Y); do NOT use for Z (use skill W).
+   ```
+   This is what suppresses false-positive activations. Without explicit non-triggers, two skills that share vocabulary fight each other and the router picks badly.
+
+## What does NOT go in a description
+
+- **Internal jargon the user would not type.** If your team calls it "the substrate layer" and users call it "the API", write "API".
+- **Marketing language.** "The best skill for..." or "comprehensive coverage of..." adds zero routing signal. Strip it.
+- **The skill's own structural conventions** (Outcomes, Principles, section names). Those are not what the user typed. The user typed "review my PR", not "run the Outcomes section".
+- **Cross-references to other skills by file path.** Cross-references go in the body. The description is for routing, not navigation.
+- **Long sentences.** Each phrase should be skim-readable. The router scans; it does not parse paragraphs.
+
+## A good and a bad description, side by side
+
+Bad description (too topical, no triggers):
+
+```yaml
+description: This skill is about agent-queryable telemetry interfaces. It covers logs, metrics, and traces.
+```
+
+Good description (carries the routing load):
+
+```yaml
+description: Use when reviewing or setting up agent-queryable telemetry: LogsQL, PromQL, TraceQL, trace lookup by ID, log search by attribute. Trigger phrases include "search the logs", "what's the p95 latency", "find the trace for request X", "query metrics", "agent can't see logs", "Grafana", "VictoriaLogs", "VictoriaMetrics", "VictoriaTraces", "Tempo", "Loki", "Mimir", "Prometheus". Use when an agent needs to read telemetry, not just emit it (for emission see the `telemetry-pipeline` skill). Do NOT use for general-purpose log hygiene; that's the software-leverage-points `logging` skill.
+```
+
+What makes the second one better, line by line:
+
+- "Use when reviewing or setting up" gives the router two concrete verbs.
+- "agent-queryable telemetry" plus the query-language names (LogsQL, PromQL, TraceQL) catches users who know what they want to do but not what to call it.
+- The quoted trigger phrases mirror how a user actually types: lowercase, conversational, with question marks and pronouns.
+- Tool names (Grafana, VictoriaLogs, Tempo, Loki, Prometheus) catch users who arrive via their stack rather than via the concept.
+- The parenthetical "(for emission see ...)" disambiguates a near-neighbor skill before the router has to guess.
+- The explicit "Do NOT use for general-purpose log hygiene" prevents this skill from stealing routing from `logging`.
+
+The bad version says what the skill is "about". The good version says when to fire it. Routers do not care about "about".
+
+## Description-first drafting
+
+Write the description before the body.
+
+The test: if you cannot list 5-10 trigger phrases the user might type, the skill is either too narrow to ship or you have not understood what it is for yet. This is the test, not a suggestion.
+
+Writing the body first feels productive, but you will then retrofit the description to match the body, which is exactly backwards. The description is the contract with the router; the body is the contract with the agent. Sign the routing contract first.
+
+If you draft the description and the trigger phrases feel forced, that is signal. Either:
+
+- The skill's scope is wrong (split it, or merge it with a sibling).
+- The skill's name is wrong (rename so the description writes itself).
+- The skill should not exist (the work belongs in an existing skill).
+
+## Iterating descriptions separately from body
+
+Triggering problems and execution problems are different problems. Do not change the description and the body in the same iteration; you will not know which fix caused the improvement (or regression).
+
+Workflow:
+
+1. Observe a routing miss or false positive.
+2. Change only the description. Commit.
+3. Re-run realistic prompts. Observe.
+4. If routing is now correct but execution is poor, change only the body. Commit.
+5. If routing is still wrong, change only the description again.
+
+Bundling description and body edits is the single most common reason authors cannot tell which change helped.
+
+## Trigger-phrase patterns by skill type
+
+Different skill types attract different trigger phrases. Match the pattern to your skill.
+
+**Principle-doc skill** (a reference that informs review or design). Trigger phrases are verbs the user does combined with the domain noun:
+
+- "review the telemetry pipeline"
+- "audit this skill's structure"
+- "set up the failure signal"
+- "check the dependency story"
+
+**Procedural skill (orchestrator)** (a skill that runs an end-to-end flow). Trigger phrases are direct invocations plus symptom phrasing:
+
+- "run a harness review"
+- "audit the plugin"
+- "review this PR through the leverage points"
+- "we need a full review"
+- "give me an audit"
+
+**Maintenance skill** (a skill that keeps state in sync). Trigger phrases are versioning, release, and sync verbs:
+
+- "bump the version"
+- "cut a release"
+- "sync the manifests"
+- "pull upstream scaffold"
+- "regenerate the lockfile"
+- "promote staging to prod"
+
+If your skill does not fit one of these patterns cleanly, pick the closest and write the description in that pattern's voice. Mixed-pattern descriptions route poorly because the trigger phrases pull in different directions.
+
+## A short checklist
+
+Before declaring a description done:
+
+- Can you list 5-10 trigger phrases? If no, rewrite.
+- Did you include 1-2 explicit non-triggers? If no, the routing will overshoot.
+- Did you avoid marketing words? If no, strip.
+- Does the description say WHAT (one clause) and WHEN (many trigger phrases) and NOT-WHEN (non-triggers)? If any missing, fill in.
+- Did you run 2-3 realistic test prompts and observe routing? If no, you are guessing.
+
+If all five answers are yes, ship it. If any answer is no, you are not done; you are hoping.
+
+## Cross-references
+
+Sibling files in this directory:
+
+- `skill-template.md`: the canonical skeleton for a new SKILL.md, including frontmatter shape.
+- `outcomes-laddering.md`: how to write the body's Outcomes section once the description is locked.
+- `audit-checklist.md`: end-to-end review for a skill, including a description-quality pass.
+- `anthropic-skill-creator.md`: upstream Anthropic guidance this document is distilled from.

--- a/.claude/skills/authoring-skills/references/outcomes-laddering.md
+++ b/.claude/skills/authoring-skills/references/outcomes-laddering.md
@@ -1,0 +1,322 @@
+# Outcomes laddering
+
+Project addition on top of Anthropic skill-creator guidance. The skill-creator
+documentation covers structure, frontmatter, and progressive disclosure. This
+document covers the most opinionated addition the harness-engineering chassis
+makes on top of that: durable Outcomes as the north star of every skill, with
+Recommended tools and practices grouped under and laddering up to those
+outcomes.
+
+## The pattern in one diagram
+
+```
+   Outcomes (durable goals)
+       ^ ladders up to
+   Recommended tools and practices (dated, churns)
+       ^ replaced when better options emerge
+```
+
+Outcomes stay. The layer below them is allowed to rot. This is intentional
+separation, not accidental drift.
+
+Why two layers instead of one:
+
+1. When a tool gets replaced, only the dated
+   `## Recommended tools and practices (as of YYYY-MM-DD)` section needs
+   editing. The outcomes above it are unaffected.
+2. A new reader can decide whether a tool recommendation is still valid by
+   asking a single question: does it still serve the named outcome? If yes,
+   keep it. If no, the recommendation has rotted even if the section's date
+   is recent.
+3. Auditing becomes mechanical. For every recommendation, you can point at the
+   outcome it ladders up to. If you cannot, the recommendation is unmoored
+   and should be removed or rewritten.
+
+The contract: outcomes are load-bearing. Tools are replaceable. A skill that
+inverts this (long tool list, vague or absent outcomes) will not survive its
+first tool churn cycle.
+
+## Writing good outcomes
+
+An outcome is:
+
+- A *goal*, not a tool or a metric.
+  - Goal: "Agent can perceive UI state without human translation."
+  - Tool: "Use Playwright." (Wrong: names the implementation.)
+  - Metric: "Page load under 800ms." (Wrong: a measurement, not a purpose.)
+- Stated as a single sentence in plain English. Avoid jargon when a plain
+  word will do. If you need a term of art, define it once nearby.
+- Paired with one or two *evidence signals*: checkable facts that, if true,
+  suggest the outcome is being met. Signals can age faster than the outcome
+  itself, and that is fine. Treat them as the dated layer for the outcome
+  the same way recommendations are the dated layer for principles.
+- Independent of the others when possible. If two outcomes overlap heavily,
+  merge them. Two outcomes that always rise and fall together are one
+  outcome wearing two hats.
+- Few in number. Three to five outcomes per skill is the comfortable range.
+  More than seven is a strong signal the skill is doing the job of two
+  skills and should be split.
+
+A useful test: read the outcome aloud to someone outside the project. If they
+cannot tell whether it is being met without asking which tools you use, the
+outcome is written at the right altitude. If their first follow-up question
+is "how", the outcome is doing its job: leaving the "how" to the layer below.
+
+### Outcome template
+
+```
+### Outcome N: <single plain-English sentence>
+
+<One short paragraph: why this matters, what failure looks like.>
+
+Evidence signals:
+- <Checkable fact 1.>
+- <Checkable fact 2.>
+```
+
+## Writing good recommendations under outcomes
+
+Each recommendation:
+
+- Is grouped under the outcome it serves. If a recommendation genuinely
+  ladders up to two outcomes, list it under both rather than splitting it
+  across the gap. Duplication here is cheap; ambiguous attribution is not.
+- Names the tool or practice first, then states the laddering with a phrase
+  like "Ladders up by ..." or "Serves this outcome by ...". The laddering
+  sentence is the load-bearing part. Without it, the recommendation is just
+  a brand name.
+- Lives under a dated section header:
+  `## Recommended tools and practices (as of YYYY-MM-DD)`. The date is the
+  honesty marker. It tells a future reader how stale the list is allowed to
+  be before they should re-evaluate.
+- Is observational about its tradeoffs, not advocacy. Note what the tool
+  costs, what it does not cover, and what would make you replace it. A
+  reader who disagrees can disagree on the evidence rather than the vibe.
+
+### Recommendation template
+
+```
+- <Tool or practice name>. <One sentence describing what it does.>
+  Ladders up by <how this advances the outcome above>.
+  Tradeoffs: <what it costs, what it does not cover>.
+```
+
+## Worked example A: browser-legibility
+
+Below is a credible outcomes section for a skill about giving coding agents
+visibility into browser state, followed by a partial recommendations section
+showing the laddering. Paraphrased to illustrate the shape; not a verbatim
+copy of any current skill file.
+
+```
+## Outcomes we are looking for
+
+### Outcome 1: agent can perceive UI state without human translation
+
+The agent should be able to answer "what is on the page right now" using
+the same kind of structured data a human inspector would read, not by
+asking a human to describe a screenshot. When this outcome is missing,
+every UI bug becomes a ping-pong between the agent and the human, and
+the agent's iteration loop stalls.
+
+Evidence signals:
+- The agent can list visible interactive elements with their roles and
+  labels without a human paraphrasing a screenshot.
+- A failing selector produces a diagnostic the agent can act on, not just
+  a generic "element not found".
+
+### Outcome 2: failures arrive as structured signals, not screenshots alone
+
+When a UI action fails, the agent receives console errors, network
+failures, and accessibility-tree state alongside any visual artifact.
+Screenshots are evidence for humans; structured signals are evidence the
+agent can route into its next decision.
+
+Evidence signals:
+- Console errors and failed network requests are captured automatically
+  on test failure.
+- A failure report includes at least one machine-readable artifact in
+  addition to any image.
+
+### Outcome 3: before/after state is diffable
+
+For any UI change the agent makes, the prior and current state can be
+compared without rerunning the whole flow. This keeps regressions cheap
+to detect and keeps "did this change anything I did not intend" answerable
+in seconds.
+
+Evidence signals:
+- Snapshots are stored in a format that diffs cleanly in version control
+  or a review tool.
+- Reverting a change visibly reverts the snapshot, with no manual cleanup.
+```
+
+```
+## Recommended tools and practices (as of 2026-05-13)
+
+### Outcome: agent can perceive UI state without human translation
+
+- Playwright Node SDK via npx playwright. Provides accessibility-tree
+  snapshots (token-cheap structured DOM), screenshots, and console plus
+  network event capture from a single entry point.
+  Ladders up by giving every human inspection action a programmatic
+  equivalent the agent can call directly.
+  Tradeoffs: Node toolchain assumed present; Chromium download on first
+  run can be slow on cold machines.
+
+- Per-invocation Playwright-bundled Chromium rather than a system browser.
+  Ladders up by removing the "is the right browser even installed" question
+  from every iteration, which previously consumed a meaningful share of
+  failed runs.
+  Tradeoffs: larger on-disk footprint; version is pinned to the Playwright
+  release rather than tracking system updates.
+
+### Outcome: failures arrive as structured signals, not screenshots alone
+
+- Default to capturing console messages and network responses on every
+  Playwright run, not only on failure.
+  Ladders up by making the structured-signal path the cheapest path,
+  so the agent never has to retry just to get logs.
+  Tradeoffs: slightly larger artifact directory; trivial to gitignore.
+
+- Emit failure reports as JSON next to any PNG. Ladders up by ensuring
+  the agent always has a machine-readable artifact alongside any human
+  one, even when a screenshot is also produced.
+  Tradeoffs: a small amount of report-formatting code to maintain.
+
+### Outcome: before/after state is diffable
+
+- Snapshot accessibility trees as pretty-printed JSON, not as opaque
+  binary blobs. Ladders up by making "what changed" answerable with a
+  standard diff tool, no custom viewer required.
+  Tradeoffs: slightly more verbose on disk than a binary representation.
+```
+
+Notice what the laddering does. If a future reader replaces Playwright with
+some successor (call it FutureDriver), they can check each bullet: does
+FutureDriver still give every human inspection action a programmatic
+equivalent? Does it still remove the "is the browser installed" question?
+If yes, swap the name and keep the bullet. If no, the bullet needs a real
+rewrite, not just a search and replace.
+
+## Worked example B: testing-coverage
+
+A more generic illustrative example. Outcomes for a skill about keeping
+the codebase mechanically consistent and well-tested:
+
+```
+## Outcomes we are looking for
+
+### Outcome 1: the codebase stays consistently formatted without human review effort
+
+Formatting drift is never a topic in code review. Whatever style the
+project uses, the machine enforces it, so humans (and agents) spend their
+attention on logic instead of whitespace.
+
+Evidence signals:
+- Pull request reviews do not contain formatting comments.
+- A fresh clone, with no manual setup beyond the documented bootstrap,
+  formats on commit automatically.
+
+### Outcome 2: regressions are caught before they reach the integration branch
+
+A change that breaks previously working behavior fails locally or in CI
+before it can land. The team does not rely on manual smoke testing to
+notice regressions.
+
+Evidence signals:
+- Coverage report exists and is published per build.
+- A deliberately broken test case fails the merge gate, not only a
+  later deploy step.
+```
+
+```
+## Recommended tools and practices (as of 2026-05-13)
+
+### Outcome: the codebase stays consistently formatted without human review effort
+
+- Project-standard formatter wired as a pre-commit hook with auto-fix on
+  staged files. Ladders up by making the formatted state the default
+  outcome of a commit, not a thing the contributor has to remember.
+  Tradeoffs: first-commit-after-bootstrap can be slower while the hook
+  warms up.
+
+- Linter run in CI as a blocking check, configured to share the same
+  rule set as the local hook. Ladders up by removing the "works on my
+  machine" gap between local format and merged format.
+  Tradeoffs: two places (local hook, CI) to keep in sync; mitigated by
+  pointing both at the same config file.
+
+### Outcome: regressions are caught before they reach the integration branch
+
+- Coverage tool with a threshold enforced in CI (the project's chosen
+  number, with rationale recorded nearby). Ladders up by making
+  coverage regressions visible at the moment they are introduced, not
+  weeks later.
+  Tradeoffs: thresholds invite gaming via trivial tests; pair with a
+  review norm that values meaningful assertions.
+
+- Pre-merge test run on the same matrix as the release build. Ladders
+  up by ensuring that the gate which protects the integration branch is
+  the same gate that protects releases, removing a class of "passed CI,
+  failed deploy" surprises.
+  Tradeoffs: matrix runs cost CI minutes; revisit if the project's
+  supported surface shrinks.
+```
+
+Both examples share a pattern. The outcomes do not name tools. The
+recommendations name tools but always come back to the outcome they serve.
+A reader can audit the recommendations bullet by bullet by asking only the
+laddering question.
+
+## Anti-patterns in this layer
+
+Observations from skills that have rotted, or that we caught before they
+rotted:
+
+- **Outcomes that name tools.** "Use a structured logger" is not an outcome.
+  The outcome is "the agent can query logs by attribute, not just by string
+  match." When the outcome names the tool, replacing the tool requires
+  rewriting the outcome, which defeats the layering.
+
+- **Recommendations with no laddering.** "We use X." is not enough. Without
+  a "ladders up by" sentence, the reader cannot tell whether X still earns
+  its place. Unmoored recommendations are the first to rot and the hardest
+  to remove, because nobody remembers why they were added.
+
+- **More than seven outcomes per skill.** A skill with twelve outcomes is
+  doing the job of two or three skills. Split it. Each child skill should
+  end up with three to five outcomes and a clearer north star.
+
+- **Outcomes section absent or buried at the bottom of the file.** The
+  outcomes section is the north star. It cannot serve as a north star if
+  the reader has to scroll past two hundred lines to find it. Put it near
+  the top, right after the skill's purpose statement.
+
+- **Outcomes section that contradicts the principles section.** If the
+  principles say "fail fast" and the outcomes describe a system that
+  swallows errors to keep going, the skill is unsure what it stands for.
+  Fix one or the other before adding any recommendations underneath.
+
+- **Undated recommendations section.** Without a date, a reader has no way
+  to judge staleness. The date does not need to be a precise commit time;
+  the YYYY-MM-DD on the section header is enough.
+
+- **Recommendations advocating instead of observing.** "X is the best
+  choice" is advocacy. "X gives us Y, costs us Z, and would be replaced
+  if W appeared" is observation. The second form survives disagreement;
+  the first invites it.
+
+- **Evidence signals that restate the outcome.** "Evidence: the outcome
+  is met" is not a signal. A signal is a checkable fact someone outside
+  the project can verify. If you cannot write the signal as a yes/no
+  question, the outcome is too vague.
+
+## Cross-references
+
+- `skill-template.md`: where the Outcomes section and the Recommended tools
+  and practices section sit in the canonical shape of a skill file.
+- `audit-checklist.md`: the binary checks an auditor runs against a skill,
+  including the laddering audit.
+- `anti-yellow-flags.md`: the broader anti-pattern catalog this document's
+  Anti-patterns section is a focused slice of.

--- a/.claude/skills/authoring-skills/references/skill-template.md
+++ b/.claude/skills/authoring-skills/references/skill-template.md
@@ -1,0 +1,435 @@
+# Skill template: the two canonical shapes
+
+Source: derived from `../SKILL.md` (the `authoring-skills` chassis). This
+document is the canonical reference for the section-by-section shape of skills
+in this plugin. When in doubt about whether a heading belongs, or how long a
+section should be, consult this file.
+
+## Two shapes, one chassis
+
+Every skill in this plugin is one of two types:
+
+1. **Principle doc.** A durable body of knowledge about a concern (security,
+   testing, configuration, architecture, etc.). It is consulted, not invoked.
+   A reviewer or implementer reads it to absorb principles, outcomes, and the
+   current recommended tools. Most skills in this plugin are principle docs.
+
+2. **Procedural skill.** A workflow with a defined input, a numbered sequence
+   of steps, and a defined output. It is invoked to do work. Orchestrators
+   (review fan-outs, merge cycles), maintenance skills (audits, bootstrappers),
+   and setup skills are procedural.
+
+Pick principle-doc when the artifact answers "what does good look like for
+this concern, and how do I recognize it." Pick procedural when the artifact
+answers "run these steps to produce this result." A skill is rarely both. If
+you find yourself wanting both, split into two skills and have the procedural
+one cite the principle doc.
+
+A useful tell: if the natural opening sentence is "When you are reviewing X,
+look for Y," it is a principle doc. If the natural opening is "Given input X,
+produce output Y by doing the following steps," it is procedural.
+
+## Principle-doc shape, section by section
+
+The principle-doc skeleton:
+
+```
+---
+name: <name>
+description: <trigger phrases + contexts + explicit non-triggers>
+---
+
+# Title
+
+## Overview
+## Outcomes we are looking for
+## Principles
+## Anti-patterns
+## Recommended tools and practices (as of YYYY-MM-DD)
+## References
+## Continual improvement
+```
+
+### Overview
+
+What it is for: a one-paragraph durable framing of the concern. Names the
+concern, says why it matters, and gestures at the boundary of what the skill
+covers. The reader should know within five lines whether they are in the
+right document.
+
+Example opening:
+
+```
+Configuration is how a system absorbs change without code edits. Strong
+configuration practice keeps secrets out of source, makes environment-specific
+behavior explicit, validates at startup, and stays discoverable. This skill
+covers env-var layering, typed config objects, and twelve-factor parity.
+```
+
+Does NOT belong: trigger phrases (those live in frontmatter), tool
+recommendations, step-by-step instructions, or rationale for individual rules.
+
+Length budget: one paragraph, three to six sentences.
+
+### Outcomes we are looking for
+
+What it is for: the north-star goals that a reviewer or implementer is trying
+to achieve. Each outcome is a state of the world, not an activity. Each
+outcome carries one or two observable signals so a reviewer can tell whether
+the outcome is met.
+
+Example opening:
+
+```
+### Secrets never appear in source or build artifacts
+Signals: no secret-shaped strings in git history; CI secret scan passes; all
+runtime secrets resolve from a secret store or injected env.
+
+### Configuration is validated at process start, not first use
+Signals: the process exits with a clear error on missing or malformed config;
+no `KeyError` or `undefined` at request time from missing config.
+```
+
+Does NOT belong: tool names (those live under Recommended tools), narrative
+prose, or anti-patterns. Keep outcomes terse and state-shaped.
+
+Length budget: three to five outcomes. Below three suggests the concern is too
+narrow to deserve its own skill. Above five suggests you are mixing two
+concerns.
+
+### Principles
+
+What it is for: the durable HOW. Short, declarative statements of the rules
+that, if followed, tend to produce the outcomes above. Principles outlive any
+particular tool.
+
+Example opening:
+
+```
+- Treat configuration as a typed object, not a bag of strings.
+- Validate the whole config at startup; fail loud, fail early.
+- Separate secret from non-secret config so they can be stored differently.
+- Prefer environment variables for deployment-varying values; prefer files
+  for structure-heavy values.
+```
+
+Does NOT belong: tool-specific guidance (Vault, doppler, etc.), version
+numbers, or anything dated.
+
+Length budget: five to eight principles. More than eight and the reader stops
+internalizing them.
+
+### Anti-patterns
+
+What it is for: observational descriptions of common failure modes. Phrased
+as patterns to recognize, not commands to follow.
+
+Example opening:
+
+```
+- `.env` files committed to git, even under `.env.example` aliases that
+  accidentally contain real values.
+- Reading `os.environ` ad hoc throughout the codebase rather than through a
+  single typed config object.
+- Defaulting secrets to empty strings, hiding misconfiguration until a 401
+  appears in production.
+```
+
+Does NOT belong: imperative commands ("do not commit secrets"). Write them as
+patterns you can spot in a diff: "Secrets defaulted to empty strings."
+
+Length budget: six to twelve. Fewer than six and the skill cannot anchor a
+review; more than twelve and the list becomes unscannable.
+
+### Recommended tools and practices (as of YYYY-MM-DD)
+
+What it is for: the current, dated, opinionated set of concrete tools and
+practices. Grouped under the outcome each recommendation ladders up to (see
+`outcomes-laddering.md`). The date in the heading signals that this section
+ages and must be refreshed.
+
+Example opening:
+
+```
+(as of 2026-05-13)
+
+### For: Secrets never appear in source or build artifacts
+- Use `gitleaks` as a pre-commit hook and in CI.
+- Store runtime secrets in 1Password or AWS Secrets Manager; inject at
+  deploy time, never at build time.
+
+### For: Configuration is validated at process start, not first use
+- Use `pydantic-settings` (Python) or `zod` (TypeScript) for typed config
+  with startup validation.
+```
+
+Does NOT belong: undated recommendations, principles restated as tools, or
+tools without a parent outcome.
+
+Length budget: roughly two to five recommendations per outcome. Total often
+lands at fifteen to twenty-five bullets.
+
+### References
+
+What it is for: pointers to the `references/` directory, plus authoritative
+external links. One line per reference, with a short gloss.
+
+Example opening:
+
+```
+- `references/secret-rotation-runbook.md`: rotation procedure for each store.
+- `references/twelve-factor-summary.md`: condensed version of the twelve-
+  factor config chapter.
+- https://12factor.net/config (canonical source)
+```
+
+Length budget: as long as needed, but each entry must earn its line.
+
+### Continual improvement
+
+What it is for: a single link to the GitHub issue tracker or discussions page
+where readers can file drift, gaps, or proposed updates. Standardized across
+skills so contributors know where to send feedback.
+
+Example:
+
+```
+File drift, gaps, or proposed updates at
+https://github.com/AgentParadise/harness-engineering/issues
+```
+
+Length budget: one to three lines.
+
+## Procedural-skill shape, section by section
+
+The procedural skeleton:
+
+```
+---
+name: <name>
+description: <trigger phrases for the procedure being invoked>
+---
+
+# Title
+## When to Use (and When NOT to Use)
+## Input
+## Workflow
+## Output
+## Outcomes we are looking for
+## Recommended tools and practices (as of YYYY-MM-DD)
+## References
+## Continual improvement
+```
+
+### When to Use (and When NOT to Use)
+
+What it is for: a short decision aid. Two bulleted lists: when to invoke this
+procedure, and when not to. The "not to" list is what prevents misrouting.
+
+Example opening:
+
+```
+Use when:
+- A pull request is ready for human review and you want a mechanical pre-pass.
+- You are auditing a long-lived branch before merge.
+
+Do NOT use when:
+- The change is a docs-only edit (use `docs-review` instead).
+- The branch has unresolved merge conflicts (resolve first).
+```
+
+Length budget: two to five bullets per list.
+
+### Input
+
+What it is for: the precondition. What the caller must provide, what state
+the workspace must be in, what credentials or context must exist.
+
+Example opening:
+
+```
+- A git branch with committed changes, rebased on the target branch.
+- `gh` authenticated for the target repo.
+- Optional: a path filter to scope the review.
+```
+
+Length budget: three to eight bullets.
+
+### Workflow
+
+What it is for: the numbered procedure. Each step is imperative, concrete,
+and verifiable. Sub-steps allowed when a step decomposes naturally.
+
+Example opening:
+
+```
+1. Resolve the diff range with `git merge-base` and capture the file list.
+2. For each leverage-point skill, dispatch a parallel review agent scoped to
+   the changed files.
+3. Aggregate findings by severity; deduplicate cross-skill overlaps.
+4. Emit a single review comment with grouped findings.
+```
+
+Does NOT belong: rationale paragraphs (push those to References), or
+principles dressed up as steps.
+
+Length budget: four to twelve top-level steps. Longer workflows should be
+split into phases or sub-procedures.
+
+### Output
+
+What it is for: the postcondition. What artifact, file, comment, or state
+change the caller can expect on success. Also: exit codes or status values if
+the procedure is invoked programmatically.
+
+Example opening:
+
+```
+- A single PR review comment containing grouped findings.
+- Exit status: `DONE`, `DONE_WITH_CONCERNS`, or `BLOCKED`.
+- No files committed; no branches pushed.
+```
+
+Length budget: two to six bullets.
+
+### Outcomes we are looking for
+
+Procedural skills may carry Outcomes when the procedure has a clear north
+star. For a review orchestrator, the outcome is something like "the codebase
+is audited mechanically with no findings missed." For a setup procedure, the
+outcome is "a fresh contributor reaches a green test run in one command."
+
+Skip this section if the procedure is purely mechanical and has no judgment
+component (e.g., a file-renamer).
+
+Length budget: one to three outcomes when present.
+
+### Recommended tools and practices (as of YYYY-MM-DD)
+
+Same shape as principle-doc. Dated, laddered under outcomes when outcomes
+exist, otherwise grouped by workflow phase.
+
+### References and Continual improvement
+
+Same shape as principle-doc.
+
+## Frontmatter rules
+
+The YAML frontmatter is required at the top of every `SKILL.md`. It has
+exactly two fields:
+
+```
+---
+name: <kebab-case-name>
+description: <routing description>
+---
+```
+
+Rules:
+
+- `name` must be kebab-case (lowercase, hyphen-separated).
+- `name` must match the directory name exactly. The skill at
+  `skills/authoring-skills/SKILL.md` has `name: authoring-skills`.
+- `description` carries all the routing weight. It must include trigger
+  phrases (verbs and nouns the user is likely to say), the contexts where the
+  skill applies, and explicit non-triggers when the skill is easily confused
+  with a sibling.
+- No other top-level frontmatter fields are permitted. Versioning, owners,
+  and metadata live elsewhere (in a manifest or in the README).
+
+For the full trigger-phrase grammar, see `description-trigger-rules.md`.
+
+## Bundled resources
+
+A skill may ship with sibling directories alongside `SKILL.md`:
+
+### `references/`
+
+Use for: durable supplementary documentation that the `SKILL.md` cites but
+that would bloat it past the length guardrail. Section deep-dives,
+checklists, templates, worked examples.
+
+Naming: kebab-case `.md` files. Names should be nouns or noun phrases
+(`audit-checklist.md`, `outcomes-laddering.md`), not verbs.
+
+### `scripts/`
+
+Use for: executable helpers that the workflow steps invoke. Bash, Python, or
+Node scripts. Each script should be self-contained, with a header comment
+describing input, output, and any environment requirements.
+
+Naming: kebab-case with an extension (`run-audit.sh`, `aggregate-findings.py`).
+
+### `assets/`
+
+Use for: non-executable, non-Markdown artifacts that the skill ships:
+templates, prompt snippets, sample YAML, fixture files, images used by
+references.
+
+Naming: descriptive, with the appropriate extension. Group by purpose when
+the directory grows beyond ten files.
+
+A skill with no bundled resources is fine. Do not create empty directories.
+
+## Example openings
+
+### Principle-doc example
+
+```
+---
+name: cache-discipline
+description: Use when reviewing caching concerns: cache key design, TTL
+  selection, invalidation strategy, stampede protection, negative caching,
+  observability of hit/miss rates. Not for CDN configuration (see
+  `edge-delivery`) or database query plans (see `query-performance`).
+---
+
+# Cache discipline
+
+## Overview
+Caching trades freshness for latency and cost. Strong caching practice makes
+that trade explicit per cache, names every key, bounds every TTL, and exposes
+hit/miss rates as first-class telemetry.
+```
+
+### Procedural-skill example
+
+```
+---
+name: release-cut
+description: Use to cut a versioned release: tag the commit, generate the
+  changelog, publish artifacts, and open a release PR. Not for hotfixes (see
+  `hotfix-flow`) or pre-release tags (see `prerelease-cut`).
+---
+
+# Release cut
+
+## When to Use (and When NOT to Use)
+Use when the release branch is green and the changelog draft is approved.
+Do NOT use for hotfixes or pre-release tags.
+```
+
+## Length guardrails
+
+- **Soft cap: 500 lines** for `SKILL.md`. Above that, move material to
+  `references/` and cite it. The chassis is meant to be skimmable in one pass.
+- **Soft floor: 80 lines.** Below 80 lines often means the skill is too thin
+  to stand alone. Consider merging with a neighbor, or expanding Outcomes
+  and Anti-patterns until the skill earns its place.
+- Individual sections have their own budgets (see above). Treat them as soft
+  guidance, not hard limits, but be suspicious of any section that grows past
+  twice its budget.
+- `references/` files have no hard cap, but each should still be focused on
+  one topic. Split when a file grows past 500 lines.
+
+## Cross-references with siblings
+
+- For the trigger-phrase grammar that goes in the `description` field, see
+  `description-trigger-rules.md`.
+- For the outcomes-to-recommendations laddering pattern (how each tool
+  recommendation cites the outcome it ladders up to), see
+  `outcomes-laddering.md`.
+- For the audit checklist used to verify an existing skill against this
+  chassis, see `audit-checklist.md`.
+- For Anthropic's underlying guidance on skill authoring (the upstream
+  philosophy this chassis specializes), see `anthropic-skill-creator.md`.

--- a/plugins/meta/.claude-plugin/plugin.json
+++ b/plugins/meta/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "meta",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Primitive generators — tools that create commands, skills, prompts, and other agentic primitives",
   "author": {
     "name": "NeuralEmpowerment"

--- a/plugins/meta/skills/authoring-skills/SKILL.md
+++ b/plugins/meta/skills/authoring-skills/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: authoring-skills
+description: Use when authoring or auditing a Claude skill (`SKILL.md` with YAML frontmatter), refining an existing skill, or reviewing a skill against a chassis. Trigger phrases include "write a skill", "author a skill", "audit this skill", "review the skill", "skill structure", "skill shape", "SKILL.md template", "skill description", "skill frontmatter", "skill not triggering". Covers Claude Code skills, plugin skills, personal `~/.claude/skills`, and project-local `.claude/skills/`. Applies to principle-doc skills (durable knowledge about a concern) and procedural skills (workflow with input/output). Do NOT use for slash commands, hooks, or MCP servers; those have different shapes.
+placement: "Meta-skill. Install in `.claude/skills/<skill-name>/` (repo-local meta scope) or `plugins/<meta-plugin>/skills/<skill-name>/` (when exported via a meta plugin). NOT alongside domain-specific skills under `skills/` or `plugins/<domain-plugin>/skills/`. The rule: skills that teach how to author other skills live at the meta level, separate from skills that teach a specific domain concern."
+---
+
+# Authoring Skills
+
+## Overview
+
+A skill is a `SKILL.md` file (plus optional bundled resources) that teaches Claude how to handle a concern by being loaded into context when relevant. Two things determine whether a skill works: whether Claude routes the right tasks to it (the description's job), and whether the body actually helps once loaded (the content's job). Most skill problems are one of those two; this chassis exists to make both reliable.
+
+This skill is the canonical authoring contract. Follow it whenever writing a new skill or auditing an existing one, both inside this plugin and in any other Claude project. It distills Anthropic's official skill-creator guidance and adds two opinionated additions: **Outcomes** as a durable north-star section, and an **anti-yellow-flag** posture that prefers observation over command-form rules.
+
+## Outcomes we are looking for
+
+Goals are durable. Tools and tactics will change; these will not. Each outcome has 1-2 evidence signals you can check later to see whether the goal is being met.
+
+### Outcome 1: skills route correctly
+
+Claude invokes the right skill for the task without prompting from the user.
+
+- *Signal:* the user gives a task that matches the skill's domain, and Claude reaches for the skill on its own.
+- *Signal:* unrelated tasks do NOT trigger the skill (no false-positive activations cluttering the session).
+
+### Outcome 2: the body earns its lines
+
+Every paragraph in a loaded skill pulls weight. The agent can act faster and more correctly with the skill than without it.
+
+- *Signal:* if a paragraph were removed, behavior would measurably degrade.
+- *Signal:* the skill body fits comfortably under 500 lines; depth lives in `references/`.
+
+### Outcome 3: durable content does not rot with the tool layer
+
+Principles and outcomes outlive specific tool recommendations. When a recommended library is replaced, only the dated tools-and-practices section needs editing.
+
+- *Signal:* the date on `## Recommended tools and practices (as of YYYY-MM-DD)` matches the last edit to that section; everything above it is unaffected by tool churn.
+
+### Outcome 4: auditing is mechanical, not opinion-shaped
+
+A reviewer following this chassis can decide if a skill conforms without making aesthetic judgments. Gaps are checkable.
+
+- *Signal:* the audit checklist in `references/audit-checklist.md` returns a clean pass-fail per criterion.
+
+### Outcome 5: the chassis demonstrates itself
+
+This skill obeys its own rules. If you read this file looking for a violation of the chassis, you will not find one. Drift in this file is an outage of the entire authoring discipline.
+
+- *Signal:* `authoring-skills` itself passes the audit checklist with zero findings.
+
+## Principles
+
+1. **Structure is two-axis: type and shape.** A skill is either a **principle doc** (durable knowledge about a concern, consulted not invoked) or a **procedural skill** (a workflow with input, steps, and output). The two have different section orders; pick one consciously. See `references/skill-template.md` for both canonical shapes.
+
+2. **The description carries the routing.** Triggering is a separate problem from execution. The description must list explicit trigger phrases, common synonyms, file extensions when applicable, adjacent intents users phrase casually, and explicit non-triggers ("Do NOT use for X"). Description content lives in the description, not the body. See `references/description-trigger-rules.md`.
+
+3. **Outcomes are the north star, recommendations ladder up.** Every principle-doc skill carries a `## Outcomes we are looking for` section near the top, before any "how." The `## Recommended tools and practices (as of YYYY-MM-DD)` section groups recommendations under the outcome each one serves, with a one-line rationale linking the tool to the goal. When a tool rots, the outcome above survives. See `references/outcomes-laddering.md`.
+
+4. **Progressive disclosure across three levels.** Metadata (always in context) → SKILL.md body (loaded on trigger, lean, ~500 lines max) → bundled resources in `references/`, `scripts/`, `assets/` (loaded only when the body points to them). If the body grows past ~500 lines, move material to `references/`.
+
+5. **Imperative voice, explained why.** Tell Claude what to do, but explain the reasoning. Skills are read by an agent that can reason; rote MUSTs and ALWAYS/NEVER paragraphs are less effective than "do X because Y." Heavy command-form rule lists are a yellow flag; see `references/anti-yellow-flags.md`.
+
+6. **Observations beat shouting.** Anti-patterns are described as observations the auditor sees in real codebases ("the agent must read user-pasted screenshots manually because no programmatic capture path exists"). They are not commandments dressed up in caps ("NEVER read user-pasted screenshots"). The former is checkable; the latter performs discipline without actually enforcing it.
+
+7. **General, not example-specific.** A skill gets used across many prompts. Do not overfit the body to two or three test cases. Worked examples belong in `references/` where they can be skipped when not relevant.
+
+8. **Iterate, do not write-once.** Draft → write 2-3 realistic test prompts → run Claude with the skill → review what it did → revise. Trigger problems are a separate iteration loop from body problems. Do not co-fix them. For the full empirical methodology (live `claude -p` routing tests, body-usefulness paired runs, flake handling), see the sibling [`skill-testing`](../skill-testing/SKILL.md) skill and its references.
+
+9. **Encode opinions the baseline would not produce.** A skill earns its lines most strongly when its body contains opinions, recommendations, or framings that baseline Claude (no skill loaded) would not produce on its own. Dated, hard-won, project-specific recommendations (validated stack versions, rejected alternatives with rationale, cross-skill handoff patterns) deliver more value than well-known best practices the model already knows. When auditing a skill, ask: if the user fired this prompt without the skill loaded, would they get a meaningfully different answer? If the answer is no, the skill is anchoring framing only; consider whether that justifies its lines or whether the content belongs as a one-line cross-reference. See `docs/superpowers/specs/2026-05-14-routing-test-results.md` for the empirical study that produced this principle.
+
+## Anti-patterns
+
+Observations from skill audits. Each one names a specific failure mode; see `references/anti-yellow-flags.md` for the longer list.
+
+- **Description describes the topic, not the trigger.** "This skill is about telemetry pipelines." The agent does not know when to reach for it. The description should list phrases users actually type.
+- **Body opens with `## When to Use` instead of `## Overview`.** Routing logic in the body is wasted bytes; routing logic is the description's job. Body opens with what the skill is and what the outcomes are.
+- **Heavy ALWAYS / NEVER / MUST blocks.** Reads like a policy document; degrades to noise once the agent has seen the third one. Reframe as "do X because Y."
+- **`## Red Flags - STOP` formatted as commandments.** Observational shape works better: name what the auditor sees, name what it means, name what to do.
+- **Tools listed without rationale.** "Use Playwright." Why? For what outcome? When the tool rots, the next reader has no anchor.
+- **Outcomes section absent.** Without it, the skill is a list of patterns with no north star, and tool drift kills the whole body over time.
+- **Body over 500 lines with no `references/`.** Loaded weight is too high; the agent's context budget is spent on detail that was not relevant to this turn.
+- **Skill describes its own existence in the body.** "This skill helps with X." The frontmatter description already said that. The body's first sentence should be useful content.
+- **Audit mode mixed into authoring mode without separation.** Reviewers and authors have different jobs. Either ship two skills, or clearly split the body into "to write a skill" and "to audit a skill" sections.
+
+## Recommended tools and practices (as of 2026-05-13)
+
+The structural recommendations are tool-independent. The drafting and review loop suggests specific tools.
+
+### Outcome: skills route correctly
+
+- **Description-first drafting.** Write the description before the body. If you cannot list 5-10 trigger phrases the user might type, the skill is either too narrow or not yet understood. Ladders up by forcing routing logic into the field that carries it.
+- **Explicit non-triggers in the description.** State "Do NOT use for X, Y" when adjacent skills exist. Ladders up by suppressing false-positive activations.
+- **Run 2-3 realistic test prompts before declaring done.** Ladders up by surfacing routing gaps before deployment.
+
+### Outcome: the body earns its lines
+
+- **500-line soft cap on `SKILL.md`.** When the body grows past that, move material to `references/<topic>.md` and reference it from the body. Ladders up by keeping loaded weight low.
+- **`references/`, `scripts/`, `assets/` subdirectories** for progressive-disclosure bundling. Ladders up by giving Claude a place to fetch depth only when the task requires it.
+- **Cut-the-fat editing pass.** After draft, re-read and delete any paragraph that does not change agent behavior. Ladders up by removing rationalization-shaped filler.
+
+### Outcome: durable content does not rot
+
+- **`## Outcomes we are looking for` section near the top.** Tool-free, goal-shaped. Ladders up by giving the rest of the body something stable to ladder up to.
+- **`## Recommended tools and practices (as of YYYY-MM-DD)` section.** Dated. Grouped under outcomes. Each recommendation cites the outcome it serves. Ladders up by isolating the high-churn layer to one section.
+- **Citation discipline.** Source articles, RFCs, official docs, named practitioners. Ladders up by letting the next reader verify a recommendation against its source.
+
+### Outcome: auditing is mechanical
+
+- **`references/audit-checklist.md`** with binary pass-fail criteria per section. Ladders up by making "is this skill compliant?" answerable without aesthetic judgment.
+- **A periodic skill sweep.** Audit every skill in the plugin against the chassis whenever the chassis itself changes. Ladders up by preventing chassis drift across the corpus.
+
+### Outcome: the chassis demonstrates itself
+
+- **Apply the chassis to this skill.** This `SKILL.md` follows the principle-doc shape it documents, has Outcomes near the top, has dated recommendations, has anti-patterns as observations. Ladders up by making the chassis falsifiable.
+
+## How to use this skill: authoring mode
+
+1. Decide the skill's **type**: principle doc (durable knowledge) or procedural (workflow). See `references/skill-template.md` for both shapes.
+2. Draft the **description** first. List 5-10 trigger phrases, common synonyms, file extensions if relevant, explicit non-triggers. See `references/description-trigger-rules.md`.
+3. Draft the **Outcomes** section before any other body content. Each outcome is a durable goal with 1-2 evidence signals.
+4. Draft the **Principles** (for principle docs) or **Workflow** (for procedural). Lean. Imperative, with the why.
+5. Draft the **Anti-patterns** as observations, not commandments.
+6. Draft the **Recommended tools and practices** section. Group recommendations under outcomes. Each recommendation cites the outcome it ladders up to.
+7. Move overflow detail to `references/<topic>.md` files.
+8. Audit the draft against `references/audit-checklist.md`.
+9. Run 2-3 realistic test prompts. Iterate description for routing problems, body for execution problems. Do not co-fix.
+
+## How to use this skill: audit mode
+
+1. Open the target `SKILL.md` and its `references/` directory.
+2. Walk `references/audit-checklist.md` top to bottom. For each criterion, mark pass or fail.
+3. For each fail, identify the smallest change that closes the gap. Prefer moving content over rewriting.
+4. Apply the changes in one editing pass per skill. Do not bundle audit fixes for multiple skills into one commit; one skill per commit so the diff stays reviewable.
+5. Re-run the checklist. If still failing on the same criterion, the criterion may need refinement; flag in `references/audit-checklist.md` rather than working around it in the audited skill.
+
+## References
+
+- `references/anthropic-skill-creator.md`: Anthropic's official skill-creator playbook, distilled.
+- `references/skill-template.md`: canonical shapes for principle-doc and procedural skills, with every section explained and example openings.
+- `references/outcomes-laddering.md`: the durable-outcomes-to-rotting-tools pattern with worked examples from real harness-engineering skills.
+- `references/description-trigger-rules.md`: how to write descriptions that route correctly; trigger-phrase patterns; non-trigger declarations.
+- `references/audit-checklist.md`: binary pass-fail criteria, walkable top to bottom.
+- `references/anti-yellow-flags.md`: longer list of skill anti-patterns, observational style.
+
+## Continual improvement
+
+This skill is maintained at:
+https://github.com/AgentParadise/harness-engineering/blob/main/skills/authoring-skills/SKILL.md
+
+Improvements to the chassis must be applied to this file first, then propagated to every other skill in the plugin via a sweep. Chassis drift is the most expensive kind of drift; do not let it land without the sweep.

--- a/plugins/meta/skills/authoring-skills/references/anthropic-skill-creator.md
+++ b/plugins/meta/skills/authoring-skills/references/anthropic-skill-creator.md
@@ -1,0 +1,100 @@
+# anthropic-skill-creator
+
+Distilled reference for the official Anthropic guidance on authoring Claude skills.
+
+Distilled from Anthropic's skill-creator guidance, accessed 2026-05-13.
+
+## Anatomy
+
+A skill is a directory whose contents Claude can selectively pull into context:
+
+```
+skill-name/
+├── SKILL.md          (required)
+│   ├── YAML frontmatter: name, description
+│   └── Markdown body of instructions
+└── (optional bundled resources)
+    ├── scripts/      executable code for repetitive or deterministic work
+    ├── references/   docs that load into context only when needed
+    └── assets/       templates, fonts, icons, and other artifacts used in output
+```
+
+Bundled resource conventions:
+
+- `scripts/`: executable code Claude can run for deterministic or repetitive work. Scripts can execute without being read into context, which keeps token usage low.
+- `references/`: longer-form documentation that Claude loads only when the body of SKILL.md instructs it to. Good home for spec-level detail, API surface tables, or domain background.
+- `assets/`: files copied into the user's output, such as templates, fonts, or icons. Not instructions to Claude, ingredients for the result.
+
+## Progressive disclosure across three levels
+
+Skills are designed so that detail unfolds only when relevant. There are three levels:
+
+1. **Metadata (name + description).** Always present in Claude's context. Roughly 100 words total. This is the trigger surface, what tells Claude the skill is the right tool for the current task.
+2. **SKILL.md body.** Loaded when the skill triggers. Keep it under roughly 500 lines as a soft cap. Past that, comprehension degrades and the prompt starts to compete with itself.
+3. **Bundled resources.** Loaded only when the body explicitly directs Claude to read them, or when scripts are invoked. Effectively unlimited in size, because most of it never enters the model's working context.
+
+Knowing you are hitting the soft cap:
+
+- SKILL.md is creeping past ~500 lines.
+- Sections describe edge cases, file format minutiae, or long enumerations that most invocations will not need.
+- You catch yourself adding "if you encounter X, here is the full background on X."
+
+Fix: move the detail into `references/` and have SKILL.md point at the file by relative path. The body should read like a table of contents into the deeper material, not a copy of it.
+
+## The description is routing
+
+The `description` field in frontmatter is the single biggest determinant of whether a skill gets invoked at all. Treat it as a routing problem distinct from the execution problem solved by the body.
+
+Why this matters:
+
+- Claude tends to undertrigger skills. A description that is too narrow, too humble, or too abstract leaves the skill dormant.
+- The body of SKILL.md is irrelevant if routing never selects the skill in the first place.
+
+What to include in the description:
+
+- What the skill does, stated plainly.
+- Specific contexts where it should fire: trigger phrases the user is likely to say, file extensions the skill applies to, synonyms for the core concept, and adjacent intents that look like the core use case.
+- Optional non-triggers when there is a sibling skill that overlaps. Naming what this skill is not for helps the router disambiguate.
+
+All "when to use" content belongs in the description, not the body. The body is for "how to do it once selected."
+
+Shape to aim for (informally, in the spirit of skills like the public `docx` skill): a sentence on capability, a sentence or clause listing trigger contexts and file types, and an optional clause on adjacent intents that should also pull this skill in. Slightly pushy beats slightly shy.
+
+## Writing style
+
+For the body of SKILL.md:
+
+- Use imperative voice for instructions. "Read the manifest before editing" beats "the manifest should be read."
+- Explain the why, not just the what. Modern models reason well about intent. A short rationale ("we read the manifest first because downstream steps assume its schema") generalizes better than a bare command.
+- Treat heavy ALWAYS, NEVER, and MUST capitalization as a yellow flag. If a rule needs shouting to land, it usually needs explanation instead. Reframe as reasoning where you can, and reserve emphatic prohibitions for cases where the failure mode is severe and non-obvious.
+- Keep the prompt lean. Cut sentences that do not change behavior. Cut examples that only restate the rule.
+- Stay general. Example-specific instructions ("when the file is named `foo.json`...") tend to mislead on the next case. Prefer principles plus one illustrative example.
+- Bundle repeated work. If the skill keeps walking Claude through the same five-step sequence, factor it into a script or a referenced procedure.
+
+## The development loop
+
+Skills are written iteratively. The loop:
+
+1. Draft SKILL.md, frontmatter first.
+2. Write two or three realistic test prompts. These should be the kinds of requests a real user would make, not idealized phrasings.
+3. Run Claude against the skill on those prompts.
+4. Review qualitatively. Did the skill trigger? Did it execute well once triggered? Where did it drift, over-explain, or miss?
+5. Rewrite based on what failed. If triggering failed, edit the description. If execution failed, edit the body or push detail into references.
+6. Repeat.
+
+Optimize triggering and execution separately. They are different problems with different fixes:
+
+- Triggering failures: change the description, add trigger phrases, add file extensions, add adjacent intents.
+- Execution failures: tighten the body, add a missing step, factor a script, move noisy detail into `references/`.
+
+Mixing the two slows the loop.
+
+## Project additions on top of Anthropic guidance
+
+The harness-engineering chassis layers two opinionated extensions on top of the official guidance. Both are conventions enforced by sibling references, not Anthropic requirements.
+
+1. **Outcomes section.** Every skill in this plugin includes an `## Outcomes we are looking for` section near the top of SKILL.md. This anchors the skill to durable goals (what success looks like for the user) and separates those goals from the tools and procedures used to reach them. Tools rot. Outcomes do not. When a skill drifts, the outcomes section is the fixed point you re-derive from. See [outcomes-laddering.md](outcomes-laddering.md).
+
+2. **Observational anti-patterns.** Where the conventional pattern is a "Red Flags - STOP" block in command form ("NEVER do X"), this chassis uses auditable observations: "If you observe X in the output, that is a signal that Y went wrong." This keeps the language descriptive rather than prohibitive, makes the signals checkable after the fact, and aligns with the "explain the why" guidance above. See [anti-yellow-flags.md](anti-yellow-flags.md).
+
+Both extensions are compatible with the three-level disclosure model: the outcomes section sits in the body of SKILL.md (loaded on trigger), and the anti-pattern observations either sit inline or live in a referenced file depending on length.

--- a/plugins/meta/skills/authoring-skills/references/anti-yellow-flags.md
+++ b/plugins/meta/skills/authoring-skills/references/anti-yellow-flags.md
@@ -1,0 +1,203 @@
+# Anti-Yellow-Flags: Observed Failure Modes in Skill Authoring
+
+Distilled from Anthropic's skill-creator guidance (the "yellow flags" they call out for skills that look disciplined but read as brittle) and from observed failure modes in this plugin's own skill corpus. The Anthropic list names a handful of stylistic tells; this document expands that list with patterns surfaced during audits of skills authored in this repository.
+
+This is a catalog of observations, not a list of commandments. Each item describes what the failure mode looks like when it shows up in a `SKILL.md`, why it degrades the skill's effectiveness, and how to rework it.
+
+## Why observations beat commandments
+
+Anti-patterns work better when stated as "this is what I see in the wild" rather than "you shall not do X." The agent reads the skill and parses observations more effectively than imperatives because observations carry context: what triggered the pattern, what it looks like on the page, and what it means for the reader. An imperative strips that context down to the rule itself, and in doing so it loses discriminative power on edge cases. The agent confronted with a near-match cannot tell whether the rule applies, because the rule no longer carries the signal that distinguishes its in-scope cases from adjacent ones.
+
+The second reason is tonal. A skill saturated with "NEVER" reads like a policy document, and policy documents teach readers to skim. An observation invites the reader to check the artifact against the description, which is the behavior the skill actually wants. The shift from "you must" to "this is what a healthy version looks like" turns the skill into a diagnostic instrument rather than a tribunal.
+
+## Yellow flags Anthropic explicitly names
+
+### Heavy ALWAYS / NEVER / MUST blocks
+
+Reads like a policy document. After three imperatives in a row, the agent stops parsing each one and starts skimming the block as a unit. The third NEVER carries no more weight than the first; in practice it carries less, because attention is already gone. Reframe as "do X because Y," with the rationale carrying the discriminative weight. The reader who understands the Y can apply the X to cases the author did not anticipate.
+
+### Rigid structures dressed up as discipline
+
+Excessive section headers with one-sentence bodies. Each header promises a topic; each body delivers a sentence; the cumulative effect is a table of contents pretending to be a document. The ritual of structure substitutes for the content the structure was meant to organize. A skill with eight `##` headers and forty lines of body is, in almost every case, four headers and forty lines of body wearing a costume.
+
+### Test-overfit content
+
+The skill solves the two examples the author ran during drafting and falls apart on the third real task. Symptom: every example in the body refers to the same domain, the same tools, or the same shape of problem. The skill is a transcript of the debugging session that produced it, not a general guide. The fix is to write at the level of pattern (what is true across cases) and demote the specific examples to one or two illustrations.
+
+### Description that describes the topic, not the trigger
+
+"This skill is about X." The agent does not learn when to invoke; the user does not see the routing signal. The description's job is to fire on the right requests and stay silent on adjacent ones. A description that names the topic without naming the trigger phrases will either over-fire (matching anything in the topic neighborhood) or under-fire (failing to match phrasings the author did not consider). See `description-trigger-rules.md`.
+
+## Yellow flags from this plugin's own audit
+
+### `## When to Use` section in a principle-doc body
+
+Routing logic in the wrong place. "When to use" belongs in the description (frontmatter), where the harness reads it to decide whether to load the skill. Putting it in the body means the harness already loaded the skill before the reader learned whether to use it. Body should open with `## Overview` or the first content section, not a re-litigation of the routing decision.
+
+### Body's first sentence is "This skill is for X."
+
+The frontmatter already said that. The first body sentence is the most valuable real estate in the file; spending it on a re-introduction wastes the slot. First sentence should deliver useful content: the central observation, the load-bearing principle, the thing the reader came for.
+
+### `## Red Flags - STOP` as commandments
+
+Each entry starts with "NEVER" or has an imperative shape. The auditor reading the skill against an artifact cannot mark "NEVER make the agent read pasted screenshots" as present or absent, because "NEVER" is a rule, not a property. Reframe each entry as an observation about the artifact: "the agent is required to read pasted screenshots to debug UI bugs," or "the workflow lacks a programmatic screenshot capture step." These can be checked against the codebase; rules cannot.
+
+### Rationalization-prevention tables that double as "I told you so" lists
+
+Useful in moderation. Over-deployed, they perform discipline without enforcing it: the reader sees a long table, recognizes the pattern, and skips it. Cap at 5 to 7 rows in the body. If the catalog needs more entries, move the long form to `references/rationalizations.md` and leave a pointer.
+
+### Growth examples that drift specific-to-the-domain
+
+Skills sometimes ladder examples through POC / Growing / Production / Safety-critical. When the production tier just says "in production, add tools," it adds no information; "more rigor" is not a maturity level. The example must distinguish what changes at each maturity level beyond a vague increase in discipline. If the author cannot articulate the change, the tier should be cut.
+
+### Key Patterns blocks with too many checkmark and cross pairs
+
+Two or three pairs is instructive. Ten is noise. The signal-to-context-cost drops fast past three. If the patterns are genuinely ten distinct lessons, they belong in a `references/patterns.md` file with room to breathe; if they are variations on a theme, three representative pairs carry the meaning.
+
+### Tools listed without rationale
+
+"Use Playwright." The next reader cannot tell whether the recommendation is still valid when Playwright is replaced by something else, because the recommendation was tied to the tool name rather than the outcome the tool delivered. Every recommendation cites the outcome it ladders up to. See `outcomes-laddering.md`.
+
+### Outcomes section absent
+
+The skill is a pile of tactics with no north star. When the tools rot, the whole body rots with them, because nothing in the document tells the reader what the tactics were trying to achieve. The outcomes section is what survives a tool migration; without it, the skill has a half-life equal to the half-life of its tooling.
+
+### Outcomes that name tools or metrics
+
+"Page load under 800ms" is a metric, not an outcome. "Agent can detect performance regression without human intervention" is an outcome. The metric is a signal that the outcome is being met; promoting the signal to the goal causes the reader to optimize the number rather than the capability.
+
+### Body over 500 lines with no `references/`
+
+Loaded context budget is being wasted on detail the current task does not need. The body is for the load-bearing 20 percent; the references hold the depth. A skill that refuses to split is a skill that has not decided what its central claim is.
+
+### Em-dashes
+
+This plugin's house rule. The em-dash (U+2014) is a stylistic tell of LLM-written prose, and its presence indicates the author has not edited the model's output. Use colons, commas, periods, parentheses, or restructure the sentence.
+
+### Marketing language
+
+"Powerful," "comprehensive," "best-in-class," "advanced." Adds no information; degrades signal. The reader skips these words automatically, which means anything load-bearing positioned next to them is also at risk of being skipped.
+
+### Cross-references with absolute paths
+
+`/Users/neural/...` or `~/Code/...` in a cross-reference. Breaks the moment the skill is installed in a different location. Cross-references inside a skill use paths relative to the skill root (`references/foo.md`), and cross-references between skills use the plugin-qualified form documented in `anthropic-skill-creator.md`.
+
+### Continual improvement section pointing at a stale URL
+
+A common pattern: the skill ends with a "feedback welcome" link to a GitHub issue tracker, and the URL is wrong, dead, or pointing at the author's personal fork. The link must resolve. If there is no place to send feedback, omit the section.
+
+## How to fix each, with examples
+
+### Heavy NEVER block
+
+Before:
+
+```markdown
+## Red Flags - STOP
+
+- NEVER skip the test suite.
+- NEVER push without review.
+- NEVER commit generated artifacts.
+- NEVER use force-push on shared branches.
+```
+
+After:
+
+```markdown
+## Observed failure modes
+
+- The test suite is skipped, because the author believed the change was
+  trivial. Trivial changes are the modal source of regressions in this repo,
+  so the suite runs on every push.
+- A commit lands without review, because the author had merge rights and a
+  deadline. The review gate exists because the modal author has both.
+```
+
+The rule survives, but the rationale carries it; the reader who understands the rationale can apply the rule to cases the author did not list.
+
+### Topical description
+
+Before:
+
+```yaml
+description: This skill is about writing good skills.
+```
+
+After:
+
+```yaml
+description: |
+  Use when creating, editing, or auditing a SKILL.md file in this plugin.
+  Triggers on phrases like "write a skill", "audit my skill", "skill yellow
+  flags", "skill anti-patterns". Does not trigger on general writing or
+  documentation tasks unrelated to the skill format.
+```
+
+The trigger phrases are explicit, and the non-triggers prevent over-firing. See `description-trigger-rules.md`.
+
+### Red Flags as commandments
+
+Before:
+
+```markdown
+- NEVER make the agent read pasted screenshots.
+```
+
+After:
+
+```markdown
+- The workflow requires the agent to read pasted screenshots to diagnose UI
+  bugs. The agent has no programmatic screenshot capture step.
+```
+
+The auditor can check the second version against the artifact and mark it true or false; the first version is a rule that the artifact cannot satisfy or violate, only ignore.
+
+### Outcomes that name tools
+
+Before:
+
+```markdown
+## Outcomes
+
+- Playwright runs on every PR.
+- Page load under 800ms.
+```
+
+After:
+
+```markdown
+## Outcomes
+
+- The agent can detect UI regressions without human intervention on every
+  pull request.
+- The agent can detect performance regressions before they reach production.
+
+## Current recommendations (2026-05)
+
+- Playwright is the current browser automation tool.
+- 800ms is the current page-load budget; see `references/performance.md`.
+```
+
+The outcomes name the capability; the dated recommendations name the tool that currently delivers it. When the tool changes, the outcomes survive.
+
+### Body over 500 lines
+
+Before: a single SKILL.md with sections on history, philosophy, tooling, examples, edge cases, and a glossary, totaling 700 lines.
+
+After: a SKILL.md of 200 lines covering the load-bearing principles and routing, with pointers to `references/history.md`, `references/tooling.md`, `references/examples.md`, `references/edge-cases.md`, and `references/glossary.md`. The body loads on every invocation; the references load only when the task needs them.
+
+## When a yellow flag is actually correct
+
+Discipline has its place. Heavy NEVER blocks are appropriate for safety-critical rules where the cost of misinterpretation is real, and where the rule is the kind a competent reader might reasonably ignore. "NEVER commit secrets" is the canonical example: the reader will, in the wild, encounter situations where committing a secret feels expedient ("it is only a test key," "the repo is private"), and the imperative form is doing real work against a real rationalization.
+
+The test is this: is the rule the kind a competent reader might reasonably ignore in the absence of the imperative? If yes (secrets, destructive git operations, prod-database writes), the NEVER form is appropriate and the cost of stylistic stiffness is worth paying. If no (formatting conventions, structural preferences, style choices), the "do X because Y" form is more effective, because the reader is not in danger of ignoring the rule, only of misapplying it, and the rationale is what enables correct application.
+
+The chassis allows imperative form in narrow cases. The audit catches it when it has spread beyond those cases.
+
+## Cross-references
+
+- `audit-checklist.md`: the checklist the auditor walks when reviewing a skill against this catalog.
+- `outcomes-laddering.md`: how to write an outcomes section that survives tool migration.
+- `description-trigger-rules.md`: how to write a description that fires on the right requests and stays silent on adjacent ones.
+- `anthropic-skill-creator.md`: the upstream guidance this catalog extends.
+- `skill-template.md`: the starting structure that already encodes the fixes for the most common anti-patterns.

--- a/plugins/meta/skills/authoring-skills/references/audit-checklist.md
+++ b/plugins/meta/skills/authoring-skills/references/audit-checklist.md
@@ -1,0 +1,183 @@
+# Audit checklist for skills
+
+A binary pass-fail checklist a reviewer walks top to bottom when auditing a skill against the `authoring-skills` chassis. Each criterion is checkable without aesthetic judgment: "Did the author follow the rule?" not "Is the writing good?"
+
+## Source attribution
+
+This checklist consolidates rules defined in sibling references:
+
+- `skill-template.md` (canonical section ordering)
+- `description-trigger-rules.md` (frontmatter routing)
+- `outcomes-laddering.md` (outcomes and recommendation grouping)
+- `anti-yellow-flags.md` (tone and prohibited constructs)
+- `anthropic-skill-creator.md` (upstream Anthropic guidance)
+
+## How to use this checklist
+
+1. Open the target `SKILL.md` and its bundled `references/`, `scripts/`, and `assets/` (if present).
+2. Walk this document top to bottom. Mark each numbered criterion pass or fail.
+3. For each fail, identify the smallest change that closes the gap. Do not redesign the skill.
+4. Apply audit fixes one skill per commit. Do not bundle multiple skills into a single audit commit; per-skill commits keep blame and rollback clean.
+5. After fixes, re-run the checklist on the changed skill to confirm every criterion now passes.
+
+A criterion that does not apply (for example, procedural-skill checks against a principle-doc skill) is marked N/A. N/A is not a failure, but the reviewer must record why it does not apply.
+
+---
+
+## Section 1: Frontmatter and routing
+
+1. **Frontmatter present and well-formed.** Pass if YAML frontmatter sits at the top of `SKILL.md` enclosed in `---` fences, containing exactly two fields: `name` and `description`. No extra fields, no trailing whitespace inside the fences.
+   - *Common failure:* author adds `version`, `author`, or `tags`. Strip them; the harness ignores everything beyond `name` and `description`.
+
+2. **`name` matches the directory.** Pass if `name: foo-bar` and the skill file lives at `skills/foo-bar/SKILL.md`. A mismatch breaks routing and discovery.
+   - *Common failure:* renamed directory but did not update frontmatter, or vice versa.
+
+3. **`description` includes 5 or more trigger phrases.** Pass if the description names at least five concrete situations, file types, keywords, or user intents that should activate the skill. See `description-trigger-rules.md`.
+   - *Common failure:* description states what the skill *is* rather than when it should fire.
+
+4. **`description` includes at least one explicit non-trigger when adjacent skills exist.** Pass if the description names what the skill is *not* for, in cases where a sibling skill could be confused with it. See `description-trigger-rules.md`.
+   - *Common failure:* two adjacent skills both claim "use when reviewing code" and the harness cannot disambiguate.
+
+5. **No marketing language in the description.** Pass if the description contains none of: "best", "powerful", "advanced", "comprehensive", "world-class", "cutting-edge". Marketing tokens are routing noise.
+   - *Common failure:* description opens with "A powerful skill for ..." which tells the router nothing useful.
+
+---
+
+## Section 2: Body structure (principle-doc skills)
+
+Apply this section when the skill documents principles, outcomes, and recommendations rather than a step-by-step procedure.
+
+6. **`## Overview` present and approximately one paragraph.** Pass if Overview frames what the skill is about in durable language. Fail if Overview is a bullet list, a table of contents, or longer than three paragraphs.
+   - *Common failure:* Overview restates the description verbatim instead of framing the underlying domain.
+
+7. **`## Outcomes we are looking for` present and near the top.** Pass if Outcomes appears between Overview and Principles. See `outcomes-laddering.md`.
+   - *Common failure:* outcomes appear at the bottom of the file as an afterthought, making the principle list read like floating advice.
+
+8. **3 to 5 outcomes.** Pass if the count is 3, 4, or 5. Occasionally 6 or 7 is acceptable for broad skills. Fail if the count is 1, 2, or greater than 7.
+   - *Common failure:* a single bloated "Outcome 1: do everything well" that cannot be evaluated.
+
+9. **Each outcome has 1 or 2 evidence signals.** Pass if every outcome names a concrete observation a reviewer could make to confirm the outcome holds. A goal without a signal cannot be checked.
+   - *Common failure:* outcomes phrased aspirationally ("write good code") with no signal naming what good looks like in this skill's context.
+
+10. **Outcomes are goals, not tools or metrics.** Pass examples: "Agent can perceive UI state without human translation." Fail examples: "Use Playwright" (tool), "Page load under 800ms" (raw metric without goal context).
+    - *Common failure:* the recommendations section migrated upward and now sits in the outcomes slot.
+
+11. **`## Principles` present and lean.** Pass if Principles contains 5 to 8 entries, each 2 to 5 sentences. Each principle is written in the imperative and includes the why, not only the what.
+    - *Common failure:* 15 principles, each one sentence long. Consolidate or move detail into a reference file.
+
+12. **`## Anti-patterns` present and observational.** Pass if Anti-patterns lists 6 to 12 entries written as observations of what auditors see in the wild. Fail if entries lean on heavy ALWAYS/NEVER blocks. See `anti-yellow-flags.md`.
+    - *Common failure:* anti-patterns written as commands ("Never use X") rather than descriptions of the failure mode and its consequence.
+
+13. **`## Recommended tools and practices (as of YYYY-MM-DD)` present and dated.** Pass if the heading carries a date and that date falls within the most recent release cycle of the plugin. Stale dates signal abandoned recommendations.
+    - *Common failure:* the date was set at skill creation and never refreshed when tools were swapped.
+
+14. **Recommendations are grouped under outcomes with explicit laddering.** Pass if each recommendation block names which outcome it serves. See `outcomes-laddering.md`.
+    - *Common failure:* a flat list of tools with no link back to the outcome each serves.
+
+15. **`## References` section present if the skill has bundled references.** Pass if the body links every file under `references/` at least once, with a one-line description of when to consult that reference.
+    - *Common failure:* a reference file exists on disk but is never linked from the body, so readers never discover it.
+
+16. **`## Continual improvement` section present with the canonical GitHub link.** Pass if the section invites contributions and points at the plugin repository so readers know where to file follow-ups.
+    - *Common failure:* the link points at a personal fork or a closed-source mirror.
+
+---
+
+## Section 3: Body structure (procedural skills)
+
+Apply this section when the skill is procedural: an orchestrator, a maintenance routine, a setup wizard, or any skill whose primary output is "the user did the steps".
+
+17. **`## When to Use` and `## When NOT to Use` present.** Pass if both sections exist and each lists concrete situations. The pair calibrates routing for procedural skills the way the description does for principle-doc skills.
+    - *Common failure:* "When NOT to Use" is omitted because the author could not think of a counter-example. Force the question: what skill or path supersedes this one?
+
+18. **`## Input` section names parameters explicitly.** Pass if every input the procedure consumes (arguments, files, environment variables) is named with its type and whether it is required.
+    - *Common failure:* the workflow references `$ARGUMENTS` or environment variables that are never declared in Input.
+
+19. **`## Workflow` is numbered steps.** Pass if the workflow is a numbered list, each step a single sentence or short paragraph. Sub-steps allowed at one level of nesting. Prose-paragraph workflows fail.
+    - *Common failure:* an unordered bullet list. Order matters; ordering must be explicit.
+
+20. **`## Output` describes the artifact(s) produced.** Pass if Output names what files, commits, branches, messages, or state changes exist after the procedure completes successfully.
+    - *Common failure:* Output is missing entirely, leaving the agent unable to verify the procedure ran to completion.
+
+21. **Outcomes and recommendations sections present when the procedure has a clear north star.** Pass if the procedure ladders to outcomes (see `outcomes-laddering.md`). Optional and may be omitted for thin procedural wrappers (for example, a 5-step utility).
+    - *Common failure:* an orchestrator that drives many sub-skills omits outcomes, so the reader cannot tell what success looks like end to end.
+
+---
+
+## Section 4: Body content quality
+
+22. **Imperative voice with explained why.** Spot-check three paragraphs at random. Pass if each answers "why" alongside "what". Fail if the paragraphs read as command lists with no rationale.
+    - *Common failure:* a principle that says "Validate input at the boundary" without saying why the boundary is the right place.
+
+23. **No heavy ALWAYS/NEVER blocks.** Pass if the body avoids capitalised commandment lists. See `anti-yellow-flags.md`. Targeted use of "never" inside a single sentence is acceptable; multi-bullet ALWAYS/NEVER walls are not.
+    - *Common failure:* a six-bullet "NEVER do X" list that reads like a warning sign rather than guidance.
+
+24. **No "this skill helps with..." opener.** Pass if the Overview does not restate the frontmatter description. The description already states what the skill helps with; repeating it wastes the top of the body.
+    - *Common failure:* Overview begins "This skill helps you ..." which is exactly what the description already conveyed.
+
+25. **No `## When to Use` in the body for principle-doc skills.** Pass if principle-doc skills route entirely from the frontmatter description. Procedural skills are exempt (see Section 3).
+    - *Common failure:* principle-doc skill duplicates routing rules in the body, creating two places that drift apart.
+
+26. **Citations present for source-derived claims.** Pass if each principle either names its source (paper, post, internal doc, observable practice) or rests on a fact a reviewer can verify directly. Unsourced assertions fail.
+    - *Common failure:* "Studies show that ..." with no study named. Either name it or drop the claim.
+
+---
+
+## Section 5: Bundled resources
+
+27. **SKILL.md is under 500 lines.** Pass if `wc -l SKILL.md` reports fewer than 500. If over, body content must have been moved into `references/` and the body must point at those references.
+    - *Common failure:* a 900-line SKILL.md that buries the routing-relevant top section under a long appendix. Move the appendix to `references/`.
+
+28. **`references/` directory present if SKILL.md is over approximately 300 lines or has depth that does not fit cleanly in the body.** Pass if depth has been externalised rather than crammed inline. A 280-line skill without references is acceptable; a 280-line skill that links five external blog posts inline is not.
+    - *Common failure:* deep technical detail inlined in SKILL.md that would be a clean reference file.
+
+29. **Each `references/` file has a clear topic and a one-line header description.** Pass if every reference file opens with a header that states what the file covers and when to read it. Reference files without orientation headers fail.
+    - *Common failure:* a reference file that opens straight into content with no orientation, leaving the reader unsure what context to bring.
+
+30. **`scripts/` if present contains executable, deterministic helpers and is referenced from SKILL.md.** Pass if scripts have shebangs, run without manual edits, and are mentioned in the body where they apply. Per Anthropic guidance, scripts replace narrative steps that the agent should execute deterministically.
+    - *Common failure:* scripts ship without shebangs or with hard-coded paths that only work on the author's machine.
+
+31. **`assets/` if present contains templates, fonts, fixtures, or fixed artifacts the skill produces or compares against.** Pass if every asset is referenced by name from SKILL.md or from a reference file. Orphan assets fail.
+    - *Common failure:* an `assets/` directory that accumulates over time and is never pruned, with files no skill section ever links.
+
+---
+
+## Section 6: Style hygiene
+
+32. **No em-dashes (U+2014).** Pass if `grep -cP "\x{2014}" SKILL.md` returns 0 (Perl-mode regex expands `\x{2014}` to the em-dash byte sequence at runtime so this rule file itself stays em-dash-free). This plugin's house rule. Use colons, commas, periods, parentheses, or restructure the sentence. Run the same check on every file under `references/`.
+
+33. **Cross-references use relative paths.** Pass if links between SKILL.md and bundled files use paths like `references/foo.md`, not absolute paths or `file://` URLs. Absolute paths break when the skill is installed under a different root.
+
+34. **No marketing language.** Pass if "powerful", "comprehensive", "best-in-class", "cutting-edge", "next-generation", and similar superlatives do not appear in body prose. Quoting a third-party name that contains these words is acceptable.
+
+35. **Tone is observational, not promotional.** Spot-check the anti-patterns and recommendations sections. Pass if each entry describes (what is observed, what happens, what the consequence is) rather than advocates (why this approach is great).
+
+---
+
+## Section 7: Demonstration test
+
+36. **2 to 3 realistic test prompts run before the skill is declared done.** Pass if the author has invoked the skill via realistic user prompts and recorded what triggered and what did not. The notes do not need to ship with the skill, but the author should be able to produce them on request.
+    - *Common failure:* the skill was written, committed, and never invoked. The first real user is the first test, and routing bugs surface in production.
+    - *What good looks like:* three prompts including one that should fire the skill, one that is adjacent but should not fire it, and one borderline case that exercises the non-trigger rule from criterion 4.
+
+---
+
+## What to do with findings
+
+For each failed criterion:
+
+1. Identify the smallest change that closes the gap. Do not redesign the skill in the same pass.
+2. Open a commit that touches only this skill. The commit message should name the skill and the criteria addressed (for example, "authoring-skills: fix criteria 11, 13, 32").
+3. Re-run the checklist against the changed skill to confirm the failed criteria now pass and no previously passing criteria regressed.
+4. If multiple skills failed the same criterion, audit each one in its own commit. Bundling masks per-skill regressions.
+
+A skill that fails three or fewer criteria can usually be fixed in one pass. A skill that fails ten or more criteria is a candidate for a deeper rewrite using `skill-template.md` as the starting point rather than incremental patching.
+
+---
+
+## Cross-references
+
+- `skill-template.md` for the canonical body skeleton to copy when starting a new skill or rewriting a failing one.
+- `description-trigger-rules.md` for the rules governing criteria 3, 4, and 5.
+- `outcomes-laddering.md` for the rules governing criteria 7, 8, 9, 10, and 14.
+- `anti-yellow-flags.md` for the rules governing criteria 12, 23, and 35.
+- `anthropic-skill-creator.md` for the upstream guidance that informs criteria 27 through 31.

--- a/plugins/meta/skills/authoring-skills/references/description-trigger-rules.md
+++ b/plugins/meta/skills/authoring-skills/references/description-trigger-rules.md
@@ -1,0 +1,152 @@
+# Description Trigger Rules
+
+How to write the `description:` field in a skill's frontmatter so the skill actually gets invoked when it should be, and only when it should be.
+
+**Source attribution:** Distilled from Anthropic's official skill-authoring guidance (see `anthropic-skill-creator.md` in this directory) and from observed routing behavior in Claude Code and agent harnesses. Per Anthropic, the description is the single biggest determinant of whether a skill triggers. Claude undertriggers by default, so descriptions need to be slightly "pushy."
+
+## Why descriptions matter most
+
+The description is always in context for routing decisions. The body is not. The body is only loaded after the description has already triggered the skill.
+
+This means triggering and body content are two different problems:
+
+- **Triggering** is solved by the description.
+- **Execution quality** is solved by the body.
+
+Most "this skill doesn't fire when I expect it to" complaints are description problems, not body problems. Authors instinctively reach for the body when their skill misfires; that is the wrong lever.
+
+Target roughly 100 words for the description, but length follows clarity, not the other way around. A 40-word description that lists the right trigger phrases beats a 200-word description that paraphrases the skill's mission statement.
+
+## What goes in a good description
+
+A description carries four loads. In order of routing weight:
+
+1. **What the skill does**, in one short clause. Not a thesis. A clause.
+2. **Specific contexts when to use it**, phrased the way a user actually phrases tasks. Trigger phrases include:
+   - Verbs: `audit`, `write`, `review`, `refactor`, `set up`, `cut`, `bump`, `sync`.
+   - Nouns: `pipeline`, `test`, `dashboard`, `release`, `manifest`.
+   - Tool names users would say out loud: `Playwright`, `Vector`, `OTLP`, `Grafana`, `Prometheus`.
+   - File extensions when applicable: `.docx`, `SKILL.md`, `compose.yaml`, `pyproject.toml`.
+   - Symptoms users describe rather than the cause: `my skill is not triggering`, `this PR is breaking`, `the deploy is stuck`, `the agent can't see logs`.
+3. **Synonyms.** Users phrase things differently than skill authors. "Browser debugging" and "UI debugging" and "frontend troubleshooting" might all route to the same skill. List the variants. Do not assume the user will speak your taxonomy.
+4. **Adjacent intents** users phrase casually that map to this skill: "see what the page looks like", "find the slow request", "check the logs from yesterday", "why did this fail last night". These are the lowest-confidence inputs and they need explicit help.
+
+Then add the suppression load:
+
+5. **Explicit non-triggers** when adjacent skills exist:
+   ```
+   Do NOT use for X (use sibling skill Y); do NOT use for Z (use skill W).
+   ```
+   This is what suppresses false-positive activations. Without explicit non-triggers, two skills that share vocabulary fight each other and the router picks badly.
+
+## What does NOT go in a description
+
+- **Internal jargon the user would not type.** If your team calls it "the substrate layer" and users call it "the API", write "API".
+- **Marketing language.** "The best skill for..." or "comprehensive coverage of..." adds zero routing signal. Strip it.
+- **The skill's own structural conventions** (Outcomes, Principles, section names). Those are not what the user typed. The user typed "review my PR", not "run the Outcomes section".
+- **Cross-references to other skills by file path.** Cross-references go in the body. The description is for routing, not navigation.
+- **Long sentences.** Each phrase should be skim-readable. The router scans; it does not parse paragraphs.
+
+## A good and a bad description, side by side
+
+Bad description (too topical, no triggers):
+
+```yaml
+description: This skill is about agent-queryable telemetry interfaces. It covers logs, metrics, and traces.
+```
+
+Good description (carries the routing load):
+
+```yaml
+description: Use when reviewing or setting up agent-queryable telemetry: LogsQL, PromQL, TraceQL, trace lookup by ID, log search by attribute. Trigger phrases include "search the logs", "what's the p95 latency", "find the trace for request X", "query metrics", "agent can't see logs", "Grafana", "VictoriaLogs", "VictoriaMetrics", "VictoriaTraces", "Tempo", "Loki", "Mimir", "Prometheus". Use when an agent needs to read telemetry, not just emit it (for emission see the `telemetry-pipeline` skill). Do NOT use for general-purpose log hygiene; that's the software-leverage-points `logging` skill.
+```
+
+What makes the second one better, line by line:
+
+- "Use when reviewing or setting up" gives the router two concrete verbs.
+- "agent-queryable telemetry" plus the query-language names (LogsQL, PromQL, TraceQL) catches users who know what they want to do but not what to call it.
+- The quoted trigger phrases mirror how a user actually types: lowercase, conversational, with question marks and pronouns.
+- Tool names (Grafana, VictoriaLogs, Tempo, Loki, Prometheus) catch users who arrive via their stack rather than via the concept.
+- The parenthetical "(for emission see ...)" disambiguates a near-neighbor skill before the router has to guess.
+- The explicit "Do NOT use for general-purpose log hygiene" prevents this skill from stealing routing from `logging`.
+
+The bad version says what the skill is "about". The good version says when to fire it. Routers do not care about "about".
+
+## Description-first drafting
+
+Write the description before the body.
+
+The test: if you cannot list 5-10 trigger phrases the user might type, the skill is either too narrow to ship or you have not understood what it is for yet. This is the test, not a suggestion.
+
+Writing the body first feels productive, but you will then retrofit the description to match the body, which is exactly backwards. The description is the contract with the router; the body is the contract with the agent. Sign the routing contract first.
+
+If you draft the description and the trigger phrases feel forced, that is signal. Either:
+
+- The skill's scope is wrong (split it, or merge it with a sibling).
+- The skill's name is wrong (rename so the description writes itself).
+- The skill should not exist (the work belongs in an existing skill).
+
+## Iterating descriptions separately from body
+
+Triggering problems and execution problems are different problems. Do not change the description and the body in the same iteration; you will not know which fix caused the improvement (or regression).
+
+Workflow:
+
+1. Observe a routing miss or false positive.
+2. Change only the description. Commit.
+3. Re-run realistic prompts. Observe.
+4. If routing is now correct but execution is poor, change only the body. Commit.
+5. If routing is still wrong, change only the description again.
+
+Bundling description and body edits is the single most common reason authors cannot tell which change helped.
+
+## Trigger-phrase patterns by skill type
+
+Different skill types attract different trigger phrases. Match the pattern to your skill.
+
+**Principle-doc skill** (a reference that informs review or design). Trigger phrases are verbs the user does combined with the domain noun:
+
+- "review the telemetry pipeline"
+- "audit this skill's structure"
+- "set up the failure signal"
+- "check the dependency story"
+
+**Procedural skill (orchestrator)** (a skill that runs an end-to-end flow). Trigger phrases are direct invocations plus symptom phrasing:
+
+- "run a harness review"
+- "audit the plugin"
+- "review this PR through the leverage points"
+- "we need a full review"
+- "give me an audit"
+
+**Maintenance skill** (a skill that keeps state in sync). Trigger phrases are versioning, release, and sync verbs:
+
+- "bump the version"
+- "cut a release"
+- "sync the manifests"
+- "pull upstream scaffold"
+- "regenerate the lockfile"
+- "promote staging to prod"
+
+If your skill does not fit one of these patterns cleanly, pick the closest and write the description in that pattern's voice. Mixed-pattern descriptions route poorly because the trigger phrases pull in different directions.
+
+## A short checklist
+
+Before declaring a description done:
+
+- Can you list 5-10 trigger phrases? If no, rewrite.
+- Did you include 1-2 explicit non-triggers? If no, the routing will overshoot.
+- Did you avoid marketing words? If no, strip.
+- Does the description say WHAT (one clause) and WHEN (many trigger phrases) and NOT-WHEN (non-triggers)? If any missing, fill in.
+- Did you run 2-3 realistic test prompts and observe routing? If no, you are guessing.
+
+If all five answers are yes, ship it. If any answer is no, you are not done; you are hoping.
+
+## Cross-references
+
+Sibling files in this directory:
+
+- `skill-template.md`: the canonical skeleton for a new SKILL.md, including frontmatter shape.
+- `outcomes-laddering.md`: how to write the body's Outcomes section once the description is locked.
+- `audit-checklist.md`: end-to-end review for a skill, including a description-quality pass.
+- `anthropic-skill-creator.md`: upstream Anthropic guidance this document is distilled from.

--- a/plugins/meta/skills/authoring-skills/references/outcomes-laddering.md
+++ b/plugins/meta/skills/authoring-skills/references/outcomes-laddering.md
@@ -1,0 +1,322 @@
+# Outcomes laddering
+
+Project addition on top of Anthropic skill-creator guidance. The skill-creator
+documentation covers structure, frontmatter, and progressive disclosure. This
+document covers the most opinionated addition the harness-engineering chassis
+makes on top of that: durable Outcomes as the north star of every skill, with
+Recommended tools and practices grouped under and laddering up to those
+outcomes.
+
+## The pattern in one diagram
+
+```
+   Outcomes (durable goals)
+       ^ ladders up to
+   Recommended tools and practices (dated, churns)
+       ^ replaced when better options emerge
+```
+
+Outcomes stay. The layer below them is allowed to rot. This is intentional
+separation, not accidental drift.
+
+Why two layers instead of one:
+
+1. When a tool gets replaced, only the dated
+   `## Recommended tools and practices (as of YYYY-MM-DD)` section needs
+   editing. The outcomes above it are unaffected.
+2. A new reader can decide whether a tool recommendation is still valid by
+   asking a single question: does it still serve the named outcome? If yes,
+   keep it. If no, the recommendation has rotted even if the section's date
+   is recent.
+3. Auditing becomes mechanical. For every recommendation, you can point at the
+   outcome it ladders up to. If you cannot, the recommendation is unmoored
+   and should be removed or rewritten.
+
+The contract: outcomes are load-bearing. Tools are replaceable. A skill that
+inverts this (long tool list, vague or absent outcomes) will not survive its
+first tool churn cycle.
+
+## Writing good outcomes
+
+An outcome is:
+
+- A *goal*, not a tool or a metric.
+  - Goal: "Agent can perceive UI state without human translation."
+  - Tool: "Use Playwright." (Wrong: names the implementation.)
+  - Metric: "Page load under 800ms." (Wrong: a measurement, not a purpose.)
+- Stated as a single sentence in plain English. Avoid jargon when a plain
+  word will do. If you need a term of art, define it once nearby.
+- Paired with one or two *evidence signals*: checkable facts that, if true,
+  suggest the outcome is being met. Signals can age faster than the outcome
+  itself, and that is fine. Treat them as the dated layer for the outcome
+  the same way recommendations are the dated layer for principles.
+- Independent of the others when possible. If two outcomes overlap heavily,
+  merge them. Two outcomes that always rise and fall together are one
+  outcome wearing two hats.
+- Few in number. Three to five outcomes per skill is the comfortable range.
+  More than seven is a strong signal the skill is doing the job of two
+  skills and should be split.
+
+A useful test: read the outcome aloud to someone outside the project. If they
+cannot tell whether it is being met without asking which tools you use, the
+outcome is written at the right altitude. If their first follow-up question
+is "how", the outcome is doing its job: leaving the "how" to the layer below.
+
+### Outcome template
+
+```
+### Outcome N: <single plain-English sentence>
+
+<One short paragraph: why this matters, what failure looks like.>
+
+Evidence signals:
+- <Checkable fact 1.>
+- <Checkable fact 2.>
+```
+
+## Writing good recommendations under outcomes
+
+Each recommendation:
+
+- Is grouped under the outcome it serves. If a recommendation genuinely
+  ladders up to two outcomes, list it under both rather than splitting it
+  across the gap. Duplication here is cheap; ambiguous attribution is not.
+- Names the tool or practice first, then states the laddering with a phrase
+  like "Ladders up by ..." or "Serves this outcome by ...". The laddering
+  sentence is the load-bearing part. Without it, the recommendation is just
+  a brand name.
+- Lives under a dated section header:
+  `## Recommended tools and practices (as of YYYY-MM-DD)`. The date is the
+  honesty marker. It tells a future reader how stale the list is allowed to
+  be before they should re-evaluate.
+- Is observational about its tradeoffs, not advocacy. Note what the tool
+  costs, what it does not cover, and what would make you replace it. A
+  reader who disagrees can disagree on the evidence rather than the vibe.
+
+### Recommendation template
+
+```
+- <Tool or practice name>. <One sentence describing what it does.>
+  Ladders up by <how this advances the outcome above>.
+  Tradeoffs: <what it costs, what it does not cover>.
+```
+
+## Worked example A: browser-legibility
+
+Below is a credible outcomes section for a skill about giving coding agents
+visibility into browser state, followed by a partial recommendations section
+showing the laddering. Paraphrased to illustrate the shape; not a verbatim
+copy of any current skill file.
+
+```
+## Outcomes we are looking for
+
+### Outcome 1: agent can perceive UI state without human translation
+
+The agent should be able to answer "what is on the page right now" using
+the same kind of structured data a human inspector would read, not by
+asking a human to describe a screenshot. When this outcome is missing,
+every UI bug becomes a ping-pong between the agent and the human, and
+the agent's iteration loop stalls.
+
+Evidence signals:
+- The agent can list visible interactive elements with their roles and
+  labels without a human paraphrasing a screenshot.
+- A failing selector produces a diagnostic the agent can act on, not just
+  a generic "element not found".
+
+### Outcome 2: failures arrive as structured signals, not screenshots alone
+
+When a UI action fails, the agent receives console errors, network
+failures, and accessibility-tree state alongside any visual artifact.
+Screenshots are evidence for humans; structured signals are evidence the
+agent can route into its next decision.
+
+Evidence signals:
+- Console errors and failed network requests are captured automatically
+  on test failure.
+- A failure report includes at least one machine-readable artifact in
+  addition to any image.
+
+### Outcome 3: before/after state is diffable
+
+For any UI change the agent makes, the prior and current state can be
+compared without rerunning the whole flow. This keeps regressions cheap
+to detect and keeps "did this change anything I did not intend" answerable
+in seconds.
+
+Evidence signals:
+- Snapshots are stored in a format that diffs cleanly in version control
+  or a review tool.
+- Reverting a change visibly reverts the snapshot, with no manual cleanup.
+```
+
+```
+## Recommended tools and practices (as of 2026-05-13)
+
+### Outcome: agent can perceive UI state without human translation
+
+- Playwright Node SDK via npx playwright. Provides accessibility-tree
+  snapshots (token-cheap structured DOM), screenshots, and console plus
+  network event capture from a single entry point.
+  Ladders up by giving every human inspection action a programmatic
+  equivalent the agent can call directly.
+  Tradeoffs: Node toolchain assumed present; Chromium download on first
+  run can be slow on cold machines.
+
+- Per-invocation Playwright-bundled Chromium rather than a system browser.
+  Ladders up by removing the "is the right browser even installed" question
+  from every iteration, which previously consumed a meaningful share of
+  failed runs.
+  Tradeoffs: larger on-disk footprint; version is pinned to the Playwright
+  release rather than tracking system updates.
+
+### Outcome: failures arrive as structured signals, not screenshots alone
+
+- Default to capturing console messages and network responses on every
+  Playwright run, not only on failure.
+  Ladders up by making the structured-signal path the cheapest path,
+  so the agent never has to retry just to get logs.
+  Tradeoffs: slightly larger artifact directory; trivial to gitignore.
+
+- Emit failure reports as JSON next to any PNG. Ladders up by ensuring
+  the agent always has a machine-readable artifact alongside any human
+  one, even when a screenshot is also produced.
+  Tradeoffs: a small amount of report-formatting code to maintain.
+
+### Outcome: before/after state is diffable
+
+- Snapshot accessibility trees as pretty-printed JSON, not as opaque
+  binary blobs. Ladders up by making "what changed" answerable with a
+  standard diff tool, no custom viewer required.
+  Tradeoffs: slightly more verbose on disk than a binary representation.
+```
+
+Notice what the laddering does. If a future reader replaces Playwright with
+some successor (call it FutureDriver), they can check each bullet: does
+FutureDriver still give every human inspection action a programmatic
+equivalent? Does it still remove the "is the browser installed" question?
+If yes, swap the name and keep the bullet. If no, the bullet needs a real
+rewrite, not just a search and replace.
+
+## Worked example B: testing-coverage
+
+A more generic illustrative example. Outcomes for a skill about keeping
+the codebase mechanically consistent and well-tested:
+
+```
+## Outcomes we are looking for
+
+### Outcome 1: the codebase stays consistently formatted without human review effort
+
+Formatting drift is never a topic in code review. Whatever style the
+project uses, the machine enforces it, so humans (and agents) spend their
+attention on logic instead of whitespace.
+
+Evidence signals:
+- Pull request reviews do not contain formatting comments.
+- A fresh clone, with no manual setup beyond the documented bootstrap,
+  formats on commit automatically.
+
+### Outcome 2: regressions are caught before they reach the integration branch
+
+A change that breaks previously working behavior fails locally or in CI
+before it can land. The team does not rely on manual smoke testing to
+notice regressions.
+
+Evidence signals:
+- Coverage report exists and is published per build.
+- A deliberately broken test case fails the merge gate, not only a
+  later deploy step.
+```
+
+```
+## Recommended tools and practices (as of 2026-05-13)
+
+### Outcome: the codebase stays consistently formatted without human review effort
+
+- Project-standard formatter wired as a pre-commit hook with auto-fix on
+  staged files. Ladders up by making the formatted state the default
+  outcome of a commit, not a thing the contributor has to remember.
+  Tradeoffs: first-commit-after-bootstrap can be slower while the hook
+  warms up.
+
+- Linter run in CI as a blocking check, configured to share the same
+  rule set as the local hook. Ladders up by removing the "works on my
+  machine" gap between local format and merged format.
+  Tradeoffs: two places (local hook, CI) to keep in sync; mitigated by
+  pointing both at the same config file.
+
+### Outcome: regressions are caught before they reach the integration branch
+
+- Coverage tool with a threshold enforced in CI (the project's chosen
+  number, with rationale recorded nearby). Ladders up by making
+  coverage regressions visible at the moment they are introduced, not
+  weeks later.
+  Tradeoffs: thresholds invite gaming via trivial tests; pair with a
+  review norm that values meaningful assertions.
+
+- Pre-merge test run on the same matrix as the release build. Ladders
+  up by ensuring that the gate which protects the integration branch is
+  the same gate that protects releases, removing a class of "passed CI,
+  failed deploy" surprises.
+  Tradeoffs: matrix runs cost CI minutes; revisit if the project's
+  supported surface shrinks.
+```
+
+Both examples share a pattern. The outcomes do not name tools. The
+recommendations name tools but always come back to the outcome they serve.
+A reader can audit the recommendations bullet by bullet by asking only the
+laddering question.
+
+## Anti-patterns in this layer
+
+Observations from skills that have rotted, or that we caught before they
+rotted:
+
+- **Outcomes that name tools.** "Use a structured logger" is not an outcome.
+  The outcome is "the agent can query logs by attribute, not just by string
+  match." When the outcome names the tool, replacing the tool requires
+  rewriting the outcome, which defeats the layering.
+
+- **Recommendations with no laddering.** "We use X." is not enough. Without
+  a "ladders up by" sentence, the reader cannot tell whether X still earns
+  its place. Unmoored recommendations are the first to rot and the hardest
+  to remove, because nobody remembers why they were added.
+
+- **More than seven outcomes per skill.** A skill with twelve outcomes is
+  doing the job of two or three skills. Split it. Each child skill should
+  end up with three to five outcomes and a clearer north star.
+
+- **Outcomes section absent or buried at the bottom of the file.** The
+  outcomes section is the north star. It cannot serve as a north star if
+  the reader has to scroll past two hundred lines to find it. Put it near
+  the top, right after the skill's purpose statement.
+
+- **Outcomes section that contradicts the principles section.** If the
+  principles say "fail fast" and the outcomes describe a system that
+  swallows errors to keep going, the skill is unsure what it stands for.
+  Fix one or the other before adding any recommendations underneath.
+
+- **Undated recommendations section.** Without a date, a reader has no way
+  to judge staleness. The date does not need to be a precise commit time;
+  the YYYY-MM-DD on the section header is enough.
+
+- **Recommendations advocating instead of observing.** "X is the best
+  choice" is advocacy. "X gives us Y, costs us Z, and would be replaced
+  if W appeared" is observation. The second form survives disagreement;
+  the first invites it.
+
+- **Evidence signals that restate the outcome.** "Evidence: the outcome
+  is met" is not a signal. A signal is a checkable fact someone outside
+  the project can verify. If you cannot write the signal as a yes/no
+  question, the outcome is too vague.
+
+## Cross-references
+
+- `skill-template.md`: where the Outcomes section and the Recommended tools
+  and practices section sit in the canonical shape of a skill file.
+- `audit-checklist.md`: the binary checks an auditor runs against a skill,
+  including the laddering audit.
+- `anti-yellow-flags.md`: the broader anti-pattern catalog this document's
+  Anti-patterns section is a focused slice of.

--- a/plugins/meta/skills/authoring-skills/references/skill-template.md
+++ b/plugins/meta/skills/authoring-skills/references/skill-template.md
@@ -1,0 +1,435 @@
+# Skill template: the two canonical shapes
+
+Source: derived from `../SKILL.md` (the `authoring-skills` chassis). This
+document is the canonical reference for the section-by-section shape of skills
+in this plugin. When in doubt about whether a heading belongs, or how long a
+section should be, consult this file.
+
+## Two shapes, one chassis
+
+Every skill in this plugin is one of two types:
+
+1. **Principle doc.** A durable body of knowledge about a concern (security,
+   testing, configuration, architecture, etc.). It is consulted, not invoked.
+   A reviewer or implementer reads it to absorb principles, outcomes, and the
+   current recommended tools. Most skills in this plugin are principle docs.
+
+2. **Procedural skill.** A workflow with a defined input, a numbered sequence
+   of steps, and a defined output. It is invoked to do work. Orchestrators
+   (review fan-outs, merge cycles), maintenance skills (audits, bootstrappers),
+   and setup skills are procedural.
+
+Pick principle-doc when the artifact answers "what does good look like for
+this concern, and how do I recognize it." Pick procedural when the artifact
+answers "run these steps to produce this result." A skill is rarely both. If
+you find yourself wanting both, split into two skills and have the procedural
+one cite the principle doc.
+
+A useful tell: if the natural opening sentence is "When you are reviewing X,
+look for Y," it is a principle doc. If the natural opening is "Given input X,
+produce output Y by doing the following steps," it is procedural.
+
+## Principle-doc shape, section by section
+
+The principle-doc skeleton:
+
+```
+---
+name: <name>
+description: <trigger phrases + contexts + explicit non-triggers>
+---
+
+# Title
+
+## Overview
+## Outcomes we are looking for
+## Principles
+## Anti-patterns
+## Recommended tools and practices (as of YYYY-MM-DD)
+## References
+## Continual improvement
+```
+
+### Overview
+
+What it is for: a one-paragraph durable framing of the concern. Names the
+concern, says why it matters, and gestures at the boundary of what the skill
+covers. The reader should know within five lines whether they are in the
+right document.
+
+Example opening:
+
+```
+Configuration is how a system absorbs change without code edits. Strong
+configuration practice keeps secrets out of source, makes environment-specific
+behavior explicit, validates at startup, and stays discoverable. This skill
+covers env-var layering, typed config objects, and twelve-factor parity.
+```
+
+Does NOT belong: trigger phrases (those live in frontmatter), tool
+recommendations, step-by-step instructions, or rationale for individual rules.
+
+Length budget: one paragraph, three to six sentences.
+
+### Outcomes we are looking for
+
+What it is for: the north-star goals that a reviewer or implementer is trying
+to achieve. Each outcome is a state of the world, not an activity. Each
+outcome carries one or two observable signals so a reviewer can tell whether
+the outcome is met.
+
+Example opening:
+
+```
+### Secrets never appear in source or build artifacts
+Signals: no secret-shaped strings in git history; CI secret scan passes; all
+runtime secrets resolve from a secret store or injected env.
+
+### Configuration is validated at process start, not first use
+Signals: the process exits with a clear error on missing or malformed config;
+no `KeyError` or `undefined` at request time from missing config.
+```
+
+Does NOT belong: tool names (those live under Recommended tools), narrative
+prose, or anti-patterns. Keep outcomes terse and state-shaped.
+
+Length budget: three to five outcomes. Below three suggests the concern is too
+narrow to deserve its own skill. Above five suggests you are mixing two
+concerns.
+
+### Principles
+
+What it is for: the durable HOW. Short, declarative statements of the rules
+that, if followed, tend to produce the outcomes above. Principles outlive any
+particular tool.
+
+Example opening:
+
+```
+- Treat configuration as a typed object, not a bag of strings.
+- Validate the whole config at startup; fail loud, fail early.
+- Separate secret from non-secret config so they can be stored differently.
+- Prefer environment variables for deployment-varying values; prefer files
+  for structure-heavy values.
+```
+
+Does NOT belong: tool-specific guidance (Vault, doppler, etc.), version
+numbers, or anything dated.
+
+Length budget: five to eight principles. More than eight and the reader stops
+internalizing them.
+
+### Anti-patterns
+
+What it is for: observational descriptions of common failure modes. Phrased
+as patterns to recognize, not commands to follow.
+
+Example opening:
+
+```
+- `.env` files committed to git, even under `.env.example` aliases that
+  accidentally contain real values.
+- Reading `os.environ` ad hoc throughout the codebase rather than through a
+  single typed config object.
+- Defaulting secrets to empty strings, hiding misconfiguration until a 401
+  appears in production.
+```
+
+Does NOT belong: imperative commands ("do not commit secrets"). Write them as
+patterns you can spot in a diff: "Secrets defaulted to empty strings."
+
+Length budget: six to twelve. Fewer than six and the skill cannot anchor a
+review; more than twelve and the list becomes unscannable.
+
+### Recommended tools and practices (as of YYYY-MM-DD)
+
+What it is for: the current, dated, opinionated set of concrete tools and
+practices. Grouped under the outcome each recommendation ladders up to (see
+`outcomes-laddering.md`). The date in the heading signals that this section
+ages and must be refreshed.
+
+Example opening:
+
+```
+(as of 2026-05-13)
+
+### For: Secrets never appear in source or build artifacts
+- Use `gitleaks` as a pre-commit hook and in CI.
+- Store runtime secrets in 1Password or AWS Secrets Manager; inject at
+  deploy time, never at build time.
+
+### For: Configuration is validated at process start, not first use
+- Use `pydantic-settings` (Python) or `zod` (TypeScript) for typed config
+  with startup validation.
+```
+
+Does NOT belong: undated recommendations, principles restated as tools, or
+tools without a parent outcome.
+
+Length budget: roughly two to five recommendations per outcome. Total often
+lands at fifteen to twenty-five bullets.
+
+### References
+
+What it is for: pointers to the `references/` directory, plus authoritative
+external links. One line per reference, with a short gloss.
+
+Example opening:
+
+```
+- `references/secret-rotation-runbook.md`: rotation procedure for each store.
+- `references/twelve-factor-summary.md`: condensed version of the twelve-
+  factor config chapter.
+- https://12factor.net/config (canonical source)
+```
+
+Length budget: as long as needed, but each entry must earn its line.
+
+### Continual improvement
+
+What it is for: a single link to the GitHub issue tracker or discussions page
+where readers can file drift, gaps, or proposed updates. Standardized across
+skills so contributors know where to send feedback.
+
+Example:
+
+```
+File drift, gaps, or proposed updates at
+https://github.com/AgentParadise/harness-engineering/issues
+```
+
+Length budget: one to three lines.
+
+## Procedural-skill shape, section by section
+
+The procedural skeleton:
+
+```
+---
+name: <name>
+description: <trigger phrases for the procedure being invoked>
+---
+
+# Title
+## When to Use (and When NOT to Use)
+## Input
+## Workflow
+## Output
+## Outcomes we are looking for
+## Recommended tools and practices (as of YYYY-MM-DD)
+## References
+## Continual improvement
+```
+
+### When to Use (and When NOT to Use)
+
+What it is for: a short decision aid. Two bulleted lists: when to invoke this
+procedure, and when not to. The "not to" list is what prevents misrouting.
+
+Example opening:
+
+```
+Use when:
+- A pull request is ready for human review and you want a mechanical pre-pass.
+- You are auditing a long-lived branch before merge.
+
+Do NOT use when:
+- The change is a docs-only edit (use `docs-review` instead).
+- The branch has unresolved merge conflicts (resolve first).
+```
+
+Length budget: two to five bullets per list.
+
+### Input
+
+What it is for: the precondition. What the caller must provide, what state
+the workspace must be in, what credentials or context must exist.
+
+Example opening:
+
+```
+- A git branch with committed changes, rebased on the target branch.
+- `gh` authenticated for the target repo.
+- Optional: a path filter to scope the review.
+```
+
+Length budget: three to eight bullets.
+
+### Workflow
+
+What it is for: the numbered procedure. Each step is imperative, concrete,
+and verifiable. Sub-steps allowed when a step decomposes naturally.
+
+Example opening:
+
+```
+1. Resolve the diff range with `git merge-base` and capture the file list.
+2. For each leverage-point skill, dispatch a parallel review agent scoped to
+   the changed files.
+3. Aggregate findings by severity; deduplicate cross-skill overlaps.
+4. Emit a single review comment with grouped findings.
+```
+
+Does NOT belong: rationale paragraphs (push those to References), or
+principles dressed up as steps.
+
+Length budget: four to twelve top-level steps. Longer workflows should be
+split into phases or sub-procedures.
+
+### Output
+
+What it is for: the postcondition. What artifact, file, comment, or state
+change the caller can expect on success. Also: exit codes or status values if
+the procedure is invoked programmatically.
+
+Example opening:
+
+```
+- A single PR review comment containing grouped findings.
+- Exit status: `DONE`, `DONE_WITH_CONCERNS`, or `BLOCKED`.
+- No files committed; no branches pushed.
+```
+
+Length budget: two to six bullets.
+
+### Outcomes we are looking for
+
+Procedural skills may carry Outcomes when the procedure has a clear north
+star. For a review orchestrator, the outcome is something like "the codebase
+is audited mechanically with no findings missed." For a setup procedure, the
+outcome is "a fresh contributor reaches a green test run in one command."
+
+Skip this section if the procedure is purely mechanical and has no judgment
+component (e.g., a file-renamer).
+
+Length budget: one to three outcomes when present.
+
+### Recommended tools and practices (as of YYYY-MM-DD)
+
+Same shape as principle-doc. Dated, laddered under outcomes when outcomes
+exist, otherwise grouped by workflow phase.
+
+### References and Continual improvement
+
+Same shape as principle-doc.
+
+## Frontmatter rules
+
+The YAML frontmatter is required at the top of every `SKILL.md`. It has
+exactly two fields:
+
+```
+---
+name: <kebab-case-name>
+description: <routing description>
+---
+```
+
+Rules:
+
+- `name` must be kebab-case (lowercase, hyphen-separated).
+- `name` must match the directory name exactly. The skill at
+  `skills/authoring-skills/SKILL.md` has `name: authoring-skills`.
+- `description` carries all the routing weight. It must include trigger
+  phrases (verbs and nouns the user is likely to say), the contexts where the
+  skill applies, and explicit non-triggers when the skill is easily confused
+  with a sibling.
+- No other top-level frontmatter fields are permitted. Versioning, owners,
+  and metadata live elsewhere (in a manifest or in the README).
+
+For the full trigger-phrase grammar, see `description-trigger-rules.md`.
+
+## Bundled resources
+
+A skill may ship with sibling directories alongside `SKILL.md`:
+
+### `references/`
+
+Use for: durable supplementary documentation that the `SKILL.md` cites but
+that would bloat it past the length guardrail. Section deep-dives,
+checklists, templates, worked examples.
+
+Naming: kebab-case `.md` files. Names should be nouns or noun phrases
+(`audit-checklist.md`, `outcomes-laddering.md`), not verbs.
+
+### `scripts/`
+
+Use for: executable helpers that the workflow steps invoke. Bash, Python, or
+Node scripts. Each script should be self-contained, with a header comment
+describing input, output, and any environment requirements.
+
+Naming: kebab-case with an extension (`run-audit.sh`, `aggregate-findings.py`).
+
+### `assets/`
+
+Use for: non-executable, non-Markdown artifacts that the skill ships:
+templates, prompt snippets, sample YAML, fixture files, images used by
+references.
+
+Naming: descriptive, with the appropriate extension. Group by purpose when
+the directory grows beyond ten files.
+
+A skill with no bundled resources is fine. Do not create empty directories.
+
+## Example openings
+
+### Principle-doc example
+
+```
+---
+name: cache-discipline
+description: Use when reviewing caching concerns: cache key design, TTL
+  selection, invalidation strategy, stampede protection, negative caching,
+  observability of hit/miss rates. Not for CDN configuration (see
+  `edge-delivery`) or database query plans (see `query-performance`).
+---
+
+# Cache discipline
+
+## Overview
+Caching trades freshness for latency and cost. Strong caching practice makes
+that trade explicit per cache, names every key, bounds every TTL, and exposes
+hit/miss rates as first-class telemetry.
+```
+
+### Procedural-skill example
+
+```
+---
+name: release-cut
+description: Use to cut a versioned release: tag the commit, generate the
+  changelog, publish artifacts, and open a release PR. Not for hotfixes (see
+  `hotfix-flow`) or pre-release tags (see `prerelease-cut`).
+---
+
+# Release cut
+
+## When to Use (and When NOT to Use)
+Use when the release branch is green and the changelog draft is approved.
+Do NOT use for hotfixes or pre-release tags.
+```
+
+## Length guardrails
+
+- **Soft cap: 500 lines** for `SKILL.md`. Above that, move material to
+  `references/` and cite it. The chassis is meant to be skimmable in one pass.
+- **Soft floor: 80 lines.** Below 80 lines often means the skill is too thin
+  to stand alone. Consider merging with a neighbor, or expanding Outcomes
+  and Anti-patterns until the skill earns its place.
+- Individual sections have their own budgets (see above). Treat them as soft
+  guidance, not hard limits, but be suspicious of any section that grows past
+  twice its budget.
+- `references/` files have no hard cap, but each should still be focused on
+  one topic. Split when a file grows past 500 lines.
+
+## Cross-references with siblings
+
+- For the trigger-phrase grammar that goes in the `description` field, see
+  `description-trigger-rules.md`.
+- For the outcomes-to-recommendations laddering pattern (how each tool
+  recommendation cites the outcome it ladders up to), see
+  `outcomes-laddering.md`.
+- For the audit checklist used to verify an existing skill against this
+  chassis, see `audit-checklist.md`.
+- For Anthropic's underlying guidance on skill authoring (the upstream
+  philosophy this chassis specializes), see `anthropic-skill-creator.md`.


### PR DESCRIPTION
## What

Ports the canonical authoring-skills chassis from AgentParadise/harness-engineering to two locations in this repo:

1. `.claude/skills/authoring-skills/` (repo-local meta scope, for authors writing skills inside this repo)
2. `plugins/meta/skills/authoring-skills/` (meta plugin export, for downstream installers)

## Why both

The .claude/skills/ copy serves authors writing in this repo. The plugins/meta/ copy is what other repos consume when they install our meta plugin. Lockstepped until the publishing story picks one as canonical.

## Why this skill

authoring-skills is the chassis that makes skill quality mechanically auditable. It defines:

- frontmatter routing rules (description shape, 5+ trigger phrases, explicit non-triggers)
- body structure for principle-doc vs procedural skills
- a 30+ item audit checklist
- the outcomes-laddering pattern (durable goals separate from tool-layer recommendations)

Having it inside this repo means every skill we author here gets the chassis on autopilot.

## Diff shape

14 files added under two parallel directory trees. Zero modifications to existing files.

## One downstream tweak

references/audit-checklist.md rule 32 (no em-dashes) was rewritten to use Perl-mode grep with \\x{2014} so the rule self-references the character without containing it. Keeps this repo em-dash-free.

## Related

- Upstream PR on the canonical chassis: AgentParadise/harness-engineering#1 (placement frontmatter)
- Sibling port: syntropic137/software-leverage-points (same skill, .claude scope only)