### PR TITLE
feat(docs): add system-infographic skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Replace `sdlc` with any plugin name (`workspace`, `research`, `meta`, `docs`) in
 | **workspace** | -- | -- | -- | Session lifecycle, tool observability, structured JSONL event emission |
 | **research** | `scrape_docs` | -- | -- | -- |
 | **meta** | `create-command`, `create-prime`, `create-doc-sync` | `prompt-generator` | -- | -- |
-| **docs** | -- | Fumadocs integration | -- | -- |
+| **docs** | -- | `fuma` (Fumadocs integration), `system-infographic` | -- | -- |
 | **notifications** | -- | -- | -- | Notification, Stop, TaskCompleted → ntfy/macOS/Pushover with sound themes |
 | **observability** | -- | -- | -- | All 14 lifecycle events → structured JSONL via agentic_events |
 

--- a/plugins/docs/.claude-plugin/plugin.json
+++ b/plugins/docs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Documentation tools — Fumadocs integration and documentation management",
   "author": {
     "name": "NeuralEmpowerment"

--- a/plugins/docs/CHANGELOG.md
+++ b/plugins/docs/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
 
+## 1.1.0
+- Add `system-infographic` skill: produce a self-contained HTML infographic that explains how a system, flow, pipeline, or setup works. Ships a fillable template, a worked example, and references for the semantic-color aesthetic system and the screenshot-QA loop.
+
 ## 1.0.0
 - Consolidated from docs/fuma

--- a/plugins/docs/README.md
+++ b/plugins/docs/README.md
@@ -4,3 +4,4 @@ Documentation tools for Claude Code agents.
 
 ## Skills
 - **fuma** — Fumadocs integration and documentation generation
+- **system-infographic** — Generate a single self-contained HTML infographic explaining how a system, flow, or architecture works

--- a/plugins/docs/skills/system-infographic/SKILL.md
+++ b/plugins/docs/skills/system-infographic/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: system-infographic
+description: Produce a single self-contained HTML infographic that explains how a system, flow, pipeline, architecture, or setup works. Trigger phrases include "make an infographic", "build an infographic", "diagram how this works", "visual explainer", "how-it-works page", "explain the architecture visually", "onboarding diagram", "flow diagram", "show the flow from X to Y", "visualize the pipeline", "schematic of the system", "one-pager that explains", "turn this README into a graphic". Output is a portable .html file (inline CSS, web fonts, no build). Do NOT use for prose documentation (use the docs `fuma` skill), for building an interactive web app or reusable UI component (use `frontend-design`), or for data-driven charts from a dataset.
+---
+
+# System infographic
+
+## When to Use (and When NOT to Use)
+
+Use when:
+- A user wants a visual one-pager that explains how a system, flow, pipeline, or setup works (onboarding, hand-off, a "how it works" page).
+- You are turning a README flow, an architecture, or a setup guide into something a reader absorbs in one scroll.
+- A diagram needs to show a trust boundary, a data path, or a sequence of phases, not just a bullet list.
+
+Do NOT use when:
+- The deliverable is prose documentation: use the docs `fuma` skill.
+- The deliverable is an interactive web app or a reusable UI component: use `frontend-design`.
+- The graphic is a data chart driven by a dataset (bar, line, series): that is a charting task, not an explainer.
+- The format requested is a slide deck or a static raster image with no HTML.
+
+## Input
+
+- Source of truth for the system being explained: a repo, README, spec, or a clear verbal description. Required, because the graphic must match reality and a real source beats memory.
+- Output path for the `.html` file. Optional; default `docs/<topic>.html` in the relevant repo.
+- Aesthetic direction. Optional; default is the dark technical-schematic blueprint in `assets/template.html`.
+- A headless browser (Playwright or Chromium) for the screenshot QA step. Optional but recommended; without it you ship unseen.
+
+## Workflow
+
+1. Extract the real flow from the source of truth. Read the repo, justfile, README, or spec and list the actual phases, the exact commands, what is local versus external, and any trust or security boundary. A graphic that invents steps is worse than none, because readers trust a diagram more than prose.
+2. Choose the spine that matches the content. Common spines: a linear pipeline (A to B to C), a perimeter map (what stays inside a trust boundary versus what crosses it), phase blocks (one-time versus per-call versus continuous), and a numbered setup checklist. Most system explainers combine a map centerpiece, phase cards, and a setup checklist. See `references/aesthetic-system.md`.
+3. Commit to a semantic visual system before writing markup. Assign each accent color one durable meaning (for example one hue for local or secret, one for data flow, one for a danger boundary, one for success) and reuse it everywhere. Pair a characterful display font with a monospace for commands and labels. Color used decoratively that elsewhere carries meaning confuses the reader, so keep the mapping strict. Start from `assets/template.html`.
+4. Build one self-contained HTML file. Inline all CSS in a `<style>` block, load fonts through a single Google Fonts `<link>`, and avoid external JS libraries; a few lines of vanilla JS for reveal-on-scroll is fine. Self-containment is what makes the artifact emailable, committable, and openable with no build step.
+5. Fill the spine with the real content from step 1: a hero stating the one-line thesis, the map or pipeline centerpiece, phase cards for the steps, callout chips for the invariants that make the system work, and a numbered setup checklist with copy-able command chips. Use the actual commands, not placeholders.
+6. Add restrained motion and print support. One staggered reveal on load (IntersectionObserver, or CSS `animation-delay`), hover affordances on nodes, and an `@media print` block so the file exports to PDF cleanly. Motion should aid comprehension and sequencing, not perform.
+7. Render and inspect before hand-off. Open the file in headless Chromium, scroll so reveal animations fire, screenshot it full-page, and look at the image. Check a narrow viewport (around 800px) for the responsive collapse. Fix overflow, low contrast, and broken connectors. Shipping an infographic you have not seen rendered is the most common way one goes out broken. See `references/screenshot-qa.md`.
+8. Open it for the user and offer follow-ups. On macOS, `open <file>`. Offer a light or print theme, an Open Graph share image, or folding the graphic into the README as a linked diagram.
+
+## Output
+
+- One self-contained `.html` file at the chosen path, openable offline (apart from the web-font CDN), printable to PDF.
+- A full-page screenshot used for the QA pass (transient; commit only if useful).
+- No build artifacts, no installed dependencies, no external runtime beyond the font CDN.
+
+## Outcomes we are looking for
+
+### The infographic is accurate to the system it explains
+Signals: every command and step in the graphic exists in the source repo or spec; a domain owner reading it does not flag an invented step.
+
+### The artifact is self-contained and portable
+Signals: opening the single file in a fresh browser renders the whole page; there is no build step; print preview is legible on one or two pages.
+
+### The design is distinctive, with a semantic visual system
+Signals: each accent color carries one consistent meaning; the page would not be mistaken for a default framework template; the font pairing is not Inter, Roboto, or Arial.
+
+### It was verified visually, not shipped blind
+Signals: a full-page screenshot was rendered and inspected; the layout holds at both desktop and narrow widths.
+
+## Recommended tools and practices (as of 2026-06-03)
+
+### For: accuracy to the system
+- Build the flow from the repo, justfile, README, or spec, not from memory. Lift the real commands and the real boundary. This prevents the invented-step failure that makes a diagram actively misleading.
+- Name the trust boundary explicitly when the system has one (what stays local versus what crosses a network or goes to a third party). The boundary is usually the part readers most misunderstand, so it earns the centerpiece.
+
+### For: self-contained and portable
+- One `.html` file: inline CSS, fonts via a single Google Fonts `<link>`, zero JS dependencies. The artifact then opens anywhere with no toolchain.
+- Add the `@media print` block while writing the CSS, not after. PDF export becomes a first-class output rather than a retrofit.
+
+### For: a distinctive, semantic design
+- Map each accent color to one meaning and reuse it; pair a characterful display font with a monospace for commands and code. A consistent color-to-meaning map is what lets a reader decode the diagram without a legend.
+- Default starting point: the dark technical-schematic blueprint (faint grid background; amber for local or secret; teal for data flow; red for a boundary; green for ok; Chakra Petch with JetBrains Mono). Override per context, but start from a working base. See `assets/template.html` and `references/aesthetic-system.md`.
+
+### For: visual verification
+- Render with headless Chromium (Playwright) and screenshot the full page, then inspect the image before delivering. A screenshot surfaces overflow, contrast, and broken-connector bugs that reading the markup hides. See `references/screenshot-qa.md`.
+- Check a narrow viewport near 800px. Infographics are read on laptops and phones, and the responsive collapse is where layouts break.
+
+## References
+
+- `assets/template.html`: the self-contained starter skeleton (the CSS system plus structural blocks) to copy and fill.
+- `assets/example-how-it-works.html`: the flagship worked example, the infographic that prompted this skill.
+- `references/aesthetic-system.md`: the semantic color system, font pairings, and spine patterns in depth.
+- `references/screenshot-qa.md`: the headless-render-and-inspect loop, with the Playwright snippet and what to look for.
+
+## Continual improvement
+
+File drift, gaps, or proposed updates at https://github.com/AgentParadise/agentic-primitives/issues

--- a/plugins/docs/skills/system-infographic/assets/example-how-it-works.html
+++ b/plugins/docs/skills/system-infographic/assets/example-how-it-works.html
@@ -1,0 +1,433 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>agent-limit-sensor · operational schematic</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+<style>
+  :root{
+    --ink:#080b10;
+    --ink-2:#0d1218;
+    --panel:#121821;
+    --panel-2:#161e29;
+    --line:rgba(120,160,180,.14);
+    --line-bright:rgba(120,200,210,.34);
+    --text:#dfe8ef;
+    --text-dim:#8595a3;
+    --text-faint:#5d6b78;
+    --amber:#ffb454;      /* local / keychain / secrets */
+    --amber-dim:rgba(255,180,84,.16);
+    --teal:#54d6cc;       /* data flow */
+    --teal-dim:rgba(84,214,204,.14);
+    --red:#ff6b6b;        /* boundary / danger */
+    --red-dim:rgba(255,107,107,.14);
+    --green:#7ee787;      /* authed / ok */
+    --radius:14px;
+  }
+  *{box-sizing:border-box;}
+  html{scroll-behavior:smooth;}
+  body{
+    margin:0;
+    background:
+      radial-gradient(1100px 600px at 78% -8%, rgba(84,214,204,.10), transparent 60%),
+      radial-gradient(900px 500px at 8% 4%, rgba(255,180,84,.08), transparent 55%),
+      var(--ink);
+    color:var(--text);
+    font-family:"Chakra Petch", sans-serif;
+    font-weight:300;
+    line-height:1.6;
+    -webkit-font-smoothing:antialiased;
+    overflow-x:hidden;
+  }
+  /* blueprint grid + grain */
+  body::before{
+    content:"";position:fixed;inset:0;z-index:0;pointer-events:none;
+    background-image:
+      linear-gradient(var(--line) 1px, transparent 1px),
+      linear-gradient(90deg, var(--line) 1px, transparent 1px);
+    background-size:46px 46px;
+    -webkit-mask-image:radial-gradient(circle at 50% 30%, #000 0%, transparent 78%);
+            mask-image:radial-gradient(circle at 50% 30%, #000 0%, transparent 78%);
+    opacity:.5;
+  }
+  .wrap{position:relative;z-index:1;max-width:1080px;margin:0 auto;padding:0 22px 90px;}
+  .mono{font-family:"JetBrains Mono", monospace;}
+
+  /* ---------- top bar ---------- */
+  .topbar{
+    display:flex;align-items:center;justify-content:space-between;gap:16px;
+    padding:18px 4px;border-bottom:1px solid var(--line);
+    font-family:"JetBrains Mono",monospace;font-size:11.5px;letter-spacing:.16em;text-transform:uppercase;
+    color:var(--text-faint);flex-wrap:wrap;
+  }
+  .topbar .brand{color:var(--text-dim);display:flex;align-items:center;gap:10px;}
+  .dot{width:8px;height:8px;border-radius:50%;background:var(--green);box-shadow:0 0 12px var(--green);animation:pulse 2.4s ease-in-out infinite;}
+  @keyframes pulse{0%,100%{opacity:1;}50%{opacity:.35;}}
+  .chip-secure{color:var(--amber);border:1px solid var(--amber-dim);background:var(--amber-dim);padding:4px 10px;border-radius:30px;}
+
+  /* ---------- hero ---------- */
+  .hero{padding:64px 0 26px;}
+  .kicker{font-family:"JetBrains Mono",monospace;font-size:12px;letter-spacing:.34em;text-transform:uppercase;color:var(--teal);margin-bottom:18px;}
+  h1{
+    font-weight:700;font-size:clamp(38px,7vw,76px);line-height:.98;letter-spacing:-.01em;margin:0;
+    text-transform:uppercase;
+  }
+  h1 .b{color:var(--amber);}
+  h1 .c{color:var(--teal);}
+  .lede{max-width:620px;margin:24px 0 0;font-size:17px;color:var(--text-dim);font-weight:300;}
+  .lede b{color:var(--text);font-weight:500;}
+
+  /* ---------- section heads ---------- */
+  section{margin-top:78px;}
+  .shead{display:flex;align-items:baseline;gap:16px;margin-bottom:26px;}
+  .shead .num{font-family:"JetBrains Mono",monospace;font-size:12px;color:var(--text-faint);letter-spacing:.2em;border:1px solid var(--line);border-radius:6px;padding:3px 8px;}
+  .shead h2{font-weight:600;font-size:clamp(22px,3.4vw,30px);margin:0;letter-spacing:.01em;text-transform:uppercase;}
+  .shead .rule{flex:1;height:1px;background:linear-gradient(90deg,var(--line-bright),transparent);align-self:center;}
+
+  /* ---------- the perimeter schematic ---------- */
+  .map{
+    border:1px solid var(--line);border-radius:var(--radius);background:
+      linear-gradient(180deg, rgba(255,180,84,.04), transparent 30%),
+      var(--ink-2);
+    padding:26px;position:relative;overflow:hidden;
+  }
+  .perimeter{
+    border:1.5px dashed rgba(255,180,84,.5);border-radius:12px;padding:22px 20px 24px;
+    position:relative;background:rgba(255,180,84,.035);
+  }
+  .perimeter > .tag{
+    position:absolute;top:-11px;left:18px;background:var(--ink-2);padding:0 10px;
+    font-family:"JetBrains Mono",monospace;font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:var(--amber);
+  }
+  .seal{
+    position:absolute;top:-13px;right:16px;background:var(--ink-2);padding:2px 11px;border:1px solid var(--red-dim);border-radius:30px;
+    font-family:"JetBrains Mono",monospace;font-size:10.5px;letter-spacing:.12em;text-transform:uppercase;color:var(--red);
+  }
+  .pipe{display:flex;align-items:stretch;gap:0;flex-wrap:wrap;}
+  .node{
+    flex:1;min-width:150px;background:var(--panel);border:1px solid var(--line);border-radius:11px;padding:14px 14px 13px;
+    position:relative;transition:transform .25s ease, border-color .25s ease, box-shadow .25s ease;
+  }
+  .node:hover{transform:translateY(-3px);border-color:var(--line-bright);box-shadow:0 10px 30px -16px rgba(84,214,204,.5);}
+  .node .ic{font-size:20px;line-height:1;margin-bottom:9px;display:block;filter:saturate(1.1);}
+  .node .nt{font-weight:600;font-size:14.5px;letter-spacing:.01em;}
+  .node .nd{font-size:12px;color:var(--text-dim);margin-top:4px;font-weight:300;line-height:1.45;}
+  .node .pin{position:absolute;top:11px;right:12px;font-family:"JetBrains Mono",monospace;font-size:9.5px;letter-spacing:.1em;color:var(--text-faint);text-transform:uppercase;}
+  .arrow{display:flex;align-items:center;justify-content:center;color:var(--teal);font-size:20px;min-width:34px;flex:0 0 auto;}
+  .arrow span{opacity:.0;animation:flow 1.8s linear infinite;}
+  @keyframes flow{0%{opacity:.2;}50%{opacity:1;}100%{opacity:.2;}}
+
+  .keyfeed{
+    display:flex;align-items:center;gap:12px;margin-top:16px;padding:12px 14px;border-radius:10px;
+    background:var(--amber-dim);border:1px dashed rgba(255,180,84,.4);
+  }
+  .keyfeed .ic{font-size:19px;}
+  .keyfeed .txt{font-size:12.5px;color:#f2d6a8;}
+  .keyfeed .txt b{color:var(--amber);font-weight:600;}
+
+  /* crossings */
+  .crossings{display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:20px;}
+  .cross{
+    border:1px solid var(--line);border-radius:11px;padding:15px 16px;background:var(--panel-2);position:relative;
+  }
+  .cross.flow{border-color:var(--teal-dim);}
+  .cross.egress{border-color:var(--amber-dim);}
+  .cross .wire{font-family:"JetBrains Mono",monospace;font-size:10.5px;letter-spacing:.14em;text-transform:uppercase;display:flex;align-items:center;gap:8px;margin-bottom:9px;}
+  .cross.flow .wire{color:var(--teal);}
+  .cross.egress .wire{color:var(--amber);}
+  .cross .big{font-weight:600;font-size:15px;}
+  .cross .sub{font-size:12.5px;color:var(--text-dim);margin-top:4px;font-weight:300;}
+  .cross .carry{margin-top:11px;font-family:"JetBrains Mono",monospace;font-size:11px;padding:5px 9px;border-radius:6px;display:inline-block;}
+  .cross.flow .carry{background:var(--teal-dim);color:#bfeee9;}
+  .cross.egress .carry{background:var(--amber-dim);color:#f2d6a8;}
+  .barred{color:var(--red);font-weight:500;}
+
+  /* ---------- phases ---------- */
+  .phases{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;}
+  .phase{
+    border:1px solid var(--line);border-radius:var(--radius);background:var(--panel);
+    padding:22px 20px 20px;position:relative;overflow:hidden;
+  }
+  .phase::before{content:"";position:absolute;top:0;left:0;right:0;height:3px;}
+  .phase.p1::before{background:linear-gradient(90deg,var(--amber),transparent);}
+  .phase.p2::before{background:linear-gradient(90deg,var(--teal),transparent);}
+  .phase.p3::before{background:linear-gradient(90deg,var(--green),transparent);}
+  .phase .pn{font-family:"JetBrains Mono",monospace;font-size:11px;letter-spacing:.2em;color:var(--text-faint);}
+  .phase h3{font-weight:600;font-size:18px;margin:8px 0 4px;text-transform:uppercase;letter-spacing:.01em;}
+  .phase .when{font-family:"JetBrains Mono",monospace;font-size:10.5px;letter-spacing:.08em;text-transform:uppercase;}
+  .phase.p1 .when{color:var(--amber);}
+  .phase.p2 .when{color:var(--teal);}
+  .phase.p3 .when{color:var(--green);}
+  .phase ol{margin:16px 0 0;padding:0;list-style:none;counter-reset:s;}
+  .phase ol li{position:relative;padding:0 0 13px 30px;font-size:13.5px;color:var(--text-dim);font-weight:300;counter-increment:s;}
+  .phase ol li::before{
+    content:counter(s);position:absolute;left:0;top:0;width:20px;height:20px;border-radius:6px;
+    font-family:"JetBrains Mono",monospace;font-size:10.5px;font-weight:700;display:flex;align-items:center;justify-content:center;
+    background:var(--panel-2);border:1px solid var(--line);color:var(--text);
+  }
+  .phase ol li:last-child{padding-bottom:0;}
+  .phase ol li b{color:var(--text);font-weight:600;}
+  .phase ol li code{font-family:"JetBrains Mono",monospace;font-size:12px;color:var(--teal);background:var(--teal-dim);padding:1px 5px;border-radius:4px;}
+
+  /* ---------- invariants ---------- */
+  .invs{display:grid;grid-template-columns:repeat(2,1fr);gap:14px;}
+  .inv{display:flex;gap:14px;align-items:flex-start;border:1px solid var(--line);border-radius:11px;padding:16px 17px;background:var(--ink-2);}
+  .inv .ic{font-size:20px;flex:0 0 auto;margin-top:1px;}
+  .inv .t{font-weight:600;font-size:14.5px;}
+  .inv .d{font-size:13px;color:var(--text-dim);margin-top:3px;font-weight:300;line-height:1.5;}
+  .inv .d b{color:var(--amber);font-weight:600;}
+
+  /* ---------- setup checklist ---------- */
+  .setup{border:1px solid var(--line);border-radius:var(--radius);background:var(--ink-2);overflow:hidden;}
+  .step{display:grid;grid-template-columns:54px 1fr;border-top:1px solid var(--line);}
+  .step:first-child{border-top:none;}
+  .step .sn{
+    display:flex;align-items:center;justify-content:center;font-family:"JetBrains Mono",monospace;font-weight:700;font-size:15px;
+    color:var(--ink);background:linear-gradient(180deg,var(--teal),#3fb6ad);
+  }
+  .step.key .sn{background:linear-gradient(180deg,var(--amber),#e8973a);}
+  .step .body{padding:16px 18px;}
+  .step .st{font-weight:600;font-size:15px;}
+  .step .sd{font-size:13px;color:var(--text-dim);margin-top:3px;font-weight:300;}
+  .step .sd b{color:var(--text);font-weight:500;}
+  .cmd{
+    font-family:"JetBrains Mono",monospace;font-size:12.5px;margin-top:10px;display:block;
+    background:#0a0f15;border:1px solid var(--line);border-left:2px solid var(--teal);border-radius:7px;padding:9px 12px;color:#cfe8e4;
+    white-space:pre-wrap;overflow-x:auto;
+  }
+  .step.key .cmd{border-left-color:var(--amber);}
+  .cmd .cm{color:var(--text-faint);}
+  .cmd .ok{color:var(--green);}
+  .note{margin-top:9px;font-size:12px;color:var(--amber);display:flex;gap:7px;align-items:flex-start;}
+
+  /* reveal */
+  .rv{opacity:0;transform:translateY(16px);transition:opacity .7s cubic-bezier(.2,.7,.2,1), transform .7s cubic-bezier(.2,.7,.2,1);}
+  .rv.in{opacity:1;transform:none;}
+
+  footer{margin-top:70px;padding-top:22px;border-top:1px solid var(--line);font-family:"JetBrains Mono",monospace;font-size:11px;letter-spacing:.1em;color:var(--text-faint);display:flex;justify-content:space-between;gap:14px;flex-wrap:wrap;text-transform:uppercase;}
+
+  @media (max-width:820px){
+    .phases{grid-template-columns:1fr;}
+    .crossings{grid-template-columns:1fr;}
+    .invs{grid-template-columns:1fr;}
+    .arrow{transform:rotate(90deg);min-width:0;width:100%;height:26px;}
+    .node{min-width:100%;}
+  }
+  @media print{
+    body{background:#fff;color:#000;}
+    body::before{display:none;}
+    .rv{opacity:1;transform:none;}
+    .node,.phase,.inv,.cross,.setup,.map{break-inside:avoid;}
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="topbar">
+    <span class="brand"><span class="dot"></span> agent-limit-sensor</span>
+    <span class="chip-secure">secrets · local-only</span>
+  </div>
+
+  <!-- HERO -->
+  <header class="hero rv">
+    <div class="kicker">operational schematic</div>
+    <h1>Log in once.<br><span class="b">Decrypt</span> on demand.<br>Serve <span class="c">numbers</span>, not keys.</h1>
+    <p class="lede">A local sensor reads your AI usage limits behind your own logged-in sessions — <b>decrypting only the cookies it needs, at scrape time, straight from Chrome</b> — and exposes the numbers to your VPS agents over Tailscale. No cookie ever touches disk, and no secret ever leaves your Mac.</p>
+  </header>
+
+  <!-- MAP -->
+  <section class="rv">
+    <div class="shead"><span class="num">MAP</span><h2>The shape of it</h2><span class="rule"></span></div>
+    <div class="map">
+      <div class="perimeter">
+        <span class="tag">🖥 your mac — everything secret stays inside</span>
+        <span class="seal">🔒 cookies never cross</span>
+
+        <div class="pipe">
+          <div class="node">
+            <span class="pin">logged in</span>
+            <span class="ic">🌐</span>
+            <div class="nt">Dedicated Chrome profile</div>
+            <div class="nd">Separate from your everyday browser. Holds the encrypted session cookies.</div>
+          </div>
+          <div class="arrow"><span>▸</span></div>
+          <div class="node">
+            <span class="pin">at scrape</span>
+            <span class="ic">🛰️</span>
+            <div class="nt">Sensor service</div>
+            <div class="nd">Decrypts just that provider's cookies via the Keychain. Nothing persisted.</div>
+          </div>
+          <div class="arrow"><span>▸</span></div>
+          <div class="node">
+            <span class="pin">ephemeral</span>
+            <span class="ic">🎭</span>
+            <div class="nt">Headless browser</div>
+            <div class="nd">Cookies injected, dashboard loaded (URL-allowlisted), screenshot taken, cookies discarded.</div>
+          </div>
+        </div>
+
+        <div class="keyfeed">
+          <span class="ic">🔑</span>
+          <span class="txt"><b>macOS Keychain</b> &nbsp;“Chrome Safe Storage” key &rarr; feeds decryption, in memory only. First run asks once: click <b>Always Allow</b>.</span>
+        </div>
+      </div>
+
+      <div class="crossings">
+        <div class="cross flow">
+          <div class="wire">⇄ tailscale · bearer-token</div>
+          <div class="big">VPS agents call <span class="mono">GET /limits</span></div>
+          <div class="sub">Your remote agents query the sensor to allocate usage across plans.</div>
+          <div class="carry">carries → usage numbers + authed booleans</div>
+        </div>
+        <div class="cross egress">
+          <div class="wire">→ the one egress</div>
+          <div class="big">Screenshot → OpenRouter vision</div>
+          <div class="sub">A vision model reads the numbers off the dashboard image.</div>
+          <div class="carry">carries → a dashboard screenshot · <span class="barred">no cookies</span></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- PHASES -->
+  <section class="rv">
+    <div class="shead"><span class="num">FLOW</span><h2>Three phases</h2><span class="rule"></span></div>
+    <div class="phases">
+      <div class="phase p1">
+        <div class="pn">PHASE 01</div>
+        <h3>Log in &amp; capture</h3>
+        <div class="when">once · and on re-auth</div>
+        <ol>
+          <li><code>just open-profile</code> opens the <b>dedicated</b> Chrome window.</li>
+          <li>You log into <b>Claude, ChatGPT, Gemini</b> there (Gemini uses a low-stakes Google account).</li>
+          <li>Chrome stores the session cookies <b>encrypted</b> in that profile. We copy nothing.</li>
+        </ol>
+      </div>
+      <div class="phase p2">
+        <div class="pn">PHASE 02</div>
+        <h3>Decrypt &amp; scrape</h3>
+        <div class="when">every /limits call</div>
+        <ol>
+          <li>Sensor decrypts <b>only that provider's first-party cookies</b> via the Keychain.</li>
+          <li>Injects them into a fresh headless context; opens the usage dashboard.</li>
+          <li>Screenshots it &rarr; OpenRouter reads the numbers. Cookies <b>discarded</b>.</li>
+        </ol>
+      </div>
+      <div class="phase p3">
+        <div class="pn">PHASE 03</div>
+        <h3>Data out</h3>
+        <div class="when">over tailscale</div>
+        <ol>
+          <li>Returns JSON: <b>used / limit / resets-at</b> per provider.</li>
+          <li>Gated by a <b>bearer token</b>; binds loopback / your Tailscale IP.</li>
+          <li>VPS agents consume the numbers — <b>never the cookies</b>.</li>
+        </ol>
+      </div>
+    </div>
+  </section>
+
+  <!-- INVARIANTS -->
+  <section class="rv">
+    <div class="shead"><span class="num">RULES</span><h2>What keeps it safe</h2><span class="rule"></span></div>
+    <div class="invs">
+      <div class="inv"><span class="ic">🗄️</span><div><div class="t">Zero secrets at rest</div><div class="d">Cookies are read fresh from Chrome's own encrypted store and live <b>only in memory</b> during a scrape. No cookie files.</div></div></div>
+      <div class="inv"><span class="ic">🎯</span><div><div class="t">Scoped decryption</div><div class="d">A suffix-matched allowlist means Claude &amp; ChatGPT <b>never pull Google cookies</b> — only Gemini does.</div></div></div>
+      <div class="inv"><span class="ic">🔢</span><div><div class="t">Numbers, not keys</div><div class="d">No endpoint returns or accepts cookie values. <b>Bearer-token gated</b>; bound to loopback / Tailscale, never 0.0.0.0.</div></div></div>
+      <div class="inv"><span class="ic">↻</span><div><div class="t">Painless re-auth</div><div class="d">Cookies are read live each scrape, so Google's rotating cookies <b>just work</b> — keep the profile logged in.</div></div></div>
+    </div>
+  </section>
+
+  <!-- SETUP -->
+  <section class="rv">
+    <div class="shead"><span class="num">SETUP</span><h2>Set it up — end to end</h2><span class="rule"></span></div>
+    <div class="setup">
+
+      <div class="step">
+        <div class="sn">1</div>
+        <div class="body">
+          <div class="st">Install</div>
+          <div class="sd">uv venv + dependencies + Playwright Chromium.</div>
+          <span class="cmd">just install</span>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="sn">2</div>
+        <div class="body">
+          <div class="st">Add your vision key</div>
+          <div class="sd">OpenRouter parses the dashboard screenshots into numbers.</div>
+          <span class="cmd"><span class="cm"># .env in repo root</span>
+OPENROUTER_API_KEY=sk-or-...</span>
+        </div>
+      </div>
+
+      <div class="step key">
+        <div class="sn">3</div>
+        <div class="body">
+          <div class="st">Log into the dedicated profile</div>
+          <div class="sd"><b>Opens a separate Chrome window.</b> Log into Claude, ChatGPT, and Gemini.</div>
+          <span class="cmd">just open-profile</span>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="sn">4</div>
+        <div class="body">
+          <div class="st">Mint an API token</div>
+          <div class="sd">Required to gate the sensor before anything can reach it.</div>
+          <span class="cmd">export SENSOR_TOKEN=$(openssl rand -hex 16)</span>
+        </div>
+      </div>
+
+      <div class="step key">
+        <div class="sn">5</div>
+        <div class="body">
+          <div class="st">Start the sensor</div>
+          <div class="sd">Loopback by default — pass <b>host=&lt;tailscale-ip&gt;</b> to expose it to your VPS agents.</div>
+          <span class="cmd">just serve                       <span class="cm"># local</span>
+just serve host=100.x.y.z         <span class="cm"># expose to tailnet</span></span>
+          <div class="note">▲ First scrape pops the macOS Keychain prompt — click <b>Always Allow</b> (this is you initiating a real read).</div>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="sn">6</div>
+        <div class="body">
+          <div class="st">Verify</div>
+          <div class="sd">All three should report authed; limits should return real numbers.</div>
+          <span class="cmd">curl -s -H "Authorization: Bearer $SENSOR_TOKEN" localhost:8000/health | python3 -m json.tool
+<span class="ok"># → "authed": { "claude_web": true, "codex": true, "gemini": true }</span></span>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="sn">7</div>
+        <div class="body">
+          <div class="st">Re-auth when a session lapses</div>
+          <div class="sd"><b>No extraction step.</b> When <code style="font-family:'JetBrains Mono',monospace;color:var(--teal)">authed:false</code> appears, just log back in.</div>
+          <span class="cmd">just open-url claude_web          <span class="cm"># log in again → done</span></span>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <footer>
+    <span>agent-limit-sensor · on-demand decryption · zero secrets at rest</span>
+    <span>claude · chatgpt · gemini</span>
+  </footer>
+
+</div>
+
+<script>
+  const obs = new IntersectionObserver((entries)=>{
+    entries.forEach((e,i)=>{ if(e.isIntersecting){ e.target.classList.add('in'); obs.unobserve(e.target); }});
+  },{threshold:.12});
+  document.querySelectorAll('.rv').forEach(el=>obs.observe(el));
+</script>
+</body>
+</html>

--- a/plugins/docs/skills/system-infographic/assets/template.html
+++ b/plugins/docs/skills/system-infographic/assets/template.html
@@ -1,0 +1,231 @@
+<!DOCTYPE html>
+<!--
+  system-infographic starter template.
+  Copy this file, then fill the marked {{PLACEHOLDERS}} and the commented blocks.
+  Keep it self-contained: inline CSS, one Google Fonts link, no JS libraries.
+  Colors carry MEANING (see references/aesthetic-system.md):
+    amber = local / secret    teal = data flow    red = boundary    green = ok
+  Override the palette per context, but keep one-color-one-meaning.
+-->
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>{{TITLE}} · how it works</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<!-- Swap the families for your tone; avoid Inter/Roboto/Arial. -->
+<link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+<style>
+  :root{
+    --ink:#080b10; --ink-2:#0d1218; --panel:#121821; --panel-2:#161e29;
+    --line:rgba(120,160,180,.14); --line-bright:rgba(120,200,210,.34);
+    --text:#dfe8ef; --text-dim:#8595a3; --text-faint:#5d6b78;
+    --amber:#ffb454; --amber-dim:rgba(255,180,84,.16);   /* local / secret */
+    --teal:#54d6cc;  --teal-dim:rgba(84,214,204,.14);     /* data flow */
+    --red:#ff6b6b;   --red-dim:rgba(255,107,107,.14);     /* boundary */
+    --green:#7ee787;                                      /* ok */
+    --radius:14px;
+  }
+  *{box-sizing:border-box;}
+  html{scroll-behavior:smooth;}
+  body{
+    margin:0;
+    background:
+      radial-gradient(1100px 600px at 78% -8%, rgba(84,214,204,.10), transparent 60%),
+      radial-gradient(900px 500px at 8% 4%, rgba(255,180,84,.08), transparent 55%),
+      var(--ink);
+    color:var(--text); font-family:"Chakra Petch", sans-serif; font-weight:300;
+    line-height:1.6; -webkit-font-smoothing:antialiased; overflow-x:hidden;
+  }
+  body::before{ /* faint blueprint grid, masked to fade at edges */
+    content:"";position:fixed;inset:0;z-index:0;pointer-events:none;
+    background-image:linear-gradient(var(--line) 1px, transparent 1px),linear-gradient(90deg, var(--line) 1px, transparent 1px);
+    background-size:46px 46px;
+    -webkit-mask-image:radial-gradient(circle at 50% 30%, #000 0%, transparent 78%);
+            mask-image:radial-gradient(circle at 50% 30%, #000 0%, transparent 78%);
+    opacity:.5;
+  }
+  .wrap{position:relative;z-index:1;max-width:1080px;margin:0 auto;padding:0 22px 90px;}
+  .mono{font-family:"JetBrains Mono", monospace;}
+
+  .topbar{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:18px 4px;border-bottom:1px solid var(--line);font-family:"JetBrains Mono",monospace;font-size:11.5px;letter-spacing:.16em;text-transform:uppercase;color:var(--text-faint);flex-wrap:wrap;}
+  .topbar .brand{color:var(--text-dim);display:flex;align-items:center;gap:10px;}
+  .dot{width:8px;height:8px;border-radius:50%;background:var(--green);box-shadow:0 0 12px var(--green);animation:pulse 2.4s ease-in-out infinite;}
+  @keyframes pulse{0%,100%{opacity:1;}50%{opacity:.35;}}
+  .chip-secure{color:var(--amber);border:1px solid var(--amber-dim);background:var(--amber-dim);padding:4px 10px;border-radius:30px;}
+
+  .hero{padding:64px 0 26px;}
+  .kicker{font-family:"JetBrains Mono",monospace;font-size:12px;letter-spacing:.34em;text-transform:uppercase;color:var(--teal);margin-bottom:18px;}
+  h1{font-weight:700;font-size:clamp(38px,7vw,76px);line-height:.98;letter-spacing:-.01em;margin:0;text-transform:uppercase;}
+  h1 .b{color:var(--amber);} h1 .c{color:var(--teal);}
+  .lede{max-width:620px;margin:24px 0 0;font-size:17px;color:var(--text-dim);font-weight:300;}
+  .lede b{color:var(--text);font-weight:500;}
+
+  section{margin-top:78px;}
+  .shead{display:flex;align-items:baseline;gap:16px;margin-bottom:26px;}
+  .shead .num{font-family:"JetBrains Mono",monospace;font-size:12px;color:var(--text-faint);letter-spacing:.2em;border:1px solid var(--line);border-radius:6px;padding:3px 8px;}
+  .shead h2{font-weight:600;font-size:clamp(22px,3.4vw,30px);margin:0;letter-spacing:.01em;text-transform:uppercase;}
+  .shead .rule{flex:1;height:1px;background:linear-gradient(90deg,var(--line-bright),transparent);align-self:center;}
+
+  /* ---- perimeter map (the centerpiece) ---- */
+  .map{border:1px solid var(--line);border-radius:var(--radius);background:linear-gradient(180deg, rgba(255,180,84,.04), transparent 30%),var(--ink-2);padding:26px;position:relative;overflow:hidden;}
+  .perimeter{border:1.5px dashed rgba(255,180,84,.5);border-radius:12px;padding:22px 20px 24px;position:relative;background:rgba(255,180,84,.035);}
+  .perimeter > .tag{position:absolute;top:-11px;left:18px;background:var(--ink-2);padding:0 10px;font-family:"JetBrains Mono",monospace;font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:var(--amber);}
+  .seal{position:absolute;top:-13px;right:16px;background:var(--ink-2);padding:2px 11px;border:1px solid var(--red-dim);border-radius:30px;font-family:"JetBrains Mono",monospace;font-size:10.5px;letter-spacing:.12em;text-transform:uppercase;color:var(--red);}
+  .pipe{display:flex;align-items:stretch;gap:0;flex-wrap:wrap;}
+  .node{flex:1;min-width:150px;background:var(--panel);border:1px solid var(--line);border-radius:11px;padding:14px;position:relative;transition:transform .25s ease, border-color .25s ease, box-shadow .25s ease;}
+  .node:hover{transform:translateY(-3px);border-color:var(--line-bright);box-shadow:0 10px 30px -16px rgba(84,214,204,.5);}
+  .node .ic{font-size:20px;line-height:1;margin-bottom:9px;display:block;}
+  .node .nt{font-weight:600;font-size:14.5px;}
+  .node .nd{font-size:12px;color:var(--text-dim);margin-top:4px;font-weight:300;line-height:1.45;}
+  .node .pin{position:absolute;top:11px;right:12px;font-family:"JetBrains Mono",monospace;font-size:9.5px;letter-spacing:.1em;color:var(--text-faint);text-transform:uppercase;}
+  .arrow{display:flex;align-items:center;justify-content:center;color:var(--teal);font-size:20px;min-width:34px;flex:0 0 auto;}
+  .arrow span{animation:flow 1.8s linear infinite;}
+  @keyframes flow{0%{opacity:.2;}50%{opacity:1;}100%{opacity:.2;}}
+  .crossings{display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:20px;}
+  .cross{border:1px solid var(--line);border-radius:11px;padding:15px 16px;background:var(--panel-2);}
+  .cross.flow{border-color:var(--teal-dim);} .cross.egress{border-color:var(--amber-dim);}
+  .cross .wire{font-family:"JetBrains Mono",monospace;font-size:10.5px;letter-spacing:.14em;text-transform:uppercase;margin-bottom:9px;}
+  .cross.flow .wire{color:var(--teal);} .cross.egress .wire{color:var(--amber);}
+  .cross .big{font-weight:600;font-size:15px;} .cross .sub{font-size:12.5px;color:var(--text-dim);margin-top:4px;font-weight:300;}
+  .barred{color:var(--red);font-weight:500;}
+
+  /* ---- phase cards ---- */
+  .phases{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;}
+  .phase{border:1px solid var(--line);border-radius:var(--radius);background:var(--panel);padding:22px 20px 20px;position:relative;overflow:hidden;}
+  .phase::before{content:"";position:absolute;top:0;left:0;right:0;height:3px;}
+  .phase.p1::before{background:linear-gradient(90deg,var(--amber),transparent);}
+  .phase.p2::before{background:linear-gradient(90deg,var(--teal),transparent);}
+  .phase.p3::before{background:linear-gradient(90deg,var(--green),transparent);}
+  .phase .pn{font-family:"JetBrains Mono",monospace;font-size:11px;letter-spacing:.2em;color:var(--text-faint);}
+  .phase h3{font-weight:600;font-size:18px;margin:8px 0 4px;text-transform:uppercase;}
+  .phase .when{font-family:"JetBrains Mono",monospace;font-size:10.5px;letter-spacing:.08em;text-transform:uppercase;}
+  .phase.p1 .when{color:var(--amber);} .phase.p2 .when{color:var(--teal);} .phase.p3 .when{color:var(--green);}
+  .phase ol{margin:16px 0 0;padding:0;list-style:none;counter-reset:s;}
+  .phase ol li{position:relative;padding:0 0 13px 30px;font-size:13.5px;color:var(--text-dim);font-weight:300;counter-increment:s;}
+  .phase ol li::before{content:counter(s);position:absolute;left:0;top:0;width:20px;height:20px;border-radius:6px;font-family:"JetBrains Mono",monospace;font-size:10.5px;font-weight:700;display:flex;align-items:center;justify-content:center;background:var(--panel-2);border:1px solid var(--line);color:var(--text);}
+  .phase ol li b{color:var(--text);font-weight:600;}
+
+  /* ---- invariant chips ---- */
+  .invs{display:grid;grid-template-columns:repeat(2,1fr);gap:14px;}
+  .inv{display:flex;gap:14px;align-items:flex-start;border:1px solid var(--line);border-radius:11px;padding:16px 17px;background:var(--ink-2);}
+  .inv .ic{font-size:20px;flex:0 0 auto;margin-top:1px;}
+  .inv .t{font-weight:600;font-size:14.5px;} .inv .d{font-size:13px;color:var(--text-dim);margin-top:3px;font-weight:300;line-height:1.5;}
+
+  /* ---- setup checklist ---- */
+  .setup{border:1px solid var(--line);border-radius:var(--radius);background:var(--ink-2);overflow:hidden;}
+  .step{display:grid;grid-template-columns:54px 1fr;border-top:1px solid var(--line);}
+  .step:first-child{border-top:none;}
+  .step .sn{display:flex;align-items:center;justify-content:center;font-family:"JetBrains Mono",monospace;font-weight:700;font-size:15px;color:var(--ink);background:linear-gradient(180deg,var(--teal),#3fb6ad);}
+  .step.key .sn{background:linear-gradient(180deg,var(--amber),#e8973a);} /* mark risky steps */
+  .step .body{padding:16px 18px;}
+  .step .st{font-weight:600;font-size:15px;} .step .sd{font-size:13px;color:var(--text-dim);margin-top:3px;font-weight:300;}
+  .cmd{font-family:"JetBrains Mono",monospace;font-size:12.5px;margin-top:10px;display:block;background:#0a0f15;border:1px solid var(--line);border-left:2px solid var(--teal);border-radius:7px;padding:9px 12px;color:#cfe8e4;white-space:pre-wrap;overflow-x:auto;}
+  .step.key .cmd{border-left-color:var(--amber);}
+  .cmd .cm{color:var(--text-faint);} .cmd .ok{color:var(--green);}
+  .note{margin-top:9px;font-size:12px;color:var(--amber);}
+
+  .rv{opacity:0;transform:translateY(16px);transition:opacity .7s cubic-bezier(.2,.7,.2,1), transform .7s cubic-bezier(.2,.7,.2,1);}
+  .rv.in{opacity:1;transform:none;}
+  footer{margin-top:70px;padding-top:22px;border-top:1px solid var(--line);font-family:"JetBrains Mono",monospace;font-size:11px;letter-spacing:.1em;color:var(--text-faint);display:flex;justify-content:space-between;gap:14px;flex-wrap:wrap;text-transform:uppercase;}
+
+  @media (max-width:820px){
+    .phases,.crossings,.invs{grid-template-columns:1fr;}
+    .arrow{transform:rotate(90deg);min-width:0;width:100%;height:26px;}
+    .node{min-width:100%;}
+  }
+  @media print{
+    body{background:#fff;color:#000;} body::before{display:none;}
+    .rv{opacity:1;transform:none;}
+    .node,.phase,.inv,.cross,.setup,.map{break-inside:avoid;}
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="topbar">
+    <span class="brand"><span class="dot"></span> {{PROJECT_NAME}}</span>
+    <span class="chip-secure">{{STATUS_CHIP}}</span>
+  </div>
+
+  <!-- HERO: one-line thesis the reader should remember; color 2-3 key words. -->
+  <header class="hero rv">
+    <div class="kicker">{{KICKER}}</div>
+    <h1>{{LINE 1}}<br><span class="b">{{KEY WORD}}</span> {{LINE 2}}<br>{{LINE 3}} <span class="c">{{KEY WORD}}</span>.</h1>
+    <p class="lede">{{One paragraph: what this system does and the single thing that makes it work.}} <b>{{the punchy clause}}</b></p>
+  </header>
+
+  <!-- MAP: the centerpiece. Use a perimeter when the key insight is what stays
+       inside a boundary vs what crosses. Each node = one stage; each crossing =
+       one thing that leaves the boundary, labeled with what it carries. -->
+  <section class="rv">
+    <div class="shead"><span class="num">MAP</span><h2>{{The shape of it}}</h2><span class="rule"></span></div>
+    <div class="map">
+      <div class="perimeter">
+        <span class="tag">{{🖥 inside the boundary, e.g. "your machine"}}</span>
+        <span class="seal">{{🔒 the invariant, e.g. "secrets never cross"}}</span>
+        <div class="pipe">
+          <div class="node"><span class="pin">{{stage tag}}</span><span class="ic">{{icon}}</span><div class="nt">{{Node A}}</div><div class="nd">{{what it is / holds}}</div></div>
+          <div class="arrow"><span>▸</span></div>
+          <div class="node"><span class="pin">{{stage tag}}</span><span class="ic">{{icon}}</span><div class="nt">{{Node B}}</div><div class="nd">{{what happens here}}</div></div>
+          <div class="arrow"><span>▸</span></div>
+          <div class="node"><span class="pin">{{stage tag}}</span><span class="ic">{{icon}}</span><div class="nt">{{Node C}}</div><div class="nd">{{output / discard}}</div></div>
+        </div>
+      </div>
+      <div class="crossings">
+        <div class="cross flow"><div class="wire">⇄ {{channel, e.g. tailscale}}</div><div class="big">{{what crosses, the happy path}}</div><div class="sub">{{who calls it / why}}</div></div>
+        <div class="cross egress"><div class="wire">→ {{the one egress}}</div><div class="big">{{what leaves to a third party}}</div><div class="sub">{{carries X · <span class="barred">no secrets</span>}}</div></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- PHASES: tag each with its cadence (once / per-call / continuous). -->
+  <section class="rv">
+    <div class="shead"><span class="num">FLOW</span><h2>{{Phases}}</h2><span class="rule"></span></div>
+    <div class="phases">
+      <div class="phase p1"><div class="pn">PHASE 01</div><h3>{{Phase one}}</h3><div class="when">{{when it runs}}</div>
+        <ol><li>{{step}}</li><li>{{step}}</li><li>{{step}}</li></ol></div>
+      <div class="phase p2"><div class="pn">PHASE 02</div><h3>{{Phase two}}</h3><div class="when">{{when it runs}}</div>
+        <ol><li>{{step}}</li><li>{{step}}</li><li>{{step}}</li></ol></div>
+      <div class="phase p3"><div class="pn">PHASE 03</div><h3>{{Phase three}}</h3><div class="when">{{when it runs}}</div>
+        <ol><li>{{step}}</li><li>{{step}}</li><li>{{step}}</li></ol></div>
+    </div>
+  </section>
+
+  <!-- INVARIANTS: the rules that make the system safe or correct. -->
+  <section class="rv">
+    <div class="shead"><span class="num">RULES</span><h2>{{What keeps it true}}</h2><span class="rule"></span></div>
+    <div class="invs">
+      <div class="inv"><span class="ic">{{icon}}</span><div><div class="t">{{Invariant}}</div><div class="d">{{why it holds}}</div></div></div>
+      <div class="inv"><span class="ic">{{icon}}</span><div><div class="t">{{Invariant}}</div><div class="d">{{why it holds}}</div></div></div>
+      <div class="inv"><span class="ic">{{icon}}</span><div><div class="t">{{Invariant}}</div><div class="d">{{why it holds}}</div></div></div>
+      <div class="inv"><span class="ic">{{icon}}</span><div><div class="t">{{Invariant}}</div><div class="d">{{why it holds}}</div></div></div>
+    </div>
+  </section>
+
+  <!-- SETUP: numbered, with real commands. Add class="key" to risky steps. -->
+  <section class="rv">
+    <div class="shead"><span class="num">SETUP</span><h2>{{Set it up}}</h2><span class="rule"></span></div>
+    <div class="setup">
+      <div class="step"><div class="sn">1</div><div class="body"><div class="st">{{Step}}</div><div class="sd">{{what it does}}</div><span class="cmd">{{command}}</span></div></div>
+      <div class="step key"><div class="sn">2</div><div class="body"><div class="st">{{Risky step}}</div><div class="sd">{{what it does}}</div><span class="cmd">{{command}}</span><div class="note">▲ {{the gotcha to call out}}</div></div></div>
+      <div class="step"><div class="sn">3</div><div class="body"><div class="st">{{Verify}}</div><div class="sd">{{expected result}}</div><span class="cmd">{{command}}
+<span class="ok"># → expected output</span></span></div></div>
+    </div>
+  </section>
+
+  <footer>
+    <span>{{project · one-line summary}}</span>
+    <span>{{tags}}</span>
+  </footer>
+
+</div>
+<script>
+  // staggered reveal on scroll
+  const obs = new IntersectionObserver((es)=>{es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');obs.unobserve(e.target);}})},{threshold:.12});
+  document.querySelectorAll('.rv').forEach(el=>obs.observe(el));
+</script>
+</body>
+</html>

--- a/plugins/docs/skills/system-infographic/references/aesthetic-system.md
+++ b/plugins/docs/skills/system-infographic/references/aesthetic-system.md
@@ -1,0 +1,97 @@
+# Aesthetic system: colors, fonts, and spines
+
+Read this when choosing the look and the structure of a system infographic. It
+covers the default semantic color system, font pairings that avoid generic
+output, and the small set of structural "spines" most system explainers are
+built from. The CSS that implements all of this lives in `../assets/template.html`.
+
+## Semantic color: the core discipline
+
+The thing that makes a system diagram readable is that color means something
+and means the same thing everywhere. A reader should be able to decode the
+graphic without a legend because the palette is consistent.
+
+Default blueprint palette and what each accent means:
+
+| Role | Meaning | Hex |
+|------|---------|-----|
+| amber | local, on-device, secret, keychain | `#ffb454` |
+| teal | data flow, requests, the happy path | `#54d6cc` |
+| red | a boundary, danger, "does not cross" | `#ff6b6b` |
+| green | ok, healthy, authenticated, success | `#7ee787` |
+| ink background | the canvas | `#080b10` |
+| panel | raised surfaces, nodes, cards | `#121821` |
+| text tiers | bright `#dfe8ef`, dim `#8595a3`, faint `#5d6b78` |
+
+Rules that keep the mapping legible:
+
+- Assign each accent one meaning at the start, then never reuse that hue
+  decoratively. If amber means "secret," an amber border somewhere unrelated
+  reads as "this is secret" and misleads.
+- Keep one dominant accent plus one or two sharp supports. Evenly distributed
+  rainbows flatten the hierarchy and read as decoration, not signal.
+- Reserve red for the single most important constraint (the boundary nothing
+  crosses). Overusing red dilutes the one place it should stop the eye.
+
+When a different tone fits (an editorial light theme for a public explainer, a
+warmer palette for a consumer product), change the palette but keep the
+one-color-one-meaning discipline. The discipline travels; the specific hues do
+not.
+
+## Fonts: pick characterful, pair display with mono
+
+Avoid Inter, Roboto, Arial, and the system stack. They read as a default and
+strip the graphic of identity. Pair a characterful display face for headings
+with a monospace for commands, labels, and pins (the mono signals "this is code
+or a precise value").
+
+Default pairing: `Chakra Petch` (display, technical and slightly HUD-like) with
+`JetBrains Mono` (mono). Both load from a single Google Fonts link.
+
+Other pairings that hold up, by tone:
+
+- Technical or HUD: `Chakra Petch`, `Orbitron` (sparingly), `Major Mono Display`
+  (extreme, headers only) with `JetBrains Mono` or `IBM Plex Mono`.
+- Editorial or refined: `Archivo` or `Archivo Expanded`, `Fraunces` (display)
+  with `Space Mono` or `Sometype Mono`.
+- Geometric or bold: `Syne`, `Clash Display` (if available) with `Space Mono`.
+
+Use the mono for every command, every pin label, and every section number. The
+contrast between a soft display face and a precise mono is what gives the
+schematic its instrument-panel feel.
+
+## Spines: the structural vocabulary
+
+Most system explainers are built from four blocks. Pick the spine that matches
+the single most important thing the reader needs to understand.
+
+- Pipeline (A to B to C). A horizontal row of nodes joined by flowing arrows.
+  Best when the story is a transform: input goes through stages to output.
+- Perimeter map (trust boundary). A bordered region labeled "inside" (for
+  example "your machine") containing the local nodes, with labeled wires that
+  cross the border, plus a seal callout for the invariant ("secrets never
+  cross"). Best when the key insight is what stays local versus what leaves.
+  This is usually the centerpiece for security and data-flow systems.
+- Phase blocks. Cards or columns tagged by cadence: one-time, per-call,
+  continuous. Best when the same system behaves differently depending on when a
+  step runs.
+- Numbered setup checklist. Ordered steps with copy-able command chips. Color
+  the step number of any step that touches something risky or irreversible (a
+  login, a keychain grant, an exposure) so the eye finds it.
+
+A complete system explainer usually combines three of these: a perimeter map or
+pipeline as the centerpiece, phase cards for the sequence, and a setup checklist
+for "what the reader does." Invariant chips (small cards stating the rules that
+make the system safe or correct) sit well between the phases and the checklist.
+
+## Composition notes
+
+- A faint blueprint grid plus a soft radial glow gives depth without clutter.
+  Mask the grid so it fades at the edges rather than tiling flatly.
+- Lead with one bold thesis in the hero: the single sentence a reader should
+  remember. Color two or three words with the accents to preview the meaning
+  map.
+- Spend space generously between sections. An infographic is read in one scroll,
+  so vertical rhythm carries the pacing.
+- One staggered reveal on load (sections fade up as they enter) creates sequence
+  without spectacle. Keep per-element micro-animations rare.

--- a/plugins/docs/skills/system-infographic/references/screenshot-qa.md
+++ b/plugins/docs/skills/system-infographic/references/screenshot-qa.md
@@ -1,0 +1,67 @@
+# Screenshot QA: render and inspect before hand-off
+
+Read this before delivering an infographic. It covers the headless-render loop
+that catches the layout bugs reading the markup hides, the snippet to produce a
+full-page screenshot, and the checklist of what to look at in the image.
+
+## Why render at all
+
+Markup looks correct in source and still ships broken: text overflows its node,
+dim text fails contrast on the dark canvas, a flex row wraps badly at a width
+you did not test, or reveal-on-scroll blocks never become visible. None of these
+are visible by reading the HTML. Rendering and looking at the pixels is the only
+reliable check.
+
+## The snippet
+
+Use the Playwright Chromium that ships with most repos, or any headless
+Chromium. Scroll to the bottom first so any IntersectionObserver reveal fires,
+then capture full-page.
+
+```python
+from playwright.sync_api import sync_playwright
+import pathlib
+
+url = pathlib.Path("docs/how-it-works.html").resolve().as_uri()
+with sync_playwright() as p:
+    b = p.chromium.launch()
+    pg = b.new_page(viewport={"width": 1100, "height": 900}, device_scale_factor=2)
+    pg.goto(url)
+    pg.wait_for_timeout(1200)
+    pg.evaluate("window.scrollTo(0, document.body.scrollHeight)")  # fire reveals
+    pg.wait_for_timeout(800)
+    pg.evaluate("window.scrollTo(0, 0)")
+    pg.wait_for_timeout(300)
+    pg.screenshot(path="/tmp/infographic.png", full_page=True)
+    b.close()
+```
+
+Then open or read `/tmp/infographic.png` and actually look at it. For a narrow
+check, run it again with `viewport={"width": 800, "height": 900}` and compare.
+
+## What to look for
+
+- Reveal blocks all fired. If a section is blank in the screenshot, the
+  scroll-to-bottom step was skipped or the reveal threshold never tripped. Any
+  block still at opacity 0 in a full-page capture is a bug, not a style.
+- No overflow or clipping. Long node titles and command chips are the usual
+  culprits. Commands should wrap or scroll inside their chip, not spill.
+- Contrast holds. Dim and faint text on the dark canvas is the first thing to
+  fail. If a label is hard to read in the screenshot, it is unreadable on a
+  laptop in daylight.
+- Connectors land. Arrows and wires between nodes should point at the right
+  thing after any responsive wrap. A rotated arrow that now points sideways is a
+  common narrow-width break.
+- Narrow viewport collapses cleanly. Around 800px the multi-column grids should
+  stack and the horizontal pipeline should become vertical. Check that nothing
+  becomes a one-pixel sliver.
+- Print preview is legible. If PDF export matters, confirm the `@media print`
+  block flattens the dark theme and avoids breaking cards across pages.
+
+## A note on reveal animations
+
+If the body uses reveal-on-scroll (sections fading up as they enter the
+viewport), a screenshot taken before scrolling will capture them invisible. The
+scroll-to-bottom step in the snippet exists for exactly this reason. When in
+doubt, also disable the reveal for the capture by adding a `.rv{opacity:1}`
+override in the page, or screenshot after the full scroll.


### PR DESCRIPTION
## Summary
Adds a new procedural skill **`docs/system-infographic`** that produces a single self-contained HTML infographic explaining how a system, flow, pipeline, architecture, or setup works.

Generalized from a real artifact (a "how it works" infographic built for a side project), then authored against the `meta:authoring-skills` chassis.

**Bundle:**
- `SKILL.md` (86 lines) — procedural shape: When to Use / Input / Workflow / Output / Outcomes / dated Recommendations / References.
- `assets/template.html` — fillable starter skeleton (the CSS system + commented blocks).
- `assets/example-how-it-works.html` — the flagship worked example.
- `references/aesthetic-system.md` — semantic color system, font pairings, the 4 structural "spines".
- `references/screenshot-qa.md` — headless render-and-inspect loop with a Playwright snippet.

Bumps `docs` plugin to **1.1.0** + CHANGELOG entry.

## Chassis compliance
- 0 em-dashes in `SKILL.md` + references; no marketing language.
- `name` matches directory; description carries trigger phrases + explicit non-triggers (defers to `fuma`, `frontend-design`, charting).
- Outcomes with evidence signals; recommendations laddered under outcomes.
- Template rendered and visually verified.

## Test Plan
- [ ] Routing: "make me an infographic of how X works" should fire this skill.
- [ ] Adjacent prompt "write the API reference docs" should route to `fuma`, not this.
- [ ] Borderline "build a usage dashboard from this dataset" should NOT fire (non-trigger).
- [ ] `assets/template.html` opens in a browser and renders all blocks.