### PR TITLE
feat(sdlc): extract git-worktree skill from command

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Replace `sdlc` with any plugin name (`workspace`, `research`, `meta`, `docs`) in
 
 | Plugin | Commands | Skills | Agents | Hooks |
 |--------|----------|--------|--------|-------|
-| **sdlc** | `git_push`, `git_merge`, `git_merge-cycle`, `git_fetch`, `git_worktree`, `git_set-attributions`, `review`, `validate_security-hooks`, `browser`, `browser_ui-review` | `git`, `commit`, `pre-commit-qa`, `qa-setup`, `testing-expert`, `review`, `prioritize`, `env-management`, `centralized-configuration`, `macos-keychain-secrets`, `browser` | `env-reviewer`, `browser-qa-agent` | PreToolUse security validators, UserPromptSubmit PII detection, git hooks |
+| **sdlc** | `git_push`, `git_merge`, `git_merge-cycle`, `git_fetch`, `git_worktree`, `git_set-attributions`, `review`, `validate_security-hooks`, `browser`, `browser_ui-review` | `git`, `git-worktree`, `commit`, `pre-commit-qa`, `qa-setup`, `testing-expert`, `review`, `prioritize`, `env-management`, `centralized-configuration`, `macos-keychain-secrets`, `browser` | `env-reviewer`, `browser-qa-agent` | PreToolUse security validators, UserPromptSubmit PII detection, git hooks |
 | **workspace** | -- | -- | -- | Session lifecycle, tool observability, structured JSONL event emission |
 | **research** | `scrape_docs` | -- | -- | -- |
 | **meta** | `create-command`, `create-prime`, `create-doc-sync` | `prompt-generator` | -- | -- |

