### PR TITLE
feat(meta): add authoring-agents-md skill

### DIFF
--- a/plugins/meta/.claude-plugin/plugin.json
+++ b/plugins/meta/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "meta",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Primitive generators - tools that create commands, skills, prompts, and other agentic primitives",
   "author": {
     "name": "NeuralEmpowerment"

--- a/plugins/meta/CHANGELOG.md
+++ b/plugins/meta/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.3.0
-- Add `authoring-agents-md` skill — author an `AGENTS.md` file and wire it to Claude Code (which reads `CLAUDE.md`), with AGENTS.md as the canonical source of truth and CLAUDE.md symlinked to it
+- Add `authoring-agents-md` skill: author an `AGENTS.md` file and wire it to Claude Code (which reads `CLAUDE.md`), with AGENTS.md as the canonical source of truth and CLAUDE.md symlinked to it
 
 ## 1.0.0
 - Consolidated from meta/generators

--- a/plugins/meta/CHANGELOG.md
+++ b/plugins/meta/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
 
+## 1.3.0
+- Add `authoring-agents-md` skill — author an `AGENTS.md` file and wire it to Claude Code (which reads `CLAUDE.md`), with AGENTS.md as the canonical source of truth and CLAUDE.md symlinked to it
+
 ## 1.0.0
 - Consolidated from meta/generators

--- a/plugins/meta/README.md
+++ b/plugins/meta/README.md
@@ -8,6 +8,6 @@ Primitive generators — tools that create other agentic primitives.
 - **create-doc-sync** — Create documentation sync configurations
 
 ## Skills
-- **authoring-skills** — Author or audit a Claude skill against the chassis
-- **skill-testing** — Validate that a skill routes correctly and its body earns its lines
-- **authoring-agents-md** — Author an `AGENTS.md` file and wire it to Claude Code (AGENTS.md canonical, `CLAUDE.md` symlinked to it)
+- **authoring-skills**: Author or audit a Claude skill against the chassis
+- **skill-testing**: Validate that a skill routes correctly and its body earns its lines
+- **authoring-agents-md**: Author an `AGENTS.md` file and wire it to Claude Code (AGENTS.md canonical, `CLAUDE.md` symlinked to it)

--- a/plugins/meta/README.md
+++ b/plugins/meta/README.md
@@ -6,3 +6,8 @@ Primitive generators — tools that create other agentic primitives.
 - **create-command** — Generate new command primitives
 - **create-prime** — Create new agentic primitives
 - **create-doc-sync** — Create documentation sync configurations
+
+## Skills
+- **authoring-skills** — Author or audit a Claude skill against the chassis
+- **skill-testing** — Validate that a skill routes correctly and its body earns its lines
+- **authoring-agents-md** — Author an `AGENTS.md` file and wire it to Claude Code (AGENTS.md canonical, `CLAUDE.md` symlinked to it)

--- a/plugins/meta/skills/authoring-agents-md/SKILL.md
+++ b/plugins/meta/skills/authoring-agents-md/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: authoring-agents-md
+description: Use when authoring, reviewing, or setting up an `AGENTS.md` file (the open "README for agents" format) and wiring it to Claude Code, which reads `CLAUDE.md` not `AGENTS.md`. Trigger phrases include "write an AGENTS.md", "author agents.md", "create AGENTS.md", "set up AGENTS.md", "AGENTS.md best practices", "AGENTS.md vs CLAUDE.md", "symlink CLAUDE.md to AGENTS.md", "make AGENTS.md canonical", "how does Claude use CLAUDE.md", "nested AGENTS.md", "monorepo agent instructions", "agents.md spec", "agent instructions file". Covers the agents.md spec, the canonical AGENTS.md-source-of-truth + symlinked-CLAUDE.md setup, Claude Code's CLAUDE.md load order and `@import` rules, and monorepo nesting. Do NOT use for authoring a Claude skill (use `authoring-skills`), for general CLAUDE.md auto-memory/rules configuration beyond the AGENTS.md bridge (see Claude Code memory docs), or for slash commands and hooks.
+placement: "Meta-skill. Lives in `plugins/<meta-plugin>/skills/authoring-agents-md/` or repo-local `.claude/skills/authoring-agents-md/`. It teaches how to author an agent-instructions artifact, so it belongs at the meta level alongside `authoring-skills`, not among domain skills."
+---
+
+# Authoring AGENTS.md
+
+## Overview
+
+`AGENTS.md` is an open Markdown format, "a README for agents", that gives coding agents a single, predictable place for build steps, test commands, conventions, and guardrails that would clutter a human README. It is stewarded by the Agentic AI Foundation under the Linux Foundation and read by 60k+ projects across Codex, Cursor, Copilot, Aider, goose, Jules, Devin, Windsurf, Zed, and more. Claude Code is the notable exception: it reads `CLAUDE.md`, **not** `AGENTS.md`. This skill covers authoring a strong AGENTS.md, the canonical single-source-of-truth wiring (AGENTS.md is authoritative; CLAUDE.md is a symlink to it), how Claude Code discovers and loads instruction files, and how nesting resolves in monorepos.
+
+## Outcomes we are looking for
+
+### One source of truth, read by every agent
+Signals: there is exactly one authored instructions file (`AGENTS.md`); `CLAUDE.md` resolves to the same bytes (symlink or thin `@AGENTS.md` import); editing AGENTS.md changes what every harness (Claude included) sees, with no second copy to drift.
+
+### The file earns its place in context
+Signals: AGENTS.md is concrete and skimmable (build/test/lint commands verifiable, conventions stated specifically); it stays well under ~200 lines so Claude loads it in full with high adherence; no marketing prose or restated README.
+
+### Hierarchy resolves predictably
+Signals: in a monorepo, the nearest AGENTS.md to the edited file wins and subproject files are scoped to their subtree; contributors can predict which instructions apply where; no contradictory rules across levels.
+
+### The Claude bridge is portable and durable
+Signals: the CLAUDE.md ↔ AGENTS.md link survives a fresh clone and works cross-platform (or its Windows caveat is documented); `/init` augments rather than forks the source of truth.
+
+## Principles
+
+1. **AGENTS.md is canonical; CLAUDE.md points at it.** Author one file. Make `CLAUDE.md` a symlink to `AGENTS.md` so the two can never diverge. Every other agent already reads AGENTS.md natively; the symlink is the single adaptation Claude Code needs. This is a deliberate choice over maintaining parallel files: duplication is the failure mode, not a feature.
+
+2. **Claude Code reads CLAUDE.md, not AGENTS.md: bridge, never duplicate.** Two sanctioned bridges exist: a `ln -s AGENTS.md CLAUDE.md` symlink (preferred: zero content, zero drift), or a `CLAUDE.md` whose first line is `@AGENTS.md` (the fallback, and the only option on Windows without Developer Mode). Both keep AGENTS.md authoritative. Writing the same content into both files by hand is the anti-pattern this skill exists to prevent. The symlink is preferred for a second reason beyond Windows: it is resolved at the filesystem level, so Claude opens AGENTS.md as the root file and AGENTS.md's own `@imports` keep the full four-hop recursion budget. The `@AGENTS.md` import spends one of those four hops just to bridge, leaving three for AGENTS.md's nested imports. This only matters when AGENTS.md itself imports deeply, but on that axis the symlink is strictly better.
+
+3. **Write for an agent that acts, not a human who reads.** Prefer exact, runnable commands (`uv run pytest`, `just qa`) over prose. Specific beats vague: "API handlers live in `src/api/handlers/`" outlive "keep files organized." The file is loaded as context, not enforced config, so clarity and concreteness directly raise adherence.
+
+4. **Keep it short enough to load in full.** Claude Code loads ancestor CLAUDE.md files in full at launch and targets <200 lines per file; longer files consume context and reduce adherence. Cut anything an agent would not act on. If content is large, factor structure-heavy or path-specific detail into the subtree where it applies (nested AGENTS.md), not the root.
+
+5. **Nearest file wins; scope instructions to where they apply.** Agents read the closest AGENTS.md in the directory tree, so per-subproject files carry tailored instructions for their subtree. Claude mirrors this: subdirectory `CLAUDE.md` files load on demand when Claude reads files there. Put root-wide truth at the root, subproject truth in the subproject.
+
+6. **Standard Markdown, no schema.** AGENTS.md has no required fields, so use whatever headings serve the project. Common sections: project overview, build/test/lint commands, code style, testing instructions, security considerations, commit/PR conventions, deployment. Pick the ones an agent needs; omit the rest.
+
+7. **Treat it as living documentation.** Update AGENTS.md when an agent makes the same mistake twice, when review catches something it should have known, or when a convention changes. A stale instructions file misroutes every agent that reads it.
+
+## Anti-patterns
+
+- **Two hand-maintained files.** A real `AGENTS.md` and a separately-edited `CLAUDE.md` with overlapping content. They drift within a week; agents get contradictory guidance depending on which they read.
+- **Content written into CLAUDE.md with AGENTS.md as an afterthought (or absent).** Inverts the canonical direction, so every non-Claude harness then reads stale or missing instructions.
+- **A symlink committed on a repo with Windows contributors and no fallback noted.** Clones fail to materialize the link without Developer Mode/Admin; those contributors silently lose the instructions.
+- **A 400-line AGENTS.md at the root.** Loads in full, burns context, and adherence drops. Subproject detail belongs in nested files; deep procedures belong in skills or path-scoped rules.
+- **Vague directives.** "Format code properly", "test your changes", "keep it clean." Not verifiable, so not actionable: the agent cannot tell whether it complied.
+- **README content copy-pasted in.** AGENTS.md is the *extra* context agents need (build steps, conventions), not a restatement of the human-facing overview.
+- **Contradictory rules across nested levels.** A root rule and a subproject rule that disagree; the agent picks arbitrarily. Reconcile, or scope each rule to the level where it is true.
+- **Relying on AGENTS.md alone for Claude Code.** Without a `CLAUDE.md` bridge, Claude Code never reads the file at all: it does not look for `AGENTS.md`.
+
+## Recommended tools and practices (as of 2026-06-15)
+
+### For: one source of truth, read by every agent
+
+- **Author `AGENTS.md` at the repo root; make `CLAUDE.md` a symlink to it.** `ln -s AGENTS.md CLAUDE.md`: zero duplicated bytes, impossible to drift. This is the canonical setup. Ladders up by guaranteeing every harness reads identical instructions. See `references/claude-integration.md`.
+- **Use the `@AGENTS.md` import when symlinks are unavailable.** A `CLAUDE.md` containing `@AGENTS.md` (optionally followed by Claude-specific notes) keeps AGENTS.md authoritative without a filesystem link, required on Windows without Developer Mode. Ladders up by preserving portability. Note the cost: recursive imports cap at **four hops**, and the bridge import consumes one, leaving three for AGENTS.md's own nested imports (a symlink consumes none). For mixed-OS teams whose AGENTS.md has few or no nested imports, this cost is negligible and portability wins.
+- **Commit the link and document the Windows caveat** in a one-line comment or contributing note. Ladders up by making the bridge survive a fresh clone everywhere.
+
+### For: the file earns its place in context
+
+- **Lead with runnable commands.** Build, test, lint, run: exact invocations the agent can paste. Ladders up by making the most-used content immediately actionable.
+- **Keep the root file under ~200 lines.** Trim anything an agent would not act on. Ladders up by ensuring Claude loads it in full with high adherence.
+- **Borrow the section menu, not all sections.** Project overview, build/test commands, code style, testing, security, commit/PR conventions, deployment: include only those that change agent behavior. See `references/agents-md-spec.md`.
+
+### For: hierarchy resolves predictably
+
+- **Ship one AGENTS.md per subproject in monorepos.** Tailored instructions live nearest the code they govern; nearest-file-wins does the routing. Ladders up by scoping rules to where they are true. See `references/agents-md-spec.md`.
+- **Keep root rules root-wide.** Anything contradicted by a subproject belongs in that subproject's file, not the root. Ladders up by eliminating cross-level contradictions.
+
+### For: the Claude bridge is portable and durable
+
+- **Run `/init` to augment, not fork.** In a repo that already has AGENTS.md, `/init` reads it and folds relevant parts into the generated CLAUDE.md; prefer keeping AGENTS.md canonical and adding only Claude-specific notes below an `@AGENTS.md` import. Ladders up by preventing a second source of truth. See `references/claude-integration.md`.
+- **Verify with `/memory`.** After wiring, `/memory` lists the loaded instruction files; confirm CLAUDE.md (resolving to AGENTS.md) appears. Ladders up by proving the bridge works before relying on it.
+
+## References
+
+- `references/agents-md-spec.md`: the agents.md format, recommended sections, monorepo nesting/precedence, and the supporting-tool ecosystem.
+- `references/claude-integration.md`: how Claude Code discovers and loads CLAUDE.md (load order, full-tree walk, `@import` four-hop limit, subdirectory on-demand loading), the symlink vs `@AGENTS.md` decision, the Windows caveat, and `/init`/`/memory` behavior.
+- `references/agents-md-template.md`: a starter AGENTS.md with the common sections, ready to fill in.
+- https://agents.md/ (canonical spec)
+- https://code.claude.com/docs/en/memory (Claude Code memory / CLAUDE.md behavior)
+
+## Continual improvement
+
+File drift, gaps, or proposed updates at
+https://github.com/AgentParadise/agentic-primitives/issues

--- a/plugins/meta/skills/authoring-agents-md/references/agents-md-spec.md
+++ b/plugins/meta/skills/authoring-agents-md/references/agents-md-spec.md
@@ -1,0 +1,73 @@
+# The AGENTS.md format
+
+Source: https://agents.md/ (the canonical spec), stewarded by the Agentic AI
+Foundation under the Linux Foundation, with contributions from OpenAI, Google,
+Cursor, Amp, and Factory. This file distills the spec as of 2026-06-15.
+
+## What it is and why it exists
+
+AGENTS.md is "a README for agents: a dedicated, predictable place to provide
+the context and instructions to help AI coding agents work on your project."
+
+The split with README.md is intentional:
+
+- **README.md** serves humans: quick start, description, contribution guide.
+- **AGENTS.md** serves agents: the extra, sometimes detailed context an agent
+  needs (build steps, tests, conventions) that would clutter a human README.
+
+Keeping them separate keeps the README focused on contributors while giving
+agents precise, machine-actionable guidance in a known location.
+
+## Format
+
+Standard Markdown. **No required fields, no schema.** From the spec: "AGENTS.md
+is just standard Markdown. Use any headings you like; the agent simply parses
+the text you provide." Choose the sections that change agent behavior; omit the
+rest.
+
+## Recommended sections
+
+Popular choices (use the ones that apply):
+
+- **Project overview**: what the project is, in two or three lines.
+- **Build and test commands**: exact, runnable invocations.
+- **Code style guidelines**: formatter, lint rules, naming conventions.
+- **Testing instructions**: how to run the suite, what must pass.
+- **Security considerations**: secret handling, sensitive paths.
+- **Commit message and pull request guidelines**: conventional commits, PR
+  template expectations.
+- **Deployment steps**: if agents are expected to deploy or release.
+
+## Nested AGENTS.md (monorepos)
+
+Multiple AGENTS.md files can coexist in a hierarchy. Agents "automatically read
+the nearest file in the directory tree, so the closest one takes precedence and
+every subproject can ship tailored instructions." The OpenAI monorepo ships 88
+nested files as the canonical example.
+
+Precedence, exactly: **the closest AGENTS.md to the edited file wins; explicit
+user chat prompts override everything.** Put repo-wide truth at the root and
+subproject-specific truth in each subproject's file. Do not duplicate a rule at
+multiple levels: scope it to the level where it is true.
+
+Many agents will also "attempt to execute relevant programmatic checks and fix
+failures before finishing the task," so listing the check commands directly is
+high-leverage.
+
+## Ecosystem (who reads it natively)
+
+60,000+ open-source projects use AGENTS.md. Supporting tools include OpenAI
+Codex, Google Jules, Factory, Aider, goose, VS Code, Cognition Devin,
+Windsurf, GitHub Copilot, Cursor, RooCode, and Zed.
+
+**Claude Code is the exception**: it reads `CLAUDE.md`, not `AGENTS.md`. See
+`claude-integration.md` for the bridge.
+
+## Best practices (from the spec)
+
+1. **Create at the repository root.** Many agents can scaffold one on request.
+2. **Conflict resolution:** closest file wins; explicit chat prompts override.
+3. **Automation:** agents attempt relevant programmatic checks and fix failures
+   before finishing, so list those checks.
+4. **Living documentation:** update it as the project changes.
+5. **Monorepo structure:** one file per subproject for tailored instructions.

--- a/plugins/meta/skills/authoring-agents-md/references/agents-md-template.md
+++ b/plugins/meta/skills/authoring-agents-md/references/agents-md-template.md
@@ -1,0 +1,61 @@
+# Starter AGENTS.md template
+
+Copy the block below to the repo root as `AGENTS.md`, then delete sections that
+do not apply and replace the placeholders. Keep it under ~200 lines so Claude
+loads it in full. Then wire Claude Code per `claude-integration.md`
+(`ln -s AGENTS.md CLAUDE.md`, or an `@AGENTS.md` import on Windows).
+
+Lead with runnable commands; cut anything an agent would not act on.
+
+```markdown
+# <Project Name>
+
+<One or two lines: what this project is and what an agent should know first.>
+
+## Setup
+
+\`\`\`bash
+<install deps, e.g. uv sync, npm install, just bootstrap>
+\`\`\`
+
+## Build / test / lint
+
+\`\`\`bash
+<build command>
+<test command, e.g. uv run pytest>
+<lint/format command, e.g. just qa-fix>
+\`\`\`
+
+Run these checks and fix failures before finishing a task.
+
+## Project layout
+
+- `<dir>/`: <what lives here>
+- `<dir>/`: <what lives here>
+
+## Conventions
+
+- <Specific, verifiable rule, e.g. "2-space indentation">
+- <e.g. "API handlers live in `src/api/handlers/`">
+- <Commit style, e.g. "Conventional commits: feat:, fix:, docs:, chore:">
+
+## Testing
+
+- <How to run the suite, what must pass before a PR>
+
+## Security
+
+- <Secret handling, sensitive paths, what never to commit>
+
+## Pull requests
+
+- <PR expectations: title format, required checks, review gates>
+```
+
+## Monorepo note
+
+For a monorepo, place a tailored `AGENTS.md` in each subproject with only the
+instructions specific to that subtree. The nearest file to an edited file wins,
+so the root file should hold repo-wide truth and each subproject file should
+hold its own build/test/convention overrides, never duplicate a rule across
+levels.

--- a/plugins/meta/skills/authoring-agents-md/references/claude-integration.md
+++ b/plugins/meta/skills/authoring-agents-md/references/claude-integration.md
@@ -1,0 +1,115 @@
+# Wiring AGENTS.md to Claude Code
+
+Source: https://code.claude.com/docs/en/memory (Claude Code memory docs) as of
+2026-06-15. Claude Code reads `CLAUDE.md`, **not** `AGENTS.md`. To keep
+AGENTS.md the single source of truth, bridge CLAUDE.md to it.
+
+## The two sanctioned bridges
+
+### Symlink (preferred, canonical setup)
+
+```bash
+ln -s AGENTS.md CLAUDE.md
+```
+
+Zero duplicated content; the two files literally cannot diverge. Commit the
+symlink. Use this whenever you do not need Claude-specific instructions beyond
+what AGENTS.md already says.
+
+### `@AGENTS.md` import (fallback, and the Windows option)
+
+When you need Claude-only additions, or when symlinks are unavailable, make
+`CLAUDE.md` a thin file that imports AGENTS.md and appends Claude-specific notes:
+
+```markdown
+@AGENTS.md
+
+## Claude Code
+
+Use plan mode for changes under `src/billing/`.
+```
+
+Claude loads the imported file at session start, then appends the rest. This
+keeps AGENTS.md authoritative while letting CLAUDE.md carry a small Claude-only
+tail.
+
+### Windows caveat
+
+On Windows, creating a symlink requires Administrator privileges or Developer
+Mode. **Use the `@AGENTS.md` import on repos with Windows contributors** (or
+document the requirement). A committed symlink will not materialize on a plain
+Windows clone.
+
+## How Claude Code discovers and loads CLAUDE.md
+
+- **Full-tree walk upward.** Claude walks up the directory tree from the current
+  working directory, loading every `CLAUDE.md` and `CLAUDE.local.md` it finds
+  along the way. There is **no fixed level cap** on this ancestor walk: running
+  in `foo/bar/` loads `foo/bar/CLAUDE.md`, `foo/CLAUDE.md`, and so on up to root.
+- **Ancestors load in full at launch.** Files above the cwd are concatenated
+  into context immediately, ordered filesystem-root → cwd (so the closest file
+  is read last and effectively wins on conflicts).
+- **Subdirectories load on demand.** `CLAUDE.md` files *below* the cwd are not
+  loaded at launch; they load when Claude reads files in those subdirectories.
+  This mirrors AGENTS.md nearest-file-wins behavior in a monorepo.
+
+### Load order / precedence (broadest → most specific)
+
+1. **Managed policy**: `/Library/Application Support/ClaudeCode/CLAUDE.md`
+   (macOS), `/etc/claude-code/CLAUDE.md` (Linux/WSL),
+   `C:\Program Files\ClaudeCode\CLAUDE.md` (Windows). Org-wide; cannot be
+   excluded.
+2. **User**: `~/.claude/CLAUDE.md`. Personal, all projects.
+3. **Project**: `./CLAUDE.md` or `./.claude/CLAUDE.md`. Team-shared via VCS.
+   This is where the AGENTS.md bridge lives.
+4. **Local**: `./CLAUDE.local.md`. Personal, gitignored.
+
+### `@import` syntax and the four-hop limit
+
+CLAUDE.md can pull in other files with `@path/to/file`. Relative paths resolve
+against the importing file. Imported files can themselves import, to a
+**maximum recursion depth of four hops**. (This four-hop import limit is the
+real number behind the common "five levels deep" misconception: the ancestor
+directory walk itself is uncapped.) Imports are expanded into context at launch,
+so an `@AGENTS.md` import loads the full AGENTS.md every session.
+
+### Why this favors the symlink
+
+The four-hop budget counts depth from the file Claude opens, and this is the
+decisive difference between the two bridges:
+
+- **Symlink:** `CLAUDE.md` *is* AGENTS.md at the filesystem level (same inode).
+  Claude opens AGENTS.md as the root file (hop 0), so AGENTS.md's own `@imports`
+  get the full four hops beneath it.
+- **`@AGENTS.md` import:** CLAUDE.md is the root (hop 0) and AGENTS.md is hop 1.
+  Nested imports inside AGENTS.md now have only three hops left. The bridge
+  spends one hop just to reach AGENTS.md.
+
+So `@AGENTS.md` → `@a` → `@b` → `@c` → `@d` overflows under the import bridge but
+not under the symlink. This only bites when AGENTS.md itself imports deeply; for
+a flat AGENTS.md with no nested imports there is no practical difference, and the
+import's cross-platform portability is the deciding factor instead.
+
+## `/init` and `/memory`
+
+- **`/init`** in a repo that already has `AGENTS.md` reads it and folds the
+  relevant parts into the generated CLAUDE.md (it also reads `.cursorrules`,
+  `.devin/rules/`, `.windsurfrules`). To keep AGENTS.md canonical, prefer the
+  `@AGENTS.md` import over letting `/init` fork a parallel copy.
+- **`/memory`** lists every CLAUDE.md / CLAUDE.local.md / rule file loaded in the
+  session. After wiring, run it to confirm CLAUDE.md (resolving to AGENTS.md)
+  appears and is loaded.
+
+## Notes that affect authoring
+
+- CLAUDE.md is delivered as a user message (context), **not** enforced
+  configuration: specificity raises adherence, but nothing guarantees
+  compliance. For hard enforcement, use hooks or managed settings, not the file.
+- Target **under 200 lines** per file; longer files reduce adherence. Splitting
+  via `@import` aids organization but does **not** reduce context: imported
+  files still load in full at launch.
+- Block-level HTML comments (`<!-- ... -->`) in CLAUDE.md are stripped before
+  injection, so they cost no context, useful for maintainer notes. (They are
+  preserved inside code blocks.)
+- Project-root CLAUDE.md survives `/compact` (re-read from disk); nested
+  subdirectory files reload only when Claude next reads a file there.

--- a/plugins/meta/skills/authoring-agents-md/references/claude-integration.md
+++ b/plugins/meta/skills/authoring-agents-md/references/claude-integration.md
@@ -78,7 +78,8 @@ so an `@AGENTS.md` import loads the full AGENTS.md every session.
 The four-hop budget counts depth from the file Claude opens, and this is the
 decisive difference between the two bridges:
 
-- **Symlink:** `CLAUDE.md` *is* AGENTS.md at the filesystem level (same inode).
+- **Symlink:** `CLAUDE.md` is resolved by the filesystem to AGENTS.md (one
+  target file, reached by either name).
   Claude opens AGENTS.md as the root file (hop 0), so AGENTS.md's own `@imports`
   get the full four hops beneath it.
 - **`@AGENTS.md` import:** CLAUDE.md is the root (hop 0) and AGENTS.md is hop 1.


### PR DESCRIPTION
## Summary

Adds a new **`authoring-agents-md`** principle-doc skill to the `meta` plugin. It teaches how to author an `AGENTS.md` (the open "README for agents" format) and bridge it to Claude Code, which reads `CLAUDE.md` — not `AGENTS.md`.

The skill encodes one canonical stance: **AGENTS.md is the single source of truth; `CLAUDE.md` is a symlink to it**, so the two can never drift and every agent harness reads the same file.

## What's in it

- **`SKILL.md`** (~95 lines) — Overview, 4 Outcomes, 7 Principles, 8 Anti-patterns, dated Recommendations laddered to outcomes.
- **`references/agents-md-spec.md`** — the agents.md format, recommended sections, monorepo nesting (closest-file-wins), and the 60k-project ecosystem.
- **`references/claude-integration.md`** — Claude Code's CLAUDE.md load order, full-tree walk, the `@import` four-hop limit, the symlink-vs-import decision, the Windows caveat, and `/init`/`/memory`.
- **`references/agents-md-template.md`** — a starter AGENTS.md.

## Notable design points

- **Symlink is the default bridge, with two justifications**, not one:
  1. Cross-platform clarity (with `@AGENTS.md` import documented as the Windows fallback).
  2. **Import-budget preservation** — a symlink resolves at the filesystem level so AGENTS.md is the root file and keeps the full 4-hop `@import` budget; the `@AGENTS.md` import spends one hop just to bridge, leaving 3 for AGENTS.md's nested imports.
- **Research correction baked in:** the common "5 levels deep" belief is really the **4-hop `@import` recursion limit**; the ancestor directory walk itself is uncapped.

## Registration

- meta `1.2.0` → `1.3.0`, CHANGELOG entry, and skills now listed in the plugin README (it had drifted and listed none).

## Validation

- `just qa` passes.
- No em-dashes (house rule), SKILL.md well under the 500-line cap, conforms to the `authoring-skills` chassis.
- Live routing test (`claude -p`) not yet run — needs the plugin reinstalled so the skill is discoverable.