### PR TITLE
fix(itmux): DooD credential transfer (docker exec stdin, not -v mounts)

### DIFF
--- a/providers/workspaces/interactive-tmux/driver-rs/src/auth.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/auth.rs
@@ -1,13 +1,32 @@
-//! Per-agent host-auth mount preparation.
+//! Per-agent credential staging and in-container transfer.
 //!
 //! Each adapter copies (never moves) the relevant host directory under a
 //! per-workspace throwaway dir (`/tmp/interactive-tmux-<name>-<random>/`)
-//! so the container can bind-mount fresh credential bytes without ever
+//! so the container can receive fresh credential bytes without ever
 //! mutating the operator's live `~/.claude`, `~/.codex`, `~/.gemini`.
 //!
 //! Synthesised files (claude's `~/.claude.json`, gemini's `settings.json`
 //! patch) follow the Python driver's policy bit-for-bit so the two
-//! implementations produce interchangeable mounts.
+//! implementations produce interchangeable payloads.
+//!
+//! # Delivery: `docker exec` transfer, not `-v` bind mounts
+//!
+//! Syntropic137 runs this driver INSIDE a container (docker-out-of-docker).
+//! A `docker run -v host:container` bind mount is resolved by the *outer*
+//! docker daemon against its own filesystem - it cannot see a staging dir
+//! that only exists in this driver's own mount namespace. So instead of
+//! bind-mounting, the container is started bare (`docker run ... sleep
+//! infinity`, see `workspace::Workspace::start`) and credential bytes are
+//! pushed into the already-running container over `docker exec` stdin:
+//! files via base64, directories file-by-file (mirrors the Python driver's
+//! `os.walk` transfer at PY:1540-1563 exactly, rather than a `tar` stream,
+//! for byte-for-byte parity with the source of truth). See
+//! `_write_bytes_to_container` / `_transfer_path_to_container` /
+//! `_secure_container_path` in `driver/interactive_tmux.py` (PY:1493-1583).
+//!
+//! Credentials never appear in `docker exec` argv - only ever in stdin
+//! (PY:1506-1517). `argv` is world-readable via `ps` / `/proc/<pid>/cmdline`
+//! for the lifetime of the exec; stdin is not.
 
 use std::fs;
 use std::io::{Error, ErrorKind, Result};
@@ -17,17 +36,47 @@ use std::path::{Path, PathBuf};
 use serde_json::{json, Map, Value};
 
 use crate::adapter::Agent;
+use crate::tmux;
 
-/// One `-v host:container` pair to hand to `docker run`.
+/// One credential file or directory staged locally, awaiting transfer into
+/// the container's filesystem at `container` via `stage_into_container`.
+///
+/// Replaces the old `-v host:container` bind-mount shape (docker-out-of-
+/// docker fix, see module docs).
 #[derive(Debug, Clone)]