--- a/plugins/sdlc/.claude-plugin/plugin.json
+++ b/plugins/sdlc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Software Development Lifecycle — commit, review, QA, testing, security hooks, git hooks, and infrastructure configuration for Claude Code agents",
   "author": {
     "name": "NeuralEmpowerment"

--- a/plugins/sdlc/CHANGELOG.md
+++ b/plugins/sdlc/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
 
+## 1.4.0
+- Add `git-worktree` skill: create/list/status/remove worktrees in a sibling `<repo>_worktrees/` dir, backed by `scripts/worktree.sh`
+- `git_worktree` command is now a thin wrapper that invokes the `git-worktree` skill
+- `git` skill cross-references `git-worktree` for worktree operations
+
 ## 1.0.0
 - Consolidated from core/security, devops/git, devops/config, qa/quality, testing/expert, review/prioritize, and workflow/merge-cycle

--- a/plugins/sdlc/CHANGELOG.md
+++ b/plugins/sdlc/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add `git-worktree` skill: create/list/status/remove worktrees in a sibling `<repo>_worktrees/` dir, backed by `scripts/worktree.sh`
 - `git_worktree` command is now a thin wrapper that invokes the `git-worktree` skill
 - `git` skill cross-references `git-worktree` for worktree operations
+- Robustness (from Codex review of #198): `create PR#N` fetches `pull/N/head` so fork PRs check out the actual PR code; `remove` refuses ambiguous fuzzy matches and warns on uncommitted changes; `status` guards against stale/missing worktree dirs under `set -e`
 
 ## 1.0.0
 - Consolidated from core/security, devops/git, devops/config, qa/quality, testing/expert, review/prioritize, and workflow/merge-cycle

--- a/plugins/sdlc/commands/git_worktree.md
+++ b/plugins/sdlc/commands/git_worktree.md
@@ -2,323 +2,38 @@
 description: Manage git worktrees in isolated sibling directory
 argument-hint: <create|list|status|remove> [name] [branch] [base-branch]
 model: sonnet
-allowed-tools: Bash
+allowed-tools: Bash, Skill
 ---
 
 # Worktree
 
-Manage git worktrees in a sibling directory to keep each Claude session in a single isolated repo context.
+Thin entry point for the `sdlc:git-worktree` skill. The skill owns the logic
+(parsing, naming, the executable); this command just routes a slash invocation
+to it with the user's arguments.
 
-## Purpose
+## Action
 
-*Level 3 (Control Flow)*
+Invoke the **`sdlc:git-worktree`** skill, passing `$ARGUMENTS` through as the
+`<action> [name] [branch] [base-branch]` it expects. The skill drives
+`scripts/worktree.sh` to create, list, inspect, or remove worktrees in the
+sibling `../<repo>_worktrees/` directory.
 
-Create, list, inspect, and remove git worktrees. Worktrees are stored in `../<repo-name>_worktrees/` as sibling directories so each agent context stays isolated.
-
-## Variables
-
-ACTION: $1                        # create, list, status, remove
-NAME: $2                          # Worktree/branch name or PR#<N>
-BRANCH: $3                        # Explicit branch (optional)
-BASE_BRANCH: $4                   # Base branch override (optional)
-
-## Instructions
-
-- Always create worktrees in the sibling `_worktrees/` directory, never inside the repo
-- Enforce `YYYYMMDD_<kebab-case-name>` directory naming
-- Smart-parse NAME: PR references, branch prefixes, or plain text
-- Auto-detect default branch via `git symbolic-ref refs/remotes/origin/HEAD`
-- Strip common branch prefixes (`feat/`, `fix/`, `chore/`, `hotfix/`, `release/`) for cleaner dir names
-
-## Workflow
-
-### 1. Setup
-
-```bash
-REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")
-REPO_ROOT=$(git rev-parse --show-toplevel)
-WORKTREE_DIR="$(dirname "$REPO_ROOT")/${REPO_NAME}_worktrees"
-ACTION="$1"
-DATE_PREFIX=$(date +%Y%m%d)
-
-echo "=== Worktree Manager ==="
-echo "Repo: ${REPO_NAME}"
-echo "Worktree dir: ${WORKTREE_DIR}"
-
-if [ -z "$ACTION" ]; then
-  echo ""
-  echo "Usage: /worktree <create|list|status|remove> [name] [branch] [base-branch]"
-  echo ""
-  echo "Actions:"
-  echo "  create  <name>        Create worktree + feature branch"
-  echo "  list                  List all worktrees"
-  echo "  status                Show branch, changes, PR info per worktree"
-  echo "  remove  <name>        Remove a worktree"
-  exit 1
-fi
-```
-
-### 2. Route Action
-
-Dispatch to the matching action handler below.
-
-### Action: create
-
-Parse the input to determine the directory name and branch:
-
-```bash
-INPUT="$2"
-EXPLICIT_BRANCH="$3"
-EXPLICIT_BASE="$4"
-
-if [ -z "$INPUT" ]; then
-  echo "Usage: /worktree create <name|branch|PR#N>"
-  exit 1
-fi
-
-# Auto-detect default branch
-if [ -n "$EXPLICIT_BASE" ]; then
-  BASE_BRANCH="$EXPLICIT_BASE"
-else
-  BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
-  if [ -z "$BASE_BRANCH" ]; then
-    BASE_BRANCH="main"
-    echo "Could not detect default branch, falling back to: ${BASE_BRANCH}"
-  fi
-fi
-
-# --- Smart input parsing ---
-
-# PR reference: PR#<N> or #<N>
-if echo "$INPUT" | grep -qE '^(PR)?#[0-9]+$'; then
-  PR_NUM=$(echo "$INPUT" | grep -oE '[0-9]+')
-  echo "Fetching branch for PR #${PR_NUM}..."
-  PR_BRANCH=$(gh pr view "$PR_NUM" --json headRefName -q '.headRefName' 2>/dev/null)
-  if [ -z "$PR_BRANCH" ]; then
-    echo "Could not find PR #${PR_NUM}"
-    exit 1
-  fi
-  BRANCH_NAME="$PR_BRANCH"
-  # Strip prefix for dir name
-  DIR_SLUG=$(echo "$PR_BRANCH" | sed -E 's|^(feat|fix|chore|hotfix|release)/||')
-  WORKTREE_NAME="${DATE_PREFIX}_${DIR_SLUG}"
-  echo "PR #${PR_NUM} -> branch: ${PR_BRANCH}"
-
-# Branch-like input: feat/..., fix/..., etc.
-elif echo "$INPUT" | grep -qE '^(feat|fix|chore|hotfix|release)/'; then
-  BRANCH_NAME="$INPUT"
-  DIR_SLUG=$(echo "$INPUT" | sed -E 's|^(feat|fix|chore|hotfix|release)/||')
-  WORKTREE_NAME="${DATE_PREFIX}_${DIR_SLUG}"
-
-# Plain text: use as name, create new branch
-else
-  # Enforce kebab-case
-  DIR_SLUG=$(echo "$INPUT" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
-  WORKTREE_NAME="${DATE_PREFIX}_${DIR_SLUG}"
-  BRANCH_NAME="${EXPLICIT_BRANCH:-${DIR_SLUG}}"
-fi
-
-echo ""
-echo "=== Creating Worktree ==="
-echo "Directory: ${WORKTREE_NAME}"
-echo "Branch: ${BRANCH_NAME}"
-echo "Base: ${BASE_BRANCH}"
-
-mkdir -p "$WORKTREE_DIR"
-git fetch origin
-
-# Check if branch already exists on remote
-if git show-ref --verify --quiet "refs/remotes/origin/${BRANCH_NAME}" 2>/dev/null; then
-  echo "Branch exists on remote, checking out..."
-  git worktree add "$WORKTREE_DIR/$WORKTREE_NAME" "$BRANCH_NAME"
-# Check if branch exists locally
-elif git show-ref --verify --quiet "refs/heads/${BRANCH_NAME}" 2>/dev/null; then
-  echo "Branch exists locally, checking out..."
-  git worktree add "$WORKTREE_DIR/$WORKTREE_NAME" "$BRANCH_NAME"
-else
-  echo "Creating new branch from origin/${BASE_BRANCH}..."
-  git worktree add -b "$BRANCH_NAME" "$WORKTREE_DIR/$WORKTREE_NAME" "origin/$BASE_BRANCH"
-fi
-
-if [ $? -ne 0 ]; then
-  echo "Worktree creation failed"
-  exit 1
-fi
-
-echo ""
-echo "Worktree created: ${WORKTREE_DIR}/${WORKTREE_NAME}"
-echo "Branch: ${BRANCH_NAME} (from ${BASE_BRANCH})"
-echo "Path: ${WORKTREE_DIR}/${WORKTREE_NAME}"
-```
-
-### Action: list
-
-```bash
-echo ""
-echo "=== Worktrees ==="
-git worktree list
-```
-
-### Action: status
-
-```bash
-echo ""
-echo "=== Worktree Status ==="
-
-git worktree list --porcelain | grep '^worktree ' | sed 's/^worktree //' | while read -r WT_PATH; do
-  echo ""
-  echo "--- $(basename "$WT_PATH") ---"
-  echo "Path: ${WT_PATH}"
-
-  BRANCH=$(cd "$WT_PATH" && git branch --show-current 2>/dev/null)
-  echo "Branch: ${BRANCH:-"(detached)"}"
-
-  # Uncommitted changes
-  CHANGES=$(cd "$WT_PATH" && git status --short 2>/dev/null | wc -l | tr -d ' ')
-  if [ "$CHANGES" -gt 0 ]; then
-    echo "Changes: ${CHANGES} file(s) modified"
-  else
-    echo "Changes: clean"
-  fi
-
-  # Ahead/behind
-  AHEAD_BEHIND=$(cd "$WT_PATH" && git rev-list --left-right --count HEAD...@{u} 2>/dev/null)
-  if [ -n "$AHEAD_BEHIND" ]; then
-    AHEAD=$(echo "$AHEAD_BEHIND" | awk '{print $1}')
-    BEHIND=$(echo "$AHEAD_BEHIND" | awk '{print $2}')
-    echo "Ahead: ${AHEAD}  Behind: ${BEHIND}"
-  fi
-
-  # PR info
-  if command -v gh &>/dev/null && [ -n "$BRANCH" ]; then
-    PR_INFO=$(gh pr list --head "$BRANCH" --json number,state,title --jq '.[0] | "PR #\(.number) [\(.state)] \(.title)"' 2>/dev/null)
-    if [ -n "$PR_INFO" ]; then
-      echo "PR: ${PR_INFO}"
-    else
-      echo "PR: none"
-    fi
-  fi
-done
-```
-
-### Action: remove
-
-```bash
-TARGET="$2"
-
-if [ -z "$TARGET" ]; then
-  echo "Usage: /worktree remove <name>"
-  echo ""
-  echo "Available worktrees:"
-  git worktree list
-  exit 1
-fi
-
-# Resolve full path — support both bare name and full path
-if [ -d "$WORKTREE_DIR/$TARGET" ]; then
-  WT_PATH="$WORKTREE_DIR/$TARGET"
-elif [ -d "$TARGET" ]; then
-  WT_PATH="$TARGET"
-else
-  # Try partial match on directory name
-  MATCH=$(ls -d "$WORKTREE_DIR"/*"$TARGET"* 2>/dev/null | head -1)
-  if [ -n "$MATCH" ]; then
-    WT_PATH="$MATCH"
-    echo "Matched: $(basename "$WT_PATH")"
-  else
-    echo "Worktree not found: ${TARGET}"
-    echo ""
-    echo "Available worktrees:"
-    git worktree list
-    exit 1
-  fi
-fi
-
-echo "=== Removing Worktree ==="
-echo "Path: ${WT_PATH}"
-
-git worktree remove --force "$WT_PATH"
-
-if [ $? -ne 0 ]; then
-  echo "Failed to remove worktree"
-  exit 1
-fi
-
-git worktree prune
-echo "Worktree removed: $(basename "$WT_PATH")"
-```
-
-## Report
-
-```markdown
-## Worktree Operation Complete
-
-**Action:** ${ACTION}
-**Repo:** ${REPO_NAME}
-**Worktree dir:** ${WORKTREE_DIR}
-
-### Result
-
-| Step | Status |
-|------|--------|
-| ${ACTION} | Done |
-
-### Current Worktrees
-
-<output of git worktree list>
-
-### Next Steps
-
-- After create: `cd <worktree-path>` and start working
-- After remove: verify with `/worktree list`
-- Use `/worktree status` to see branch and PR info across all worktrees
-```
+If `$ARGUMENTS` is empty, ask which action the user wants
+(`create`, `list`, `status`, `remove`).
 
 ## Examples
 
-### Example 1: Create from plain text
 ```
-/worktree create auth-refactor
+/sdlc:git_worktree create auth-refactor      # new branch + YYYYMMDD_auth-refactor dir
+/sdlc:git_worktree create PR#42              # check out PR #42's branch in isolation
+/sdlc:git_worktree create feat/user-settings # dir YYYYMMDD_user-settings, branch feat/user-settings
+/sdlc:git_worktree list                      # list all worktrees
+/sdlc:git_worktree status                    # branch, changes, ahead/behind, PR per worktree
+/sdlc:git_worktree remove 20260608_auth-refactor
 ```
-Creates `YYYYMMDD_auth-refactor` with branch `auth-refactor` from default base.
-
-### Example 2: Create from PR
-```
-/worktree create PR#42
-```
-Fetches the branch for PR #42, creates worktree with date-prefixed dir name.
-
-### Example 3: Create from branch name
-```
-/worktree create feat/user-settings
-```
-Uses `feat/user-settings` as branch, creates dir `YYYYMMDD_user-settings`.
-
-### Example 4: Create with explicit base branch
-```
-/worktree create my-fix bugfix/login-error develop
-```
-Creates branch `bugfix/login-error` from `develop` in dir `YYYYMMDD_my-fix`.
-
-### Example 5: List worktrees
-```
-/worktree list
-```
-
-### Example 6: Status of all worktrees
-```
-/worktree status
-```
-Shows branch, uncommitted changes, ahead/behind, and PR info for each worktree.
-
-### Example 7: Remove a worktree
-```
-/worktree remove 20260212_auth-refactor
-```
-Force-removes the worktree and prunes stale entries.
 
 ## Integration Points
 
-- Pairs with `/devops/push` for pushing from worktree branches
-- Use `/devops/commit` inside a worktree for structured commits
-- Worktrees share the same `.git` — all branches are visible across worktrees
+- Pairs with `/sdlc:git_push` for pushing from worktree branches.
+- Use `/sdlc:commit` inside a worktree for structured commits.
+- The `git` skill cross-references this skill for worktree operations.

--- a/plugins/sdlc/skills/git-worktree/SKILL.md
+++ b/plugins/sdlc/skills/git-worktree/SKILL.md
@@ -33,11 +33,11 @@ ${CLAUDE_PLUGIN_ROOT}/skills/git-worktree/scripts/worktree.sh <action> [name] [b
 
 1. **Parse intent into an action.** Map the request to one of `create`, `list`, `status`, `remove`. If ambiguous, ask which.
 2. **Run the script** with the parsed arguments. It handles base-branch auto-detection (`origin/HEAD`), PR-ref lookup via `gh`, branch-prefix stripping for clean directory names, and existing-branch reuse (remote → local → new).
-3. **For `remove`, confirm the target first** when the user gave a partial or fuzzy name — the script force-removes and prunes, which is hard to undo. Show `list` output and confirm before running.
+3. **For `remove`, confirm the target first** when the user gave a partial or fuzzy name — the script force-removes and prunes, which is hard to undo. It refuses ambiguous fuzzy matches and warns about uncommitted changes before removing, but still show `list` output and confirm before running.
 4. **Report** the resulting path and branch. After `create`, tell the user to `cd` into the printed path to start working.
 
 Input parsing the script applies on `create`:
-- `PR#42` / `#42` → resolves the PR's head branch via `gh`, dir becomes `YYYYMMDD_<branch-without-prefix>`.
+- `PR#42` / `#42` → resolves the PR's head via `gh`, fetches `pull/42/head` into a local branch (works for fork PRs too), dir becomes `YYYYMMDD_<branch-without-prefix>`.
 - `feat/foo` (or `fix/`, `chore/`, `hotfix/`, `release/`) → uses it as the branch, strips the prefix for the dir name.
 - Plain text → kebab-cased as both dir slug and (by default) branch name.
 

--- a/plugins/sdlc/skills/git-worktree/SKILL.md
+++ b/plugins/sdlc/skills/git-worktree/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: git-worktree
+description: Create, list, inspect, and remove git worktrees in an isolated sibling directory so each agent session works in its own repo context. Use when the user wants to "create a worktree", "spin up a worktree", "work on a PR in isolation", "check out PR#N in a worktree", "list/clean up worktrees", "parallel branch workspace", or "isolated workspace for a feature". Triggers on "worktree", "git worktree", "isolated checkout", "sibling workspace", "parallel feature branch". Do NOT use for general push/merge/fetch/PR-lifecycle git work (use the `git` skill), for plain branch creation without a separate directory, or for a single simple commit (use `commit`).
+---
+
+# Git Worktree
+
+## When to Use (and When NOT to Use)
+
+Use when:
+- You want a feature branch to live in its own directory so the current workspace stays untouched (parallel agent sessions, long-running experiments).
+- You need to check out a PR's branch in isolation to test or build on it.
+- You want to list, inspect (branch / changes / ahead-behind / PR), or clean up existing worktrees.
+
+Do NOT use when:
+- The operation is push, merge, fetch, or PR lifecycle — use the `git` skill.
+- You just need a new branch in the same directory — `git checkout -b` is enough.
+- You are committing staged changes — use `commit`.
+
+## Input
+
+- A git repository (the script resolves the toplevel itself).
+- For `create`: a name, branch ref, or PR reference. Optional explicit branch and base branch.
+- For `create`/`status` from a PR: `gh` authenticated for the repo (optional — falls back gracefully).
+
+## Workflow
+
+All actions are driven by the bundled script, which enforces the sibling-directory layout and `YYYYMMDD_<kebab-case>` naming. Pass the user's arguments straight through:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/skills/git-worktree/scripts/worktree.sh <action> [name] [branch] [base-branch]
+```
+
+1. **Parse intent into an action.** Map the request to one of `create`, `list`, `status`, `remove`. If ambiguous, ask which.
+2. **Run the script** with the parsed arguments. It handles base-branch auto-detection (`origin/HEAD`), PR-ref lookup via `gh`, branch-prefix stripping for clean directory names, and existing-branch reuse (remote → local → new).
+3. **For `remove`, confirm the target first** when the user gave a partial or fuzzy name — the script force-removes and prunes, which is hard to undo. Show `list` output and confirm before running.
+4. **Report** the resulting path and branch. After `create`, tell the user to `cd` into the printed path to start working.
+
+Input parsing the script applies on `create`:
+- `PR#42` / `#42` → resolves the PR's head branch via `gh`, dir becomes `YYYYMMDD_<branch-without-prefix>`.
+- `feat/foo` (or `fix/`, `chore/`, `hotfix/`, `release/`) → uses it as the branch, strips the prefix for the dir name.
+- Plain text → kebab-cased as both dir slug and (by default) branch name.
+
+## Output
+
+- A worktree directory under `../<repo>_worktrees/` (on `create`), or a removed/listed/inspected worktree.
+- Plain-text status to stdout; exit `0` on success, `1` on failure.
+- No commits, no pushes — worktrees share the repo's `.git`, so all branches are visible across them.
+
+## Outcomes we are looking for
+
+- **Each agent session is isolated.** Concurrent work happens in separate directories with no checkout thrash on the main workspace.
+- **Worktree names are predictable.** Every directory is `YYYYMMDD_<kebab-case>`, so listings sort chronologically and never collide with the repo itself.
+
+## Recommended tools and practices (as of 2026-06-08)
+
+### For: each agent session is isolated
+- **Keep worktrees as siblings, never nested inside the repo.** The script enforces `../<repo>_worktrees/`; a worktree inside the repo confuses tooling and git status.
+- **One worktree per concurrent task.** Pairs with parallel-agent dispatch — each agent gets its own directory and branch.
+
+### For: predictable, low-friction cleanup
+- **Remove worktrees when the branch merges.** Use `remove`, then verify with `list`; the script prunes stale metadata automatically.
+- **Use `status` before cleanup** to spot uncommitted changes or unmerged commits in a worktree you are about to delete.
+
+## References
+
+- `scripts/worktree.sh`: the executable that performs all four actions. Self-contained; safe to run directly.
+- The `git` skill (same plugin) covers push / merge / fetch / PR lifecycle and cross-references this skill for worktree work.

--- a/plugins/sdlc/skills/git-worktree/scripts/worktree.sh
+++ b/plugins/sdlc/skills/git-worktree/scripts/worktree.sh
@@ -62,11 +62,12 @@ cmd_create() {
     fi
   fi
 
-  local branch_name dir_slug worktree_name
+  local branch_name dir_slug worktree_name is_pr="" pr_num=""
 
   if echo "$input" | grep -qE '^(PR)?#[0-9]+$'; then
     # PR reference: PR#<N> or #<N>
-    local pr_num pr_branch
+    local pr_branch
+    is_pr=1
     pr_num=$(echo "$input" | grep -oE '[0-9]+')
     echo "Fetching branch for PR #${pr_num}..."
     pr_branch=$(gh pr view "$pr_num" --json headRefName -q '.headRefName' 2>/dev/null || true)
@@ -74,6 +75,8 @@ cmd_create() {
       echo "Could not find PR #${pr_num}" >&2
       exit 1
     fi
+    # Use a local branch name for the worktree. Fetch pull/<N>/head so this
+    # works for fork PRs too, where origin/<headRefName> does not exist.
     branch_name="$pr_branch"
     dir_slug=$(strip_prefix "$pr_branch")
     worktree_name="${DATE_PREFIX}_${dir_slug}"
@@ -99,7 +102,14 @@ cmd_create() {
   mkdir -p "$WORKTREE_DIR"
   git fetch origin
 
-  if git show-ref --verify --quiet "refs/remotes/origin/${branch_name}" 2>/dev/null; then
+  if [ -n "$is_pr" ]; then
+    # Fetch the PR head into a local branch — covers same-repo and fork PRs,
+    # since origin/<branch_name> may not exist for forks.
+    echo "Fetching pull/${pr_num}/head into ${branch_name}..."
+    git fetch origin "pull/${pr_num}/head:${branch_name}" 2>/dev/null \
+      || git fetch origin "+refs/pull/${pr_num}/head:${branch_name}"
+    git worktree add "$WORKTREE_DIR/$worktree_name" "$branch_name"
+  elif git show-ref --verify --quiet "refs/remotes/origin/${branch_name}" 2>/dev/null; then
     echo "Branch exists on remote, checking out..."
     git worktree add "$WORKTREE_DIR/$worktree_name" "$branch_name"
   elif git show-ref --verify --quiet "refs/heads/${branch_name}" 2>/dev/null; then
@@ -130,6 +140,11 @@ cmd_status() {
     echo ""
     echo "--- $(basename "$wt_path") ---"
     echo "Path: ${wt_path}"
+
+    if [ ! -d "$wt_path" ]; then
+      echo "Status: missing on disk (run 'worktree.sh remove' to prune)"
+      continue
+    fi
 
     local branch changes ahead_behind ahead behind pr_info
     branch=$(cd "$wt_path" && git branch --show-current 2>/dev/null || true)
@@ -171,27 +186,44 @@ cmd_remove() {
     exit 1
   fi
 
-  local wt_path match
+  local wt_path matches match_count
   if [ -d "$WORKTREE_DIR/$target" ]; then
     wt_path="$WORKTREE_DIR/$target"
   elif [ -d "$target" ]; then
     wt_path="$target"
   else
-    match=$(ls -d "$WORKTREE_DIR"/*"$target"* 2>/dev/null | head -1 || true)
-    if [ -n "$match" ]; then
-      wt_path="$match"
-      echo "Matched: $(basename "$wt_path")"
-    else
+    # Fuzzy match — refuse to act if it is ambiguous, so we never force-remove
+    # the wrong worktree (and lose uncommitted work in it).
+    matches=$(ls -d "$WORKTREE_DIR"/*"$target"* 2>/dev/null || true)
+    match_count=$(printf '%s\n' "$matches" | grep -c . || true)
+    if [ "$match_count" -eq 0 ]; then
       echo "Worktree not found: ${target}" >&2
       echo ""
       echo "Available worktrees:" >&2
       git worktree list >&2
       exit 1
+    elif [ "$match_count" -gt 1 ]; then
+      echo "Ambiguous target '${target}' matches ${match_count} worktrees:" >&2
+      printf '%s\n' "$matches" | while read -r m; do echo "  $(basename "$m")" >&2; done
+      echo "Re-run with the full directory name." >&2
+      exit 1
     fi
+    wt_path="$matches"
+    echo "Matched: $(basename "$wt_path")"
   fi
 
   echo "=== Removing Worktree ==="
   echo "Path: ${wt_path}"
+
+  # Surface uncommitted changes before the force-remove discards them.
+  if [ -d "$wt_path" ]; then
+    local dirty
+    dirty=$(cd "$wt_path" && git status --short 2>/dev/null | wc -l | tr -d ' ')
+    if [ "${dirty:-0}" -gt 0 ]; then
+      echo "⚠️  ${dirty} uncommitted change(s) in this worktree will be lost:"
+      (cd "$wt_path" && git status --short 2>/dev/null) || true
+    fi
+  fi
 
   git worktree remove --force "$wt_path"
   git worktree prune

--- a/plugins/sdlc/skills/git-worktree/scripts/worktree.sh
+++ b/plugins/sdlc/skills/git-worktree/scripts/worktree.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# Manage git worktrees in a sibling `<repo>_worktrees/` directory so each agent
+# session stays in an isolated repo context.
+#
+# Usage: worktree.sh <create|list|status|remove> [name] [branch] [base-branch]
+#   create <name|branch|PR#N> [branch] [base]  Create worktree + feature branch
+#   list                                       List all worktrees
+#   status                                     Branch, changes, ahead/behind, PR per worktree
+#   remove <name|path>                         Remove a worktree and prune
+#
+# Naming: worktree dirs are forced to `YYYYMMDD_<kebab-case-name>`.
+# Output is plain text; exit 0 on success, 1 on failure.
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+REPO_NAME=$(basename "$REPO_ROOT")
+WORKTREE_DIR="$(dirname "$REPO_ROOT")/${REPO_NAME}_worktrees"
+DATE_PREFIX=$(date +%Y%m%d)
+
+ACTION="${1:-}"
+
+usage() {
+  cat <<EOF
+=== Worktree Manager ===
+Repo: ${REPO_NAME}
+Worktree dir: ${WORKTREE_DIR}
+
+Usage: worktree.sh <create|list|status|remove> [name] [branch] [base-branch]
+
+Actions:
+  create  <name>        Create worktree + feature branch
+  list                  List all worktrees
+  status                Show branch, changes, PR info per worktree
+  remove  <name>        Remove a worktree
+EOF
+}
+
+slugify() {
+  echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g; s/--*/-/g; s/^-//; s/-$//'
+}
+
+strip_prefix() {
+  echo "$1" | sed -E 's|^(feat|fix|chore|hotfix|release)/||'
+}
+
+cmd_create() {
+  local input="${1:-}" explicit_branch="${2:-}" explicit_base="${3:-}"
+  if [ -z "$input" ]; then
+    echo "Usage: worktree.sh create <name|branch|PR#N>" >&2
+    exit 1
+  fi
+
+  # Auto-detect default base branch unless overridden
+  local base_branch
+  if [ -n "$explicit_base" ]; then
+    base_branch="$explicit_base"
+  else
+    base_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' || true)
+    if [ -z "$base_branch" ]; then
+      base_branch="main"
+      echo "Could not detect default branch, falling back to: ${base_branch}"
+    fi
+  fi
+
+  local branch_name dir_slug worktree_name
+
+  if echo "$input" | grep -qE '^(PR)?#[0-9]+$'; then
+    # PR reference: PR#<N> or #<N>
+    local pr_num pr_branch
+    pr_num=$(echo "$input" | grep -oE '[0-9]+')
+    echo "Fetching branch for PR #${pr_num}..."
+    pr_branch=$(gh pr view "$pr_num" --json headRefName -q '.headRefName' 2>/dev/null || true)
+    if [ -z "$pr_branch" ]; then
+      echo "Could not find PR #${pr_num}" >&2
+      exit 1
+    fi
+    branch_name="$pr_branch"
+    dir_slug=$(strip_prefix "$pr_branch")
+    worktree_name="${DATE_PREFIX}_${dir_slug}"
+    echo "PR #${pr_num} -> branch: ${pr_branch}"
+  elif echo "$input" | grep -qE '^(feat|fix|chore|hotfix|release)/'; then
+    # Branch-like input: feat/..., fix/..., etc.
+    branch_name="$input"
+    dir_slug=$(strip_prefix "$input")
+    worktree_name="${DATE_PREFIX}_${dir_slug}"
+  else
+    # Plain text: use as name, create new branch
+    dir_slug=$(slugify "$input")
+    worktree_name="${DATE_PREFIX}_${dir_slug}"
+    branch_name="${explicit_branch:-${dir_slug}}"
+  fi
+
+  echo ""
+  echo "=== Creating Worktree ==="
+  echo "Directory: ${worktree_name}"
+  echo "Branch: ${branch_name}"
+  echo "Base: ${base_branch}"
+
+  mkdir -p "$WORKTREE_DIR"
+  git fetch origin
+
+  if git show-ref --verify --quiet "refs/remotes/origin/${branch_name}" 2>/dev/null; then
+    echo "Branch exists on remote, checking out..."
+    git worktree add "$WORKTREE_DIR/$worktree_name" "$branch_name"
+  elif git show-ref --verify --quiet "refs/heads/${branch_name}" 2>/dev/null; then
+    echo "Branch exists locally, checking out..."
+    git worktree add "$WORKTREE_DIR/$worktree_name" "$branch_name"
+  else
+    echo "Creating new branch from origin/${base_branch}..."
+    git worktree add -b "$branch_name" "$WORKTREE_DIR/$worktree_name" "origin/$base_branch"
+  fi
+
+  echo ""
+  echo "Worktree created: ${WORKTREE_DIR}/${worktree_name}"
+  echo "Branch: ${branch_name} (from ${base_branch})"
+  echo "Path: ${WORKTREE_DIR}/${worktree_name}"
+}
+
+cmd_list() {
+  echo ""
+  echo "=== Worktrees ==="
+  git worktree list
+}
+
+cmd_status() {
+  echo ""
+  echo "=== Worktree Status ==="
+
+  git worktree list --porcelain | grep '^worktree ' | sed 's/^worktree //' | while read -r wt_path; do
+    echo ""
+    echo "--- $(basename "$wt_path") ---"
+    echo "Path: ${wt_path}"
+
+    local branch changes ahead_behind ahead behind pr_info
+    branch=$(cd "$wt_path" && git branch --show-current 2>/dev/null || true)
+    echo "Branch: ${branch:-"(detached)"}"
+
+    changes=$(cd "$wt_path" && git status --short 2>/dev/null | wc -l | tr -d ' ')
+    if [ "$changes" -gt 0 ]; then
+      echo "Changes: ${changes} file(s) modified"
+    else
+      echo "Changes: clean"
+    fi
+
+    ahead_behind=$(cd "$wt_path" && git rev-list --left-right --count HEAD...@{u} 2>/dev/null || true)
+    if [ -n "$ahead_behind" ]; then
+      ahead=$(echo "$ahead_behind" | awk '{print $1}')
+      behind=$(echo "$ahead_behind" | awk '{print $2}')
+      echo "Ahead: ${ahead}  Behind: ${behind}"
+    fi
+
+    if command -v gh &>/dev/null && [ -n "$branch" ]; then
+      pr_info=$(gh pr list --head "$branch" --json number,state,title \
+        --jq 'if length == 0 then "none" else "PR #\(.[0].number) [\(.[0].state)] \(.[0].title)" end' 2>/dev/null || true)
+      if [ -n "$pr_info" ]; then
+        echo "PR: ${pr_info}"
+      else
+        echo "PR: none"
+      fi
+    fi
+  done
+}
+
+cmd_remove() {
+  local target="${1:-}"
+  if [ -z "$target" ]; then
+    echo "Usage: worktree.sh remove <name>" >&2
+    echo ""
+    echo "Available worktrees:" >&2
+    git worktree list >&2
+    exit 1
+  fi
+
+  local wt_path match
+  if [ -d "$WORKTREE_DIR/$target" ]; then
+    wt_path="$WORKTREE_DIR/$target"
+  elif [ -d "$target" ]; then
+    wt_path="$target"
+  else
+    match=$(ls -d "$WORKTREE_DIR"/*"$target"* 2>/dev/null | head -1 || true)
+    if [ -n "$match" ]; then
+      wt_path="$match"
+      echo "Matched: $(basename "$wt_path")"
+    else
+      echo "Worktree not found: ${target}" >&2
+      echo ""
+      echo "Available worktrees:" >&2
+      git worktree list >&2
+      exit 1
+    fi
+  fi
+
+  echo "=== Removing Worktree ==="
+  echo "Path: ${wt_path}"
+
+  git worktree remove --force "$wt_path"
+  git worktree prune
+  echo "Worktree removed: $(basename "$wt_path")"
+}
+
+case "$ACTION" in
+  create) cmd_create "${2:-}" "${3:-}" "${4:-}" ;;
+  list)   cmd_list ;;
+  status) cmd_status ;;
+  remove) cmd_remove "${2:-}" ;;
+  ""|-h|--help|help) usage; [ -z "$ACTION" ] && exit 1 || exit 0 ;;
+  *) echo "Unknown action: ${ACTION}" >&2; echo ""; usage >&2; exit 1 ;;
+esac

--- a/plugins/sdlc/skills/git/SKILL.md
+++ b/plugins/sdlc/skills/git/SKILL.md
@@ -44,6 +44,10 @@ If ACTION is blank, infer from context:
 
 ### Worktree (isolated feature branches)
 
+For anything beyond a one-off `git worktree add`, defer to the dedicated
+**`git-worktree`** skill — it enforces sibling-directory layout, `YYYYMMDD_`
+naming, PR-ref resolution, and clean removal. Quick inline form:
+
 1. Determine worktree base dir (sibling to repo root, e.g. `../repo_worktrees/`)
 2. Create branch: `git worktree add ../repo_worktrees/<name> -b <branch>`
 3. Report the path — agent or human navigates there to work in isolation


### PR DESCRIPTION
## What

Converts the `git_worktree` command into a reusable **`git-worktree` skill**, with the command now a thin wrapper that invokes it.

## Why

The worktree logic lived entirely inside a slash command, so it was only reachable via `/sdlc:git_worktree`. As a skill it routes automatically when the user describes the intent ("spin up a worktree for PR#42", "clean up worktrees") and stays callable as a command.

## Changes

- **New skill `plugins/sdlc/skills/git-worktree/`**
  - `SKILL.md` — procedural-shaped, authored against the `authoring-skills` chassis. Description carries routing weight + explicit non-triggers steering push/merge/fetch to the `git` skill.
  - `scripts/worktree.sh` — the command's inline bash consolidated into one self-contained, testable executable (`create|list|status|remove`).
- **`commands/git_worktree.md`** — now a thin wrapper that invokes `sdlc:git-worktree`, passing `$ARGUMENTS` through.
- **`git` skill** — worktree section defers to `git-worktree` for anything beyond a one-off `git worktree add`.
- Bumped sdlc `1.3.2 → 1.4.0`; updated CHANGELOG and README skills column.

## Notes

- Fixed a latent bug carried from the original command: worktrees with no PR printed `PR #null` instead of `none`.
- Verified `list`/`status`/usage run live; `just fmt-check` and `just lint` pass.
- `just qa`'s test step has a **pre-existing, unrelated** failure (`test_aef_contract.py` expects `EventType.TOOL_EXECUTION_STARTED`, renamed under ADR-042). This diff touches zero Python.