### PR TITLE
plugin(experiments): new dedicated plugin for hypothesis-first experiments

### DIFF
--- a/plugins/experiments/.claude-plugin/plugin.json
+++ b/plugins/experiments/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "experiments",
+  "version": "1.0.0",
+  "description": "Hypothesis-first experiment workflow. Scaffolding, eval packs, results, verdicts, and the two-commit discipline.",
+  "author": {
+    "name": "NeuralEmpowerment"
+  },
+  "repository": "https://github.com/AgentParadise/agentic-primitives"
+}

--- a/plugins/experiments/README.md
+++ b/plugins/experiments/README.md
@@ -1,0 +1,27 @@
+# experiments plugin
+
+A plugin for running hypothesis-first experiments inside any repo.
+
+## What this plugin provides
+
+- **`running-experiments` skill** (under `skills/running-experiments/`):
+  The canonical workflow for creating, scaffolding, executing, scoring,
+  and auditing an experiment. Covers the four-file layout (README,
+  eval-pack, results, verdict), the verdict vocabulary (go, no-go,
+  inconclusive), and the two-commit rule.
+
+The skill body is generic. Repo-specific conventions (folder root,
+status-matrix paths, retrospective layout) belong in each consumer
+repo's CLAUDE.md, not in this skill.
+
+## Why a dedicated plugin instead of a meta skill
+
+Experiments are a first-class domain concern with their own
+vocabulary, discipline, and tooling surface. The plugin shape gives
+future tooling (eval-pack generator, status linter, results
+aggregator) a home without bloating the meta plugin.
+
+## See also
+
+- `plugins/meta/skills/authoring-skills/` -- the chassis for writing
+  the skill in this plugin (and any other skill).