-pub struct Mount {
+pub struct StagedPath {
     pub host: PathBuf,
     pub container: String,
 }
 
-impl Mount {
-    pub fn as_docker_arg(&self) -> String {
-        format!("{}:{}", self.host.display(), self.container)
+/// All per-agent staged credential paths for one workspace, ready to be
+/// pushed into the running container.
+///
+/// Derefs to `Vec<StagedPath>` so callers can use slice/iterator methods
+/// (`len()`, `iter()`, indexing) directly.
+#[derive(Debug, Clone, Default)]
+pub struct PreparedAuth(pub Vec<StagedPath>);
+
+impl PreparedAuth {
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn extend(&mut self, other: PreparedAuth) {
+        self.0.extend(other.0);
+    }
+}
+
+impl std::ops::Deref for PreparedAuth {
+    type Target = Vec<StagedPath>;
+    fn deref(&self) -> &Vec<StagedPath> {
+        &self.0
+    }
+}
+
+impl FromIterator<StagedPath> for PreparedAuth {
+    fn from_iter<T: IntoIterator<Item = StagedPath>>(iter: T) -> Self {
+        Self(iter.into_iter().collect())
     }
 }
 
@@ -38,13 +87,15 @@ pub struct AuthContext {
     /// Explicit override for the operator's `~/.claude.json` source. `None`
     /// falls back to `host_src.parent() / .claude.json`. Set by callers that
     /// run from inside another container where the host's dotjson is mounted
-    /// at an unrelated path — see `StartOptions::host_claude_dotjson` and
+    /// at an unrelated path - see `StartOptions::host_claude_dotjson` and
     /// the DooD discussion in `_default_claude_dotjson_from_env` (Python).
     pub host_claude_dotjson: Option<PathBuf>,
 }
 
-/// Best-effort chmod (non-fatal — docker will run as the requested uid
-/// inside the container regardless).
+/// Best-effort chmod on the LOCAL staging copy (defense in depth only - the
+/// bytes are re-secured again in-container by `secure_path_plan` once
+/// transferred, which is the guarantee that actually matters since the
+/// staging dir is transient and never mounted into anything).
 fn chmod_file(path: &Path, mode: u32) {
     let _ = fs::set_permissions(path, fs::Permissions::from_mode(mode));
 }
@@ -77,14 +128,14 @@ fn copy_tree(src: &Path, dst: &Path, skip_names: &[&str]) -> Result<()> {
             fs::copy(&src_path, &dst_path)?;
         }
         // Ignore unsupported entries (symlinks to vanished files, sockets):
-        // the Python adapter does the same — the auth surface is regular
+        // the Python adapter does the same - the auth surface is regular
         // files in practice.
     }
     Ok(())
 }
 
 // ---------------------------------------------------------------------------
-// Claude — EXP-01 + EXP-05a
+// Claude - EXP-01 + EXP-05a
 
 /// Build the synthetic `~/.claude.json` (mirrors Python
 /// `_build_seeded_claude_dotjson`): copies `oauthAccount` through, forces
@@ -131,7 +182,7 @@ fn build_seeded_claude_dotjson(host_dotjson: &Path, workdir: &str) -> Value {
     Value::Object(seeded)
 }
 
-pub fn prepare_claude(host_src: &Path, ctx: &AuthContext) -> Result<Vec<Mount>> {
+pub fn prepare_claude(host_src: &Path, ctx: &AuthContext) -> Result<PreparedAuth> {
     if !host_src.is_dir() {
         return Err(Error::new(
             ErrorKind::NotFound,
@@ -149,14 +200,14 @@ pub fn prepare_claude(host_src: &Path, ctx: &AuthContext) -> Result<Vec<Mount>> 
         ));
     }
 
-    // Throwaway ~/.claude/ — copy only .credentials.json (no session history).
+    // Throwaway ~/.claude/ - copy only .credentials.json (no session history).
     let dst_dir = ctx.throwaway_dir.join("claude.dir");
     fs::create_dir_all(&dst_dir)?;
     let dst_creds = dst_dir.join(".credentials.json");
     copy_file(&creds, &dst_creds)?;
     chmod_file(&dst_creds, 0o600);
 
-    // Throwaway ~/.claude.json — synthesised regardless of host presence.
+    // Throwaway ~/.claude.json - synthesised regardless of host presence.
     // Resolution order (caller > sibling > nothing): if the caller passed
     // `host_claude_dotjson` (via `StartOptions` or the `ITMUX_CLAUDE_JSON`
     // env var), use it directly. Otherwise fall back to the sibling-of-
@@ -173,22 +224,22 @@ pub fn prepare_claude(host_src: &Path, ctx: &AuthContext) -> Result<Vec<Mount>> 
     fs::write(&dotjson_dst, serde_json::to_vec_pretty(&seeded)?)?;
     chmod_file(&dotjson_dst, 0o600);
 
-    Ok(vec![
-        Mount {
+    Ok(PreparedAuth(vec![
+        StagedPath {
             host: dst_dir,
             container: "/home/agent/.claude".to_string(),
         },
-        Mount {
+        StagedPath {
             host: dotjson_dst,
             container: "/home/agent/.claude.json".to_string(),
         },
-    ])
+    ]))
 }
 
 // ---------------------------------------------------------------------------
-// Codex — EXP-02
+// Codex - EXP-02
 
-pub fn prepare_codex(host_src: &Path, ctx: &AuthContext) -> Result<Vec<Mount>> {
+pub fn prepare_codex(host_src: &Path, ctx: &AuthContext) -> Result<PreparedAuth> {
     if !host_src.is_dir() {
         return Err(Error::new(
             ErrorKind::NotFound,
@@ -199,16 +250,16 @@ pub fn prepare_codex(host_src: &Path, ctx: &AuthContext) -> Result<Vec<Mount>> {
     // Skip tmp/log/logs: codex races there during normal operation. The auth
     // surface lives at `auth.json` / `config.toml` / `sessions/`.
     copy_tree(host_src, &dst_dir, &["tmp", "log", "logs"])?;
-    Ok(vec![Mount {
+    Ok(PreparedAuth(vec![StagedPath {
         host: dst_dir,
         container: "/home/agent/.codex".to_string(),
-    }])
+    }]))
 }
 
 // ---------------------------------------------------------------------------
-// Gemini — EXP-03
+// Gemini - EXP-03
 
-pub fn prepare_gemini(host_src: &Path, ctx: &AuthContext) -> Result<Vec<Mount>> {
+pub fn prepare_gemini(host_src: &Path, ctx: &AuthContext) -> Result<PreparedAuth> {
     if !host_src.is_dir() {
         return Err(Error::new(
             ErrorKind::NotFound,
@@ -245,19 +296,218 @@ pub fn prepare_gemini(host_src: &Path, ctx: &AuthContext) -> Result<Vec<Mount>> 
     folder_trust_obj.insert("enabled".to_string(), Value::Bool(false));
     fs::write(&settings_path, serde_json::to_vec_pretty(&settings)?)?;
 
-    Ok(vec![Mount {
+    Ok(PreparedAuth(vec![StagedPath {
         host: dst_dir,
         container: "/home/agent/.gemini".to_string(),
-    }])
+    }]))
 }
 
 // ---------------------------------------------------------------------------
 // Dispatch
 
-pub fn prepare(agent: Agent, host_src: &Path, ctx: &AuthContext) -> Result<Vec<Mount>> {
+pub fn prepare(agent: Agent, host_src: &Path, ctx: &AuthContext) -> Result<PreparedAuth> {
     match agent {
         Agent::Claude => prepare_claude(host_src, ctx),
         Agent::Codex => prepare_codex(host_src, ctx),
         Agent::Gemini => prepare_gemini(host_src, ctx),
     }
+}
+
+// ---------------------------------------------------------------------------
+// Transfer plan (pure, testable without a docker daemon) + execution.
+
+/// One step of a credential transfer/secure plan: a `docker exec <container>
+/// <argv...>` invocation, optionally fed `stdin` bytes.
+///
+/// Built as plain data (rather than shelling out directly) so the plan can
+/// be asserted on in tests without a running docker daemon - see
+/// `tests/cred_transfer.rs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecStep {
+    pub argv: Vec<String>,
+    pub stdin: Option<Vec<u8>>,
+}
+
+/// POSIX `dirname`, matching Python's `posixpath.dirname` for the ASCII
+/// forward-slash paths this driver deals with exclusively (in-container
+/// Linux paths).
+fn posix_dirname(path: &str) -> String {
+    match path.rfind('/') {
+        Some(0) => "/".to_string(),
+        Some(idx) => path[..idx].to_string(),
+        None => String::new(),
+    }
+}
+
+/// Shell-quote a single argument, matching Python's `shlex.quote`: safe
+/// (alnum + `-_./:`) strings pass through unquoted; anything else is
+/// wrapped in single quotes with embedded quotes escaped as `'\''`.
+fn shell_quote(s: &str) -> String {
+    if !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || "-_./:".contains(c))
+    {
+        return s.to_string();
+    }
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// Minimal std-only base64 encoder (standard alphabet, `=` padding)  -
+/// avoids pulling in a dependency for the one encode call this crate needs
+/// (decoding happens in-container via the coreutils `base64 -d`).
+fn base64_encode(data: &[u8]) -> Vec<u8> {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = Vec::with_capacity(data.len().div_ceil(3) * 4);
+    for chunk in data.chunks(3) {
+        let b0 = chunk[0];
+        let b1 = chunk.get(1).copied();
+        let b2 = chunk.get(2).copied();
+        out.push(ALPHABET[(b0 >> 2) as usize]);
+        out.push(ALPHABET[(((b0 & 0x03) << 4) | (b1.unwrap_or(0) >> 4)) as usize]);
+        if let Some(b1) = b1 {
+            out.push(ALPHABET[(((b1 & 0x0F) << 2) | (b2.unwrap_or(0) >> 6)) as usize]);
+        } else {
+            out.push(b'=');
+        }
+        if let Some(b2) = b2 {
+            out.push(ALPHABET[(b2 & 0x3F) as usize]);
+        } else {
+            out.push(b'=');
+        }
+    }
+    out
+}
+
+/// Mirrors Python `_write_bytes_to_container`: `mkdir -p` the destination's
+/// parent (if non-empty), truncate/create the destination, then push the
+/// payload as base64 over stdin to an in-container `base64 -d`. Credentials
+/// never appear in argv (PY:1506-1517) - only inside `ExecStep::stdin`.
+pub fn write_bytes_plan(container_path: &str, data: &[u8]) -> Vec<ExecStep> {
+    let mut steps = Vec::new();
+    let parent = posix_dirname(container_path);
+    if !parent.is_empty() {
+        steps.push(ExecStep {
+            argv: vec!["mkdir".to_string(), "-p".to_string(), parent],
+            stdin: None,
+        });
+    }
+    let quoted = shell_quote(container_path);
+    steps.push(ExecStep {
+        argv: vec!["sh".to_string(), "-c".to_string(), format!("> {quoted}")],
+        stdin: None,
+    });
+    steps.push(ExecStep {
+        argv: vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            format!("base64 -d >> {quoted}"),
+        ],
+        stdin: Some(base64_encode(data)),
+    });
+    steps
+}
+
+fn walk_files_sorted(dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        for entry in fs::read_dir(&d)? {
+            let entry = entry?;
+            let path = entry.path();
+            let kind = entry.file_type()?;
+            if kind.is_dir() {
+                stack.push(path);
+            } else if kind.is_file() {
+                out.push(path);
+            }
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+/// Mirrors Python `_transfer_path_to_container`'s directory branch: walks
+/// `host_dir` (matching `os.walk`) and builds a `write_bytes_plan` for every
+/// regular file, keyed by its path relative to `host_dir` joined onto
+/// `container_path`. Deliberately per-file (not a `tar` stream) for exact
+/// parity with the Python source of truth (PY:1554-1561).
+pub fn transfer_dir_plan(host_dir: &Path, container_path: &str) -> Result<Vec<ExecStep>> {
+    let mut steps = Vec::new();
+    let base = container_path.trim_end_matches('/');
+    for file in walk_files_sorted(host_dir)? {
+        let rel = file
+            .strip_prefix(host_dir)
+            .expect("walked file is under host_dir")
+            .to_string_lossy()
+            .replace(std::path::MAIN_SEPARATOR, "/");
+        let dst = format!("{base}/{rel}");
+        let data = fs::read(&file)?;
+        steps.extend(write_bytes_plan(&dst, &data));
+    }
+    Ok(steps)
+}
+
+/// Mirrors Python `_secure_container_path`: chown the transferred path to
+/// the in-container `agent` user (uid/gid 1000) and lock file permissions
+/// to 0600. For a directory, `chown -R` the whole tree and `chmod 600`
+/// every regular file under it via `find` - matching PY:1566-1583 exactly,
+/// including that the directory's own mode is intentionally left
+/// untouched (Python does not `chmod` the directory itself, only the files
+/// inside it).
+pub fn secure_path_plan(container_path: &str, is_dir: bool) -> ExecStep {
+    let quoted = shell_quote(container_path);
+    let cmd = if is_dir {
+        format!("chown -R 1000:1000 {quoted} && find {quoted} -type f -exec chmod 600 {{}} +")
+    } else {
+        format!("chown 1000:1000 {quoted} && chmod 600 {quoted}")
+    };
+    ExecStep {
+        argv: vec!["sh".to_string(), "-c".to_string(), cmd],
+        stdin: None,
+    }
+}
+
+/// Full plan (transfer steps + trailing secure step) for one staged path.
+/// Pure and side-effect-free: reads the local staged bytes (needed to embed
+/// them in the plan) but performs no `docker exec` calls. Exposed for
+/// tests that assert the plan shape without a docker daemon.
+pub fn plan_for_staged_path(staged: &StagedPath) -> Result<Vec<ExecStep>> {
+    let is_dir = staged.host.is_dir();
+    let mut steps = if is_dir {
+        transfer_dir_plan(&staged.host, &staged.container)?
+    } else {
+        let data = fs::read(&staged.host)?;
+        write_bytes_plan(&staged.container, &data)
+    };
+    steps.push(secure_path_plan(&staged.container, is_dir));
+    Ok(steps)
+}
+
+fn run_exec_step(container: &str, step: &ExecStep) -> Result<()> {
+    let argv_refs: Vec<&str> = step.argv.iter().map(String::as_str).collect();
+    match &step.stdin {
+        Some(bytes) => {
+            tmux::docker_exec_with_stdin(container, &argv_refs, bytes)?;
+        }
+        None => {
+            tmux::docker_exec(container, &argv_refs)?;
+        }
+    }
+    Ok(())
+}
+
+/// Push every staged path in `prepared` into `container`'s filesystem over
+/// `docker exec` and lock down ownership/permissions in-container.
+///
+/// The container is assumed already started (bare `docker run ... sleep
+/// infinity`, no credential bind mounts - see `workspace::Workspace::start`).
+/// This is the "PUSHES credential files ... then secures them in-container"
+/// half of the docker-out-of-docker fix (PY:1850-1869).
+pub fn stage_into_container(container: &str, prepared: &PreparedAuth) -> Result<()> {
+    for staged in prepared.iter() {
+        for step in plan_for_staged_path(staged)? {
+            run_exec_step(container, &step)?;
+        }
+    }
+    Ok(())
 }

--- a/providers/workspaces/interactive-tmux/driver-rs/src/tmux.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/tmux.rs
@@ -5,8 +5,8 @@
 //! without a docker daemon (the per-agent readiness logic lives in
 //! `adapter` and only needs strings).
 
-use std::io::{Error, Result};
-use std::process::{Command, Output};
+use std::io::{Error, Result, Write};
+use std::process::{Command, Output, Stdio};
 
 pub const TMUX_SESSION: &str = "agents";
 
@@ -55,6 +55,41 @@ pub fn docker_exec(container: &str, args: &[&str]) -> Result<Output> {
     )
 }
 
+/// `docker exec -i <container> <args...>`, feeding `stdin_data` to the
+/// process's stdin and returning its `Output`.
+///
+/// Used by credential transfer (`auth::stage_into_container`) to push file
+/// bytes / base64 payloads into the container without ever putting them in
+/// argv (PY:1506-1517) - argv is world-readable via `ps` /
+/// `/proc/<pid>/cmdline` for the lifetime of the exec; stdin is not.
+pub fn docker_exec_with_stdin(container: &str, args: &[&str], stdin_data: &[u8]) -> Result<Output> {
+    let mut cmd = Command::new("docker");
+    cmd.arg("exec").arg("-i").arg(container);
+    cmd.args(args);
+    cmd.stdin(Stdio::piped());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    let mut child = cmd.spawn()?;
+    // Feed stdin from a dedicated thread so a payload larger than the pipe
+    // buffer can't deadlock against `wait_with_output` reading stdout/stderr
+    // (classic "write blocks because the child is blocked writing its own
+    // full stdout pipe, which we haven't started draining yet" deadlock).
+    let mut stdin = child
+        .stdin
+        .take()
+        .expect("stdin piped above via Stdio::piped()");
+    let payload = stdin_data.to_vec();
+    let writer = std::thread::spawn(move || stdin.write_all(&payload));
+    let out = child.wait_with_output()?;
+    writer
+        .join()
+        .map_err(|_| Error::other("stdin-writer thread panicked"))??;
+    check_output(
+        out,
+        &format!("docker exec -i {container} {}", redact_args(args)),
+    )
+}
+
 /// `docker exec <container> tmux send-keys -t <session>:<window> <keys...>`.
 /// Each `key` is one tmux send-keys argument (special-key names like
 /// `Enter`, `C-j`, or `Escape` are honoured by tmux).
@@ -69,7 +104,7 @@ pub fn send_keys(container: &str, window: &str, keys: &[&str]) -> Result<()> {
 /// `docker exec <container> tmux send-keys -l -t <session>:<window> <text>`.
 ///
 /// The `-l` flag tells tmux to deliver the bytes literally (no special-key
-/// interpretation) — the canonical pattern for the body of a user message.
+/// interpretation) - the canonical pattern for the body of a user message.
 pub fn send_literal(container: &str, window: &str, text: &str) -> Result<()> {
     let target = format!("{TMUX_SESSION}:{window}");
     // `--` ends option parsing so a prompt beginning with `-` (e.g. "-R",
@@ -115,7 +150,7 @@ pub fn capture_pane(container: &str, window: &str) -> Result<String> {
 /// Mirrors the Python driver's `_pane_tail`: with the full-scrollback
 /// capture above, the buffer contains every prompt and every prior
 /// generation. The per-agent `is_started` / `is_ready` predicates would
-/// be fooled by old text — `"esc to interrupt" not in pane` flips false
+/// be fooled by old text - `"esc to interrupt" not in pane` flips false
 /// after the first generation, and Claude's empty-chevron regex matches
 /// against ancient prompts. Evaluating against the tail preserves the
 /// pre-fix "check the visible window" semantics on a full-history capture.

--- a/providers/workspaces/interactive-tmux/driver-rs/src/workspace.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/workspace.rs
@@ -10,7 +10,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::adapter::{self, Agent};
-use crate::auth::{self, AuthContext, Mount};
+use crate::auth::{self, AuthContext, PreparedAuth};
 use crate::registry::{self, WorkspaceRecord};
 use crate::result::AwaitResult;
 use crate::tmux;
@@ -84,7 +84,7 @@ pub struct Workspace {
 
 fn random_suffix() -> String {
     // 8 hex chars from a non-crypto seed mix (no `rand` dep). Mirrors the
-    // Python `uuid.uuid4().hex[:8]` slot — used only for container naming.
+    // Python `uuid.uuid4().hex[:8]` slot - used only for container naming.
     use std::time::{SystemTime, UNIX_EPOCH};
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -94,6 +94,30 @@ fn random_suffix() -> String {
     #[allow(clippy::cast_possible_truncation)]
     let low = (mix & 0xFFFF_FFFF) as u64;
     format!("{low:08x}")
+}
+
+/// Build the `docker run` argv for a bare, credential-free container:
+/// `docker run -d --name <c> --workdir <wd> <image> sleep infinity`.
+///
+/// Deliberately carries NO `-v` flags for credentials (docker-out-of-docker
+/// fix): a sibling `-v host:container` bind mount is resolved by the OUTER
+/// daemon against its own filesystem, which cannot see this driver's own
+/// staging dir when the driver itself runs inside a container. Credentials
+/// are pushed in afterwards over `docker exec` - see
+/// `auth::stage_into_container`. Pure (no I/O) so it can be asserted on
+/// without a docker daemon; see `tests/cred_transfer.rs`.
+pub fn build_docker_run_argv(container: &str, workdir: &str, image: &str) -> Vec<String> {
+    vec![
+        "run".to_string(),
+        "-d".to_string(),
+        "--name".to_string(),
+        container.to_string(),
+        "--workdir".to_string(),
+        workdir.to_string(),
+        image.to_string(),
+        "sleep".to_string(),
+        "infinity".to_string(),
+    ]
 }
 
 fn run_capture(cmd: &mut Command, what: &str) -> Result<Output> {
@@ -150,9 +174,9 @@ impl Workspace {
         // must clean up the staged credential copies on failure; otherwise
         // a failed `docker run` (or a bad host auth dir) leaks auth
         // material under the temp dir.
-        let docker_run = (|| -> Result<Vec<Agent>> {
+        let provision = (|| -> Result<Vec<Agent>> {
             let mut enabled: Vec<Agent> = Vec::new();
-            let mut mounts: Vec<Mount> = Vec::new();
+            let mut prepared_by_agent: Vec<PreparedAuth> = Vec::new();
             for agent in adapter::AGENTS {
                 let Some(Some(src)) = opts.host_auth.get(&agent) else {
                     continue;
@@ -162,7 +186,7 @@ impl Workspace {
                     continue;
                 }
                 enabled.push(agent);
-                mounts.extend(prepared);
+                prepared_by_agent.push(prepared);
             }
 
             if enabled.is_empty() {
@@ -172,28 +196,28 @@ impl Workspace {
                 ));
             }
 
-            // docker run -d --name <c> --workdir <wd> [-v host:container ...] <image> sleep infinity
+            // Provision a bare, credential-free container (docker-out-of-
+            // docker fix - see `build_docker_run_argv` and module docs on
+            // `auth::stage_into_container`).
+            let argv = build_docker_run_argv(&container, &opts.workdir, &opts.image);
             let mut run = Command::new("docker");
-            run.args([
-                "run",
-                "-d",
-                "--name",
-                &container,
-                "--workdir",
-                &opts.workdir,
-            ]);
-            for m in &mounts {
-                run.arg("-v").arg(m.as_docker_arg());
-            }
-            run.arg(&opts.image).args(["sleep", "infinity"]);
+            run.args(&argv);
             run_capture(&mut run, "docker run")?;
+
+            // Container is up; push each agent's staged credentials into it
+            // over `docker exec` and lock down ownership/permissions
+            // in-container (PY:1850-1869, PY:1566-1583).
+            for prepared in &prepared_by_agent {
+                auth::stage_into_container(&container, prepared)?;
+            }
             Ok(enabled)
         })();
-        let enabled = match docker_run {
+        let enabled = match provision {
             Ok(enabled) => enabled,
             Err(e) => {
-                // Best-effort: `docker run -d` can fail after the container
-                // is created (e.g. start failure), so remove it too.
+                // Best-effort: `docker run -d` (or the credential transfer
+                // that follows it) can fail after the container is
+                // created, so remove it too.
                 let _ = Command::new("docker")
                     .args(["rm", "-f", &container])
                     .output();
@@ -327,7 +351,7 @@ impl Workspace {
         // D-block-2 + D-block-3 fix (Syntropic137 stress): the readiness
         // predicate AND the stability comparison both operate on the
         // bottom-of-pane tail. Stability on the full scrollback buffer
-        // would fail forever — any new response token appended changes
+        // would fail forever - any new response token appended changes
         // the buffer, even when the live TUI window has settled.
         // Comparing tails matches the pre-fix "visible window" semantics
         // on the full-history capture introduced by `-S - -E -`.

--- a/providers/workspaces/interactive-tmux/driver-rs/tests/cred_transfer.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/tests/cred_transfer.rs
@@ -1,0 +1,191 @@
+//! Docker-out-of-docker credential transfer parity tests.
+//!
+//! Syntropic137 runs this driver INSIDE a container. A sibling
+//! `docker run -v host:container` bind mount resolves `host` against the
+//! OUTER daemon's filesystem and can't see this driver's own staging dir  -
+//! so credentials must be pushed into the container over `docker exec`
+//! stdin instead (mirrors `driver/interactive_tmux.py` PY:1493-1583,
+//! PY:1850-1869). These tests assert the command *plan* built by pure
+//! functions in `auth` and `workspace` - no docker daemon required.
+
+use std::fs;
+use std::path::PathBuf;
+
+use itmux::auth::{prepare, secure_path_plan, stage_into_container, write_bytes_plan, AuthContext};
+use itmux::workspace::build_docker_run_argv;
+use itmux::Agent;
+
+fn tmp(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "itmux-cred-transfer-{name}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+#[test]
+fn docker_run_argv_carries_no_v_flags() {
+    let argv = build_docker_run_argv(
+        "interactive-tmux-foo-abcd1234",
+        "/workspace",
+        "my-image:latest",
+    );
+    assert!(
+        !argv.iter().any(|a| a == "-v"),
+        "docker run argv must not bind-mount credentials in DooD: {argv:?}"
+    );
+    assert_eq!(
+        argv,
+        vec![
+            "run",
+            "-d",
+            "--name",
+            "interactive-tmux-foo-abcd1234",
+            "--workdir",
+            "/workspace",
+            "my-image:latest",
+            "sleep",
+            "infinity",
+        ]
+    );
+}
+
+#[test]
+fn prepare_yields_staged_destination_paths_not_mount_bind_args() {
+    let host_root = tmp("claude-host-root");
+    let claude_dir = host_root.join(".claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    fs::write(claude_dir.join(".credentials.json"), b"{}").unwrap();
+
+    let ctx = AuthContext {
+        workdir: "/workspace".to_string(),
+        throwaway_dir: tmp("claude-throwaway"),
+        host_claude_dotjson: None,
+    };
+
+    let prepared = prepare(Agent::Claude, &claude_dir, &ctx).unwrap();
+    assert_eq!(prepared.len(), 2);
+    // Destinations are in-container paths meant for exec-transfer, never a
+    // "host:container" bind-mount argument string.
+    for staged in prepared.iter() {
+        assert!(staged.container.starts_with("/home/agent/"));
+        assert!(
+            !staged.container.contains(':'),
+            "container dest must not look like a `-v host:container` arg: {}",
+            staged.container
+        );
+        assert!(staged.host.exists(), "locally staged file must exist");
+    }
+}
+
+#[test]
+fn write_bytes_plan_never_puts_payload_in_argv() {
+    let secret = b"super-secret-oauth-token-xyz";
+    let steps = write_bytes_plan("/home/agent/.claude.json", secret);
+
+    // mkdir -p parent, truncate, then base64-decode-from-stdin.
+    assert_eq!(steps.len(), 3);
+    assert_eq!(steps[0].argv, vec!["mkdir", "-p", "/home/agent"]);
+    assert!(steps[0].stdin.is_none());
+
+    assert_eq!(steps[1].argv[0], "sh");
+    assert!(steps[1].argv[2].starts_with('>'));
+    assert!(steps[1].stdin.is_none());
+
+    assert_eq!(steps[2].argv[0], "sh");
+    assert!(steps[2].argv[2].contains("base64 -d"));
+    let stdin = steps[2].stdin.as_ref().expect("payload travels via stdin");
+
+    // The secret bytes must never appear in any argv string.
+    for step in &steps {
+        for arg in &step.argv {
+            assert!(
+                !arg.as_bytes()
+                    .windows(secret.len())
+                    .any(|w| w == secret.as_slice()),
+                "credential payload leaked into argv: {arg}"
+            );
+        }
+    }
+    // But the (base64-encoded) payload must be present in stdin somewhere.
+    assert!(!stdin.is_empty());
+}
+
+#[test]
+fn secure_path_plan_chowns_1000_1000_and_chmods_600_for_a_file() {
+    let step = secure_path_plan("/home/agent/.claude.json", false);
+    assert_eq!(step.argv[0], "sh");
+    assert_eq!(step.argv[1], "-c");
+    let cmd = &step.argv[2];
+    assert!(cmd.contains("chown 1000:1000"), "got: {cmd}");
+    assert!(cmd.contains("chmod 600"), "got: {cmd}");
+    assert!(step.stdin.is_none());
+}
+
+#[test]
+fn secure_path_plan_chowns_recursively_and_chmods_600_every_file_for_a_dir() {
+    let step = secure_path_plan("/home/agent/.codex", true);
+    let cmd = &step.argv[2];
+    assert!(cmd.contains("chown -R 1000:1000"), "got: {cmd}");
+    assert!(cmd.contains("chmod 600"), "got: {cmd}");
+    assert!(cmd.contains("find"), "dir secure step must use find: {cmd}");
+}
+
+#[test]
+fn plan_for_prepared_claude_auth_includes_transfer_and_secure_steps_for_every_staged_path() {
+    let host_root = tmp("claude-host-root-2");
+    let claude_dir = host_root.join(".claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    fs::write(claude_dir.join(".credentials.json"), b"{}").unwrap();
+
+    let ctx = AuthContext {
+        workdir: "/workspace".to_string(),
+        throwaway_dir: tmp("claude-throwaway-2"),
+        host_claude_dotjson: None,
+    };
+    let prepared = prepare(Agent::Claude, &claude_dir, &ctx).unwrap();
+
+    // Two staged paths (the .claude dir, the synthesised .claude.json)  -
+    // each must get its own secure (chown+chmod) step after transfer.
+    let mut secure_steps_seen = 0;
+    for staged in prepared.iter() {
+        let plan = itmux::auth::plan_for_staged_path(staged).unwrap();
+        let last = plan.last().expect("plan has at least the secure step");
+        assert!(last.argv[2].contains("chown"));
+        assert!(last.argv[2].contains("1000:1000"));
+        assert!(last.argv[2].contains("chmod 600"));
+        secure_steps_seen += 1;
+    }
+    assert_eq!(secure_steps_seen, 2);
+}
+
+#[test]
+fn stage_into_container_without_docker_fails_cleanly_not_via_v_mount() {
+    // No docker daemon / container named this in the test environment  -
+    // `stage_into_container` must attempt a `docker exec` (and fail with an
+    // I/O or nonzero-exit error) rather than silently succeeding via some
+    // bind-mount fallback. This exercises the real code path end-to-end
+    // (argv construction, stdin plumbing) even though the outer assertion
+    // is just "it does not panic and returns a Result".
+    let host_root = tmp("claude-host-root-3");
+    let claude_dir = host_root.join(".claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    fs::write(claude_dir.join(".credentials.json"), b"{}").unwrap();
+    let ctx = AuthContext {
+        workdir: "/workspace".to_string(),
+        throwaway_dir: tmp("claude-throwaway-3"),
+        host_claude_dotjson: None,
+    };
+    let prepared = prepare(Agent::Claude, &claude_dir, &ctx).unwrap();
+
+    let result = stage_into_container("itmux-cred-transfer-test-nonexistent-container", &prepared);
+    // Either docker isn't installed (I/O error) or the container doesn't
+    // exist (nonzero exit) - both surface as Err, never a silent Ok that
+    // would mean credentials were dropped via some other, unaudited path.
+    assert!(result.is_err());
+}

--- a/providers/workspaces/interactive-tmux/driver-rs/tests/pane_tail.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/tests/pane_tail.rs
@@ -73,7 +73,10 @@ fn pane_tail_short_returns_pane_verbatim() {
 
 #[test]
 fn pane_tail_long_truncates_to_last_n_lines() {
-    let pane: String = (0..200).map(|i| format!("row{i}")).collect::<Vec<_>>().join("\n");
+    let pane: String = (0..200)
+        .map(|i| format!("row{i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
     let tail = pane_tail(&pane, 50);
     let lines: Vec<&str> = tail.split('\n').collect();
     assert_eq!(lines.len(), 50);


### PR DESCRIPTION
## What & why

`itmux` (Rust driver) delivered credentials via `docker run -v host:container` bind mounts. In Syntropic137's **docker-out-of-docker (DooD)** topology the driver runs *inside* a container, so a sibling `-v` resolves the source on the OUTER daemon and mounts empty/nonexistent paths - every agent starts **unauthenticated**. The canonical Python driver abandoned `-v` for exactly this reason.

This ports the Python driver's model (parity source `driver/interactive_tmux.py`):
- **Bare** `docker run ... sleep infinity` (no `-v` cred flags).
- Push each credential file into the running container via `docker exec -i` with **base64 over stdin** (`ExecStep.stdin`) - credentials never appear in argv (PY:1506-1517).
- Directories transferred per-file (matching PY:1540-1563).
- **Secure in-container**: `chown -R 1000:1000` + `find -type f -exec chmod 600` so the non-root `agent` (uid 1000) can read them (PY:1566-1583).

Part of Plan 1a (itmux -> production parity), Tasks 1+2. Prerequisite for deleting the Python driver (Plan 1b). Tracks okrs-51p.6 / okrs-o78.

## Tests & gates (local - Rust not yet in CI; wired in Plan 1a Task 7)
- `cargo test`: **54 passed** (new `cred_transfer.rs`: 7 tests asserting no `-v` cred flags, stdin-only payload, chown/chmod plan - all without a docker daemon).
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean.
- No new dependencies (std-only base64 encoder).

## Reviewer notes
- Security-sensitive credential path. Matched the real Python source over illustrative examples (per-file writes not tar; dir mode left untouched as Python does).
- **Residual risk:** the live end-to-end path (bare run -> stage -> tmux bootstrap) was not exercised against a real Docker daemon (sandboxed impl env). A live DooD smoke is gated in Plan 1a Task 7 before the Python driver is deleted.