### PR TITLE
feat(workspaces): bake skills CLI 1.5.14 into claude-cli and interactive-tmux images

### DIFF
--- a/providers/workspaces/claude-cli/Dockerfile
+++ b/providers/workspaces/claude-cli/Dockerfile
@@ -97,6 +97,9 @@ RUN uv python install 3.12.13 \
 ARG CLAUDE_CLI_VERSION
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CLI_VERSION}
 
+# Install the skills CLI globally via npm. Pin exact version deliberately.
+RUN npm install -g skills@1.5.14
+
 # =============================================================================
 # LSP: Language Servers for code intelligence
 # Plugins: pyright-lsp, typescript-lsp, rust-analyzer-lsp (claude-plugins-official)

--- a/providers/workspaces/interactive-tmux/Dockerfile
+++ b/providers/workspaces/interactive-tmux/Dockerfile
@@ -64,9 +64,11 @@ RUN npm install -g \
         @anthropic-ai/claude-code@${CLAUDE_CLI_VERSION} \
         @openai/codex@${CODEX_CLI_VERSION} \
         @google/gemini-cli@${GEMINI_CLI_VERSION} \
+        skills@1.5.14 \
     && claude --version \
     && codex --version \
-    && gemini --version
+    && gemini --version \
+    && skills --version
 
 # Non-root user. node:22-slim ships node:node uid/gid 1000; rename to
 # agent for parity with the claude-cli provider's user model.


### PR DESCRIPTION
Adds `RUN npm install -g skills@1.5.14` (exact pin, one transitive dep: yaml) to both workspace images, enabling harness-agnostic skill injection from syntropic137 (syntropic137/syntropic137#772, PR syntropic137/syntropic137#774).

Verified locally before push (hard rule):
- Both images build via `scripts/build-provider.py`
- `skills --version` = 1.5.14 in-image
- Agent-key vocabulary confirmed from the bundled cli.mjs: `claude-code`, `codex`, `gemini-cli` (alias `gemini -> gemini-cli`)
- Offline local-path install smoke test passes; installs are cwd-relative (`./.claude/skills/<name>`), matching the consumer's `working_directory=/workspace` invocation

Consumer lands in syntropic137/syntropic137#774; that repo's submodule pin bumps after this merges.