--- a/plugins/experiments/skills/running-experiments/SKILL.md
+++ b/plugins/experiments/skills/running-experiments/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: running-experiments
+description: Use when creating, scaffolding, executing, scoring, or auditing a hypothesis-first experiment in any repo that follows the `experiments/<date>--<slug>/` convention, OR when capturing a prospective experiment as a proposal under `docs/experiments/proposals/`. Trigger phrases include "new experiment", "new probe", "run an experiment", "score the probe", "write the verdict", "hypothesis first", "design the eval pack", "two-commit rule", "hypothesis scorecard", "write a retrospective for", "is this an experiment", "capture this as a proposal", "prospective experiment", "lock this idea", "promote this proposal". Covers the four-file layout (README, eval-pack, results, verdict), the verdict vocabulary (go, no-go, inconclusive), the proposal lifecycle (`docs/experiments/proposals/<slug>.md` then promoted to a real experiment), and the relationship between an experiment and its retrospective under `docs/retrospectives/`. Do NOT use for: ad-hoc debugging sessions, code review, skill authoring (see `authoring-skills`), or domain-specific probes that have their own workbench skill (those repos extend this skill with daemon/bank machinery of their own).
+placement: "Domain skill. Install in `plugins/<domain-plugin>/skills/<name>/` (the canonical home in plugin-structured repos; this skill lives at `plugins/experiments/skills/running-experiments/` in agentic-primitives) or `skills/<name>/` (in flat-structured repos). NOT in `.claude/skills/`. That scope is reserved for meta skills that teach how to author other skills."
+---
+
+# Running experiments
+
+## Overview
+
+An experiment is a falsifiable probe: a predicted outcome committed before any data is collected, a frozen eval pack, runs that produce evidence, and a verdict that scores both the hypothesis and the question. Two commits per experiment (`hypothesis for <slug>`, then `run <slug> (<verdict>)`) make the timeline auditable. The result lands in a retrospective (canonical path: `docs/retrospectives/NNN-<topic>.md`) so the lesson outlives the probe folder.
+
+This skill is the contract for that loop. Drafting, running, scoring, and auditing all live here. Repo-specific paths (where retrospectives live, what the status matrix looks like, which canonical scripts to use) belong in each consumer repo's CLAUDE.md or AGENTS.md; this skill provides the durable methodology, not the per-repo conventions.
+
+## Outcomes we are looking for
+
+Durable goals. Each has 1-2 signals a reviewer can check later.
+
+### Outcome 1: predictions precede data
+
+The commit timestamp on `hypothesis for <slug>` is older than every file in `runs/`. Without this anchor, scoring degenerates into storytelling.
+
+- *Signal:* `git log --diff-filter=A -- experiments/<slug>/README.md` predates any `experiments/<slug>/runs/**` file.
+- *Signal:* the README's `## Hypothesis` section contains predicted numbers, directions, or failure modes -- not "the system will work."
+
+### Outcome 2: experiments are comparable across time
+
+Slug shape, four-file layout, and verdict vocabulary are uniform, so a reader six months later can scan `experiments/` and find what they need.
+
+- *Signal:* folder name matches `YYYY-MM-DD--<slug-with-double-dash-segments>`.
+- *Signal:* each experiment has all four files: `README.md`, `eval-pack.md`, `results.md`, `verdict.md`.
+
+### Outcome 3: load-bearing claims have evidence
+
+Any claim in `docs/evolution/` or a retrospective that drives an architectural decision points back to a specific experiment artifact.
+
+- *Signal:* claims of the form "X saves Y%" cite a path under `experiments/<slug>/runs/`.
+- *Signal:* the cited artifact exists and contains the number being quoted.
+
+### Outcome 4: wrong predictions get the headline
+
+A scorecard of 5/5 correct is a warning, not a victory -- it usually means the hypothesis was written after the run, or the question was obvious. Misses are where the learning lives.
+
+- *Signal:* `verdict.md` has a `## Hypothesis scorecard` section that names misses with one-line reasons.
+- *Signal:* the executive summary and retrospective for the probe foreground what was wrong, not what was right.
+
+### Outcome 5: scope is honest
+
+An experiment is for a question whose outcome you don't already know. Debugging, code reading, and feature implementation are not experiments and don't belong under `experiments/`.
+
+- *Signal:* the README's `## Question` section names a falsifiable claim, not a task.
+- *Signal:* declared mapping probes (no hypothesis) are explicit about that exemption, not silently hiding it.
+
+## Principles
+
+1. **Hypothesis-first commit is the falsifiability anchor.** A separate commit before any `runs/` artifact is the only mechanical proof that the prediction preceded the data. Honor-system "I predicted this" claims are not auditable. The first commit message is `experiments: hypothesis for <slug>`.
+
+2. **No smoke testing before the hypothesis commit.** A "let me verify the setup works" run leaks the answer. Verify the setup by *reading* code, configs, and the `_template/README.md` pre-flight checklist -- not by running the experiment.
+
+3. **The eval pack is frozen.** Once `eval-pack.md` is committed alongside the hypothesis, mid-experiment edits invalidate the run. If the pack is wrong, start a new probe; don't rewrite the spec to match what you observed.
+
+4. **Conditions exist to isolate one variable at a time.** A one-condition probe can show whether something *worked*, but not whether it was *the system* that worked vs. the baseline drift. Pair every claim that "X helps" with a condition that exercises the alternative.
+
+5. **Verdicts are tied to evidence, not impressions.** `go` / `no-go` / `inconclusive` each cites paths under `runs/`. `inconclusive` is a real verdict, not a copout -- use it freely and follow up with a sharper probe.
+
+6. **Tool guidance is dated and isolated.** Specific commands (`pnpm harness boot --bug …`, `rtk pnpm …`, LogsQL projections) live in `## Recommended tools and practices` so they can rot without taking the principles down with them.
+
+## Anti-patterns
+
+Observations from probe audits. Each names a failure mode an auditor can spot in a real folder.
+
+- **Scorecard 100% correct.** The auditor sees every prediction marked ✅ in `verdict.md`. This means the hypothesis was written after the run or the question was trivial. Either way, the probe didn't earn its keep.
+
+- **`runs/` files older than the hypothesis commit.** `git log -- experiments/<slug>/` shows runs predating `experiments: hypothesis for <slug>`. The two-commit rule was violated; falsifiability is gone.
+
+- **Smoke-test fingerprints in the hypothesis.** The README hedges with words like "as we observed in early runs" -- meaning the hypothesis was edited after looking at data. Smoke-testing leaked the result.
+
+- **One-condition probe with a comparative claim.** `verdict.md` says "X is 80% faster" but `eval-pack.md` only exercised X -- no baseline, no alternative. The number is unfalsifiable.
+
+- **Magic numbers without evidence paths.** `results.md` headline table cites "11.9× reduction" with no link to a `runs/` artifact. The number could be invented and no one would know.
+
+- **Debugging stuffed into `experiments/`.** The README's question is "why is the layout broken?" instead of "does technique X catch layout breaks within Y wall-clock?". This is a debugging session, not an experiment.
+
+- **Mid-experiment eval-pack edits.** `git log -- experiments/<slug>/eval-pack.md` shows edits after the first `runs/` file. The frozen-spec rule was violated.
+
+- **Tool churn rotting principles.** Removing a specific command (say, an RTK invocation) breaks half the skill body because tool guidance was woven through the structural sections. Dated `## Recommended tools and practices` exists to prevent exactly this.
+
+## Recommended tools and practices (as of 2026-05-13)
+
+Concrete commands, harness toggles, and patterns. When a tool here is replaced, edit only this section.
+
+### Outcome: predictions precede data
+
+- **Scaffold from the template.** `cp -R experiments/_template experiments/<slug>` then fill `README.md` only -- leave `runs/` empty. Ladders up by separating spec-time work from data-time work.
+- **Run the `_template/README.md` pre-flight checklist before committing the hypothesis.** Clean working tree, known stack state, empty `.harness/artifacts/<iso_key>/`, documented tool versions. Ladders up by ruling out confounds before they corrupt the hypothesis. See `references/preflight.md`.
+- **First commit is `experiments: hypothesis for <slug>`.** No other files in this commit beyond the four scaffolded files. Ladders up by making the timeline mechanical.
+
+### Outcome: experiments are comparable across time
+
+- **Slug shape: `YYYY-MM-DD--<dimension>--<short-question>`.** Today's date, kebab-case. Examples in `experiments/` are the canonical references. Ladders up by giving folder listings a stable scannable shape.
+- **Four files exactly: `README.md` (question + hypothesis + setup), `eval-pack.md` (frozen probe set), `results.md` (per-probe scoring), `verdict.md` (go/no-go/inconclusive + scorecard).** Ladders up by making cross-probe comparison mechanical.
+
+### Outcome: load-bearing claims have evidence
+
+- **Headline numbers in a table at the top of `results.md`.** Each row cites a path under `runs/`. Ladders up by making evidence-or-fabrication a one-glance audit.
+- **Retrospective under `docs/retrospectives/NNN-<topic>.md`** when the probe changes how we work. Cross-link from the verdict. Ladders up by giving the lesson somewhere stable to live after the probe folder ages out of attention.
+
+### Outcome: wrong predictions get the headline
+
+- **`## Hypothesis scorecard` table in `verdict.md`** with predicted / observed / score / notes per prediction. Misses are flagged 🟡 partial or ❌ wrong with a one-line reason. See `references/scorecard-template.md`.
+- **Second commit is `experiments: run <slug> (<verdict>)`.** This commit contains `eval-pack.md` (final), `runs/`, `results.md`, `verdict.md`, and any retrospective updates. Two commits per experiment, never more for the spec/result split. Ladders up by keeping the audit trail clean.
+
+### Outcome: scope is honest
+
+- **Mapping probes (no hypothesis) declare the exemption.** Add a `## No hypothesis (mapping probe)` section to the README and skip the scorecard. Ladders up by making the exemption visible rather than silent.
+- **Audit a candidate experiment against the "When NOT" list before scaffolding.** See `references/audit-checklist.md`. Ladders up by catching debugging-disguised-as-experiment at intake.
+
+## Intake: the FOCUS gate
+
+Before scaffolding, the candidate experiment must pass FOCUS. FOCUS is borrowed from AI-pilot design (Schneider Electric and the broader "designing successful AI pilots" literature); it transfers cleanly to harness probes because both share the same risk: spending real time and tokens on a question whose answer won't change anything. Each letter is a gate, not a wish -- if the answer is "I don't know" or "no," fix that first or drop the probe.
+
+| Gate | Question for a harness-lab probe | Failure mode if you skip it |
+|---|---|---|
+| **F**it | Does this question fit a current strategic priority (the active `docs/evolution/v0.X.Y` cycle, a known cost/wall-clock claim under load, or a documented gap)? | Probes that don't fit produce results no one acts on; the verdict ages out unread. |
+| **O**rganization pull | Will the result get used? Is there a decision waiting on this evidence (a tool adoption, a skill rewrite, a removed dependency)? | Without a downstream decision, the probe is a curiosity, not leverage. |
+| **C**apability readiness | Do we have the tooling and skills to actually run the eval pack -- the right harness toggles, observability queries, evidence-capture scripts? | Mid-probe tool gaps turn into yak-shaving and contaminate the run. |
+| **U**nderlying data | Is the measurable data available and ready (logs/metrics/traces wired, baseline numbers captured, a clean stack state) and is the *baseline* defined before the run? | "Before and after" without a captured "before" is just "after." Baseline is the comparative anchor; without it you have anecdotes. |
+| **S**uccess | Can the probe baseline the current state and measure impact against a predefined success metric (numbers, directions, failure modes)? | If success is undefined at hypothesis time, the verdict will be retrofitted to the data -- see anti-pattern "scorecard 100% correct." |
+
+**Pilot-design adaptations.** Successful AI pilots use clear boundaries, appropriate duration, and predefined success metrics. For harness-lab probes:
+
+- **Clear boundaries** = the frozen eval pack. The pack states the universe under test; everything outside is explicitly out of scope and goes in a follow-up probe.
+- **Appropriate duration** = time-box per probe. An organizational pilot runs 8-12 weeks; a harness probe usually runs hours to a few days. If a probe drags past a working week, split it. "Long enough to collect meaningful data, short enough to show wins" applies to both scales.
+- **Predefined success metrics** = the hypothesis's predicted numbers, committed before any `runs/` artifact. Schneider Electric's contact-generation pilot worked because the before/after metric was defined before deploying Copilot -- same anchor here.
+- **Structured feedback mechanisms** = the retrospective under `docs/retrospectives/` and the executive summary update. Insights captured continuously across probes are what let the next probe build on the last instead of relitigating it.
+
+If a candidate fails one or more FOCUS gates, the move is rarely "run a sloppier probe." It's: capture the missing piece (priority, decision, tooling, baseline, metric) first, then come back. Or write a smaller mapping probe to surface the missing piece deliberately.
+
+## Prospective experiments (proposals)
+
+Not every idea is ready to run. A real experiment costs hours of agent + human time and locks in a frozen eval pack. Skipping the proposal step for half-formed ideas pollutes `experiments/` with hypotheses no one acts on -- exactly the "Fit / Organization pull" FOCUS failure mode.
+
+**A proposal is a captured idea that's hypothesis-shaped but not on the running queue.** It lives at `docs/experiments/proposals/<YYYY-MM-DD>--<slug>.md` and holds enough context that a future reader (human or agent) can decide whether to promote it to a real experiment without re-deriving the thinking.
+
+### When to write a proposal vs. scaffold an experiment
+
+| Situation | Write a proposal | Scaffold an experiment |
+|---|---|---|
+| Idea surfaced mid-conversation; we want to capture it before it's lost | ✓ | ✗ |
+| FOCUS gate currently fails on Fit, Organization pull, or Underlying data | ✓ (capture; revisit when the gate clears) | ✗ |
+| We've committed to running this next or now | ✗ | ✓ |
+| We're deciding between several adjacent ideas and want to see them side-by-side | ✓ (write proposals for each, then pick) | ✗ until picked |
+| The work would be obvious enough that a frozen eval pack doesn't add value (a pure refactor, a doc fix, an upstream version bump) | ✗ (just commit it; it's not an experiment at all) | ✗ |
+
+### Proposal file format
+
+Lightweight by design. Each `docs/experiments/proposals/<slug>.md` has these sections:
+
+```markdown
+# Proposal: <slug>
+
+**Status:** proposed
+**Captured:** YYYY-MM-DD
+**Triggered by:** (conversation, observation, or external signal that surfaced this)
+
+## Question
+   One sentence. Same shape as the experiment README's Question.
+
+## Why it matters (cost of not knowing)
+   What decision would the experiment's result inform? What's the downside
+   of running blind / continuing without an answer?
+
+## What running it would look like
+   - Implementation sketch
+   - Predicted numbers / bands / failure modes
+   - Eval-pack shape (probes, conditions, what would invalidate the run)
+
+## What this proposal explicitly does NOT cover
+   Scoping fence. Sibling proposals if relevant.
+
+## What promotes this from proposal to experiment
+   The condition that would move it from `docs/experiments/proposals/` to `experiments/`.
+   Often: a downstream decision needing the data, a related arc landing,
+   or an explicit user-pulled "run this next."
+
+## References
+   Other proposals, prior experiments, retrospectives, or code that this
+   proposal builds on or against.
+```
+
+See `docs/experiments/proposals/2026-05-14--identifier-uniqueness-vs-lsp-for-agent-navigation.md` for a canonical example.
+
+### Promotion lifecycle
+
+```
+docs/experiments/proposals/<slug>.md
+        │
+        │  ← User or arc planning explicitly says "run this next."
+        ▼
+experiments/<YYYY-MM-DD>--<slug>/  (scaffold from _template; copy Question + Predictions from proposal)
+        │
+        │  ← Two-commit rule from here: hypothesis, run, verdict.
+        ▼
+docs/retrospectives/NNN-<topic>.md (if the result changes how we work)
+```
+
+After promotion, the proposal stays as a **captured-context record** with a link to the experiment, or gets archived. The proposal's "What promotes…" section becomes a useful history of *why* this experiment was prioritized when it was. Don't delete proposals just because they got promoted -- the captured triggering context is the cheap part of the audit trail.
+
+### What proposals are NOT
+
+- A backlog to grind through. Proposals accumulate; only some get promoted; that's fine.
+- A substitute for the hypothesis-first commit. Promotion still requires the two-commit rule.
+- A retrospective replacement. Retros are post-run lessons; proposals are pre-run framing.
+- A todo list. The breadcrumb (`docs/v0.X-next-steps.md` per active arc) is for "items we plan to run next, in order." Proposals are "ideas captured; promotion timing TBD."
+
+## How to use this skill: authoring mode
+
+0. **Check `docs/experiments/proposals/` first.** If a proposal for this idea already exists, copy its Question and "What running it would look like" into the new experiment README rather than re-deriving them; the proposal's framing is usually richer than a from-scratch first draft. Update the proposal's status to `promoted` with a link to the experiment.
+1. Walk the FOCUS gate above. If any gate fails, address it before scaffolding -- don't proceed with a known-weak probe. **If the gate fails on Fit / Organization pull / Underlying data, write a `docs/experiments/proposals/<slug>.md` instead and stop.** Promotion can happen later when the gate clears.
+2. Audit the candidate against `references/audit-checklist.md` -- is this actually an experiment? If not, stop here.
+3. Pick the slug: `YYYY-MM-DD--<dimension>--<short-question>`.
+4. `cp -R experiments/_template experiments/<slug>`.
+5. Walk the `_template/README.md` pre-flight checklist (`references/preflight.md`). Resolve every confound or document it as part of Setup.
+6. Fill `README.md` (question, hypothesis with predicted numbers, setup, conditions, expected signals) and `eval-pack.md` (frozen probe set).
+7. Commit: `experiments: hypothesis for <slug>`. No other files. No smoke test before this.
+8. Run the eval pack. Write to `runs/`. Score in `results.md` with evidence links.
+9. Write `verdict.md` with verdict and `## Hypothesis scorecard`. Wrong predictions get the headline.
+10. If the result changes how we work, write `docs/retrospectives/NNN-<topic>.md` and cross-link.
+11. Update the status matrix in the root `README.md` if applicable.
+12. Commit: `experiments: run <slug> (<verdict>)`.
+
+## How to use this skill: audit mode
+
+1. Open `experiments/<slug>/` and walk `references/audit-checklist.md` top to bottom.
+2. For each fail, identify the smallest change that closes the gap. If `runs/` predates the hypothesis commit, the probe is unsalvageable -- record the finding in the retrospective and move on; don't backfill timestamps.
+3. Audit the retrospective (if any) against its cited evidence paths. Broken links mean the lesson is floating.
+4. If multiple probes fail the same criterion, the criterion may need refinement -- flag in `references/audit-checklist.md` rather than working around it per-probe.
+
+## References
+
+- `references/preflight.md`: the pre-flight checklist from `_template/README.md`, with rationale per item and the retrospective each one came from.
+- `references/scorecard-template.md`: canonical `## Hypothesis scorecard` table shape with worked examples (predicted right, partial, wrong).
+- `references/canonical-scripts.md`: example shell patterns for running probes against the harness stack (boot with bug toggle, LogsQL projection queries, before-after evidence capture).
+- `references/audit-checklist.md`: binary pass-fail criteria for an experiment folder, walkable top to bottom.
+
+## Cross-references
+
+- **Skill authoring chassis:** `../../../../../AgentParadise/harness-engineering/skills/authoring-skills/SKILL.md` -- the contract this skill itself was written against. Read it before refactoring this file.
+- **Repo conventions:** `docs/AGENTS.md` for the agent runbook; `docs/evolution/` for the current synthesis; `docs/retrospectives/` for prior lessons; `experiments/_template/` for the scaffold.
+
+## Parallel via worktrees (added 2026-05-14 from EXP-25)
+
+When ≥3 experiments are independent and you have orchestrator budget for parallel dispatch, run them in isolated git worktrees with delegated subagents. Measured 2.08× speedup, zero merge conflicts, 1.0× token-cost ratio (no overhead) -- see retro 017.
+
+### When to use this pattern
+
+- **Yes:** ≥3 independent experiments, each with a clear hypothesis-first README committed, disjoint tree areas, distinct branches.
+- **Probably:** 2 independent experiments where wall-clock dominates token cost (UE-class probes, long builds).
+- **No:** experiments that share files, where one's verdict gates another's hypothesis, or where a single eval pack covers multiple probes.
+
+### The orchestrator's contract
+
+1. **Commit all hypotheses together first.** One commit on the arc branch with every README. The shared SHA is the timeline anchor for every subagent's `runs/`.
+2. **Create one worktree per experiment.** Naming: `../<repo>-<slug>` for the directory, `feat/exp-N-<slug>` for the branch.
+3. **Dispatch in one batch.** Use the Agent tool with `run_in_background: true`; send all dispatches in a single message.
+4. **Charter template** (each subagent gets a self-contained prompt):
+   - Working directory (the worktree path) -- explicit `cd` instruction.
+   - Pointer to its README and the hypothesis-commit SHA.
+   - Method bullets (don't make the subagent reinterpret the README from scratch -- extract the runnable steps).
+   - Hard wall-clock budget with explicit "at budget, write inconclusive and stop" instruction.
+   - Constraints carried over from CLAUDE.md (bracket env access, 100% coverage rule, etc.).
+   - Final-report format: ≤200 words, fixed schema (verdict, wall-clock, scorecard counts, headline numbers, last-commit SHA, blockers).
+5. **Measure from the orchestrator's perspective.** Real time = dispatch-to-task-notification. Subagent-reported "wall-clock" is its perceived effort, not real time -- useful for the subagent's own scorecard, not for the meta-measurement.
+
+### High-risk experiment requirement: pre-flight env probe
+
+For experiments touching new languages / engines / heavy installs (UE, Unity, Blender, large LLM models, etc.), the README's Method section MUST start with an env probe:
+
+- Check for the required binary / SDK / toolchain at known install paths.
+- If absent, the subagent writes `results.md` documenting the missing pieces + re-run trigger, then stops. Verdict = `inconclusive` with blocker tree.
+- This is BETTER than a long grind ending in the same answer. Examples: EXP-22 returned in 85s with a complete UE re-run trigger.
+
+### Integration step
+
+1. After all subagents return: `git merge --no-ff feat/exp-N-<slug>` from the arc branch.
+2. **Conflict count is a measurement.** Zero conflicts confirms the disjoint-tree-areas hypothesis. Non-zero conflicts means the experiments overlapped unexpectedly -- investigate before merging.
+3. Run the full verification (`pnpm -r typecheck && pnpm -r test && biome check .`) on the integrated branch.
+4. Score the meta-experiment if there is one (see EXP-25 for the canonical scorecard shape).
+
+### What this pattern does NOT cover
+
+- Cross-machine orchestration (CI / cloud). The orchestrator and worktrees share a filesystem today.
+- Experiments with shared mutable state (a single database, a single port range outside the harness's hash-based allocation).
+- Quality assessment of the subagent's verdict -- that's a separate measurement question.

--- a/plugins/experiments/skills/running-experiments/references/audit-checklist.md
+++ b/plugins/experiments/skills/running-experiments/references/audit-checklist.md
@@ -1,0 +1,59 @@
+# Experiment audit checklist
+
+Binary pass/fail per criterion. Walk top to bottom. A clean experiment passes every box. The checklist also doubles as an intake filter: if a candidate can't plausibly pass §1, don't scaffold.
+
+## §1. FOCUS intake gates
+
+- [ ] **Fit** -- the question maps to an active priority in `docs/evolution/v0.X.Y` or a documented gap.
+- [ ] **Organization pull** -- a downstream decision is waiting on this evidence (adoption, removal, rewrite).
+- [ ] **Capability readiness** -- harness toggles, observability queries, and evidence-capture scripts the probe needs all exist and work.
+- [ ] **Underlying data** -- baseline is captured (or capturable) before the run; logs/metrics/traces wired for the conditions under test.
+- [ ] **Success** -- the README's hypothesis names predicted numbers, directions, or failure modes -- not "it will work."
+
+## §2. Folder shape
+
+- [ ] Folder name matches `YYYY-MM-DD--<slug>--<short-question>` (kebab-case, double-dash segments, today's date).
+- [ ] All four files present: `README.md`, `eval-pack.md`, `results.md`, `verdict.md`.
+- [ ] `runs/` exists and contains the raw evidence artifacts.
+
+## §3. Two-commit rule
+
+- [ ] `git log --diff-filter=A -- experiments/<slug>/README.md` predates every file under `experiments/<slug>/runs/`.
+- [ ] A commit message exactly matching `experiments: hypothesis for <slug>` exists.
+- [ ] A second commit message matching `experiments: run <slug> (<verdict>)` exists, with `runs/`, `results.md`, `verdict.md` in that commit.
+- [ ] `eval-pack.md` has no edits after the first `runs/` file's commit (the pack was frozen).
+
+## §4. Hypothesis quality
+
+- [ ] Hypothesis includes at least one predicted number OR direction OR failure mode.
+- [ ] If declared as a mapping probe (no hypothesis), the README has an explicit `## No hypothesis (mapping probe)` section.
+- [ ] Conditions table names baseline (a) and at least one alternative -- unless the probe is purely descriptive.
+
+## §5. Evidence
+
+- [ ] `results.md` opens with a headline table; each row cites a path under `runs/`.
+- [ ] Cited paths exist and contain the quoted numbers.
+- [ ] No magic numbers in `results.md` or `verdict.md` without a path link.
+
+## §6. Verdict and scorecard
+
+- [ ] `verdict.md` has a verdict of `go` / `no-go` / `inconclusive`.
+- [ ] Reasoning ties to specific evidence paths.
+- [ ] `## Hypothesis scorecard` section is present (unless mapping probe).
+- [ ] At least one row is 🟡 partial or ❌ wrong, OR the README makes a credible case the question was non-trivial. (100% correct scorecards are flagged for review, not auto-failed.)
+
+## §7. Downstream propagation
+
+- [ ] If the verdict changes how we work: `docs/retrospectives/NNN-<topic>.md` exists and is cross-linked from `verdict.md`.
+- [ ] If the verdict updates the status matrix in the root `README.md`: the matrix cell is bumped in the same commit as the verdict.
+- [ ] Executive summary (`docs/executive-summary.md`) updated if the headline learning warrants it.
+
+## §8. Scope hygiene
+
+- [ ] The question is not a debugging task disguised as an experiment.
+- [ ] The question is not answerable by reading code + grep.
+- [ ] The probe is time-bounded -- under a working week. If it grew larger, it should have been split.
+
+## How to use a failure
+
+A failed box is a finding, not a verdict. Fix the smallest thing that closes the gap. If a probe fails §3 (two-commit rule), it's unsalvageable -- record the finding in the retrospective and move on; don't backfill timestamps.

--- a/plugins/experiments/skills/running-experiments/references/canonical-scripts.md
+++ b/plugins/experiments/skills/running-experiments/references/canonical-scripts.md
@@ -1,0 +1,60 @@
+# Canonical shell patterns
+
+Reusable shapes for running probes against the harness-lab stack. When a specific command rots, edit this file -- the principles in `SKILL.md` stay put.
+
+## Boot the stack with a planted bug
+
+```sh
+# Each branch gets a unique iso_key (port allocation + label prefix)
+pnpm harness boot --bug BUG_COMPLETE_TASK_500
+pnpm harness inspect            # discover allocated ports + iso_key
+ISO_KEY=$(pnpm harness inspect --json | jq -r '.iso_key')
+```
+
+## LogsQL projection (cuts response size ~12×)
+
+Always project the fields you need; without `| fields …` each log line returns ~2300 B.
+
+```sh
+# Errors on a specific endpoint
+curl -s "http://localhost:$VL_PORT/select/logsql/query" --data-urlencode \
+  "query={harness.iso_key=\"$ISO_KEY\"} req.url:/complete | fields _time, _msg, severity, req.url, res.statusCode, trace_id | limit 20"
+
+# Word match (no |~ operator -- bare word or field:/regex/)
+curl -s "http://localhost:$VL_PORT/select/logsql/query" --data-urlencode \
+  "query={harness.iso_key=\"$ISO_KEY\"} \"TypeError\" | fields _time, _msg, severity, trace_id | limit 20"
+```
+
+Gotchas:
+- Field name is **`severity`**, not `level`. `level:error` returns silently empty.
+- `| fields` drops `_stream` and `_stream_id`. Re-query without projection if full context is needed for one line.
+
+## Trace correlation
+
+```sh
+# Trace ID from a failed response → traces backend
+curl -s "http://localhost:$VT_PORT/select/jaeger/api/traces/$TRACE_ID" \
+  | jq '.data[0].spans | length'
+```
+
+## Before/after evidence capture
+
+```sh
+# Screenshot pair around a fix commit
+node harness/agent-tools/screenshot-pair.mjs \
+  --url "http://localhost:$WEB_PORT/" \
+  --label-before "broken" --label-after "fixed" \
+  --out experiments/<slug>/runs/screenshots/
+```
+
+See `.claude/skills/before-after-evidence/` for the full evidence-bundle recipe.
+
+## Storing the probe script in-repo
+
+Long probe sequences live in `scripts/run-experiment-<slug>.sh`, not inlined into `justfile` recipes. The script can be invoked from the experiment folder and committed alongside the eval pack -- that makes the probe reproducible months later when the inline `## How to run` block has been edited or forgotten.
+
+## Parallelism, when applicable
+
+Most harness-lab probes are I/O-bound (HTTP queries, browser sessions). Parallelize within a phase only when the probes target orthogonal resources -- different `iso_key`s, different endpoints, different toggles. Serialize across "reset" boundaries (`pnpm harness destroy` → boot).
+
+If you're measuring p95 latency, run with concurrency = 1 -- concurrent invocations distort per-request latency.

--- a/plugins/experiments/skills/running-experiments/references/preflight.md
+++ b/plugins/experiments/skills/running-experiments/references/preflight.md
@@ -1,0 +1,33 @@
+# Pre-flight checklist
+
+Run BEFORE writing the hypothesis. Each item resolves a confound that has bitten prior experiments. Sourced from `experiments/_template/README.md` and the retrospectives that hardened it.
+
+## 1. Working tree is clean for the files the experiment depends on
+
+`git status --short` and audit. If a relevant source file shows `M`, either commit the change, `git checkout HEAD -- <file>` to reset, or explicitly document it as part of Setup (it's now a confound).
+
+*Source:* retrospective 002 -- working-tree drift cost ~5 min of false-bug investigation.
+
+## 2. Stack is in a known state
+
+If the experiment requires a fresh stack: `pnpm harness destroy` first. If it requires baseline traffic, seed it before measuring. Don't measure against a stack whose state evolved across other experiments.
+
+## 3. Artifacts directory is clean for the iso_key under test
+
+Pre-existing `.harness/artifacts/<iso>/` files from prior runs can confuse subagents that read them expecting fresh state.
+
+*Source:* retrospective 003 -- reviewer noted REPORT.md from a prior run.
+
+## 4. Tool versions documented
+
+If the experiment depends on a specific version of a tool (Playwright, RTK, ffmpeg, Rust, Node), note the version in the Setup section so the experiment is reproducible across time.
+
+## 5. Conventions cited; marketing claims separated
+
+If your hypothesis references a marketing claim from a tool's docs ("saves 60-90% tokens"), treat that as a WORKLOAD average and predict your specific commands separately. Aggregate ≠ per-command.
+
+*Source:* retrospective 005 -- RTK marketing aggregate ≠ per-command.
+
+## 6. Baseline captured before any change
+
+Without a recorded baseline, "after" numbers are anecdotes. The baseline goes into `runs/baseline-*` and is referenced from `results.md` as the comparison anchor. This is the harness-lab analog of the AI-pilot "before/after snapshot" pattern: the baseline is what lets impact be measured, not assumed.

--- a/plugins/experiments/skills/running-experiments/references/scorecard-template.md
+++ b/plugins/experiments/skills/running-experiments/references/scorecard-template.md
@@ -1,0 +1,31 @@
+# Hypothesis scorecard template
+
+Every `verdict.md` includes a `## Hypothesis scorecard` section, except for declared mapping probes (which have no hypothesis to score). Misses get the headline; a probe where every prediction was right either tested something obvious or had a hypothesis written after the data.
+
+## Canonical shape
+
+```markdown
+## Hypothesis scorecard
+
+| Predicted | Observed | Score | Notes |
+|---|---|---|---|
+| LogsQL `| fields` cuts response size ≥5× | 11.9× | ✅ correct | exceeded prediction; baseline 2300 B → 200 B |
+| Bare-word match works without `|~` | works on `_msg` | ✅ correct | |
+| p95 query latency ≤ 200 ms | 0.52 s | ❌ wrong | cardinality higher than predicted; follow-up needed |
+| `severity` is the field name (not `level`) | confirmed | ✅ correct | silent-empty when wrong |
+| Projection drops `_stream` context | confirmed | 🟡 partial | direction right, but re-query without projection restores it cheaply |
+```
+
+## Scoring vocabulary
+
+- **✅ correct** -- observed result matches the predicted number / direction within the predicted tolerance.
+- **🟡 partial** -- direction correct, magnitude or boundary off. Useful -- names exactly where the model of the system was incomplete.
+- **❌ wrong** -- observed result contradicts the prediction. **These are the rows that make the probe worth running.** Cite the contradicting evidence path in Notes.
+
+## When the scorecard is suspiciously clean
+
+If every row is ✅, audit:
+
+1. Did smoke testing happen before the hypothesis commit? Check `git log --diff-filter=A -- experiments/<slug>/runs/` vs. the hypothesis commit timestamp.
+2. Was the question trivial -- i.e., did anyone actually not know the answer? If so, write it as a mapping probe explicitly, not a hypothesis-testing one.
+3. Were the predictions vague enough to be unfalsifiable ("the system will work")? Tighten next time.


### PR DESCRIPTION
## What

A new `plugins/experiments/` plugin housing the canonical `running-experiments` skill.

## Why a dedicated plugin, not a meta skill

Experiments are a first-class domain concern (hypothesis-first methodology, evidence capture, verdict scoring) with their own vocabulary and discipline. Same status as `sdlc`, `docs`, `observability`. A dedicated plugin gives later tooling a home (eval-pack generator, status-matrix linter, results aggregator) without bloating the meta plugin.

Per the placement rule we just encoded in `authoring-skills` (PR #174), domain skills live under `plugins/<domain>/skills/`. Meta-level scopes (`.claude/skills/`) are reserved for skills that teach how to author other skills.

## Canonical source picked

The skill exists in two divergent copies:

- `/Users/neural/Code/ai/agentic-harness-lab/.claude/skills/running-experiments/` (newer, 2026-05-15, has `references/`, better-structured)
- `/Users/neural/Code/AgentParadise/agentic-memory/.claude/skills/running-experiments/` (older, 2026-05-12, workbench-specific framing)

Picked harness-lab as canonical. Generalized the body to drop harness-lab-specific framing while keeping the durable methodology.

## Style fixes for the diff

46 em-dashes substituted to ASCII (colons, commas, periods) and 3 en-dashes to ASCII hyphens, keeping this repo em-dash-free per house style. Placement frontmatter added to document where the skill lands in any consumer repo.

## Contents

```
plugins/experiments/
  .claude-plugin/plugin.json    manifest
  README.md                     overview + pointer to meta plugin
  skills/running-experiments/   the canonical skill + 4 reference files
```

7 files, 513 insertions, zero modifications to existing files.

## Related

- Sibling PR (authoring-skills port that gave us the placement rule): #174
- Upstream chassis: AgentParadise/harness-engineering#1