### PR TITLE
fix(itmux): bound every docker/tmux exec with a timeout (15s/30s)

### DIFF
--- a/providers/workspaces/interactive-tmux/driver-rs/src/tmux.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/tmux.rs
@@ -5,10 +5,77 @@
 //! without a docker daemon (the per-agent readiness logic lives in
 //! `adapter` and only needs strings).
 
-use std::io::{Error, Result, Write};
-use std::process::{Command, Output, Stdio};
+use std::io::{Error, ErrorKind, Result, Write};
+use std::process::{Child, Command, Output, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
 
 pub const TMUX_SESSION: &str = "agents";
+
+/// Bound for one `docker exec` / `tmux` operation. Mirrors the Python
+/// driver's `DEFAULT_EXEC_TIMEOUT_S` (PY:86): a single wedged exec must not
+/// be able to hang the workflow forever.
+pub const DEFAULT_EXEC_TIMEOUT_S: f64 = 15.0;
+
+/// Bound for `docker run` / `docker rm -f`. Mirrors the Python driver's
+/// `DEFAULT_RUN_TIMEOUT_S` (PY:87).
+pub const DEFAULT_RUN_TIMEOUT_S: f64 = 30.0;
+
+/// Run `cmd`, bounding its execution to `timeout`.
+///
+/// std-only, no `unsafe`: spawns the child (stdout/stderr always piped, so
+/// the returned `Output` is populated the same way `Command::output()`
+/// would populate it), then waits for it on a dedicated thread and races
+/// that wait against `timeout` via `mpsc::recv_timeout`. On timeout the
+/// child is best-effort killed and an `ErrorKind::TimedOut` error is
+/// returned. Mirrors Python's `subprocess.run(..., timeout=...)` bound
+/// (PY:222-280, PY:576-626) without pulling in an async runtime or a new
+/// dependency.
+pub fn run_bounded(mut cmd: Command, timeout: Duration) -> Result<Output> {
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    let child = cmd.spawn()?;
+    wait_bounded(child, timeout)
+}
+
+/// Wait on an already-spawned `child`, bounded by `timeout`.
+///
+/// Shared by `run_bounded` and the stdin-writer path
+/// (`docker_exec_with_stdin`), which needs to feed the child's stdin from
+/// its own thread before this bound takes over waiting on exit.
+///
+/// On timeout, the child is killed (best-effort - `Child::kill` is a plain
+/// signal send, not a guarantee the process has fully exited by the time
+/// this function returns) and the waiter thread is left to finish and drop
+/// its result on the floor; we do not block joining it; the timeout error
+/// is returned immediately so a wedged process can never make this
+/// function itself hang.
+pub fn wait_bounded(child: Child, timeout: Duration) -> Result<Output> {
+    let pid = child.id();
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let result = child.wait_with_output();
+        let _ = tx.send(result);
+    });
+    match rx.recv_timeout(timeout) {
+        Ok(result) => result,
+        Err(_) => {
+            // Best-effort: ask the process (and, since docker/tmux
+            // children are frequently themselves a fork/exec wrapper,
+            // just its own pid - not a process group) to die. We do not
+            // have a `Child` handle here anymore (it was moved into the
+            // waiter thread so that thread can drain stdout/stderr without
+            // deadlocking on a full pipe buffer), so killing by pid via
+            // the `kill` utility is the only std-only, `unsafe`-free way
+            // to reach it from this side.
+            let _ = Command::new("kill").args(["-9", &pid.to_string()]).output();
+            Err(Error::new(
+                ErrorKind::TimedOut,
+                format!("command timed out after {timeout:?}"),
+            ))
+        }
+    }
+}
 
 fn check_output(out: Output, what: &str) -> Result<Output> {
     if out.status.success() {
@@ -43,12 +110,13 @@ fn redact_args(args: &[&str]) -> String {
     parts.join(" ")
 }
 
-/// Run `docker exec <container> <args...>` and return its `Output`.
+/// Run `docker exec <container> <args...>` and return its `Output`, bounded
+/// by `DEFAULT_EXEC_TIMEOUT_S` (PY:86) so a wedged exec can't hang forever.
 pub fn docker_exec(container: &str, args: &[&str]) -> Result<Output> {
     let mut cmd = Command::new("docker");
     cmd.arg("exec").arg(container);
     cmd.args(args);
-    let out = cmd.output()?;
+    let out = run_bounded(cmd, Duration::from_secs_f64(DEFAULT_EXEC_TIMEOUT_S))?;
     check_output(
         out,
         &format!("docker exec {container} {}", redact_args(args)),
@@ -80,7 +148,11 @@ pub fn docker_exec_with_stdin(container: &str, args: &[&str], stdin_data: &[u8])
         .expect("stdin piped above via Stdio::piped()");
     let payload = stdin_data.to_vec();
     let writer = std::thread::spawn(move || stdin.write_all(&payload));
-    let out = child.wait_with_output()?;
+    // Bounded wait (PY:86 `DEFAULT_EXEC_TIMEOUT_S`): if this times out, `?`
+    // returns immediately and the writer thread is left detached - once the
+    // killed child's stdin pipe closes its `write_all` fails fast and the
+    // thread exits on its own; there is nothing useful left to join.
+    let out = wait_bounded(child, Duration::from_secs_f64(DEFAULT_EXEC_TIMEOUT_S))?;
     writer
         .join()
         .map_err(|_| Error::other("stdin-writer thread panicked"))??;

--- a/providers/workspaces/interactive-tmux/driver-rs/src/workspace.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/workspace.rs
@@ -120,8 +120,12 @@ pub fn build_docker_run_argv(container: &str, workdir: &str, image: &str) -> Vec
     ]
 }
 
-fn run_capture(cmd: &mut Command, what: &str) -> Result<Output> {
-    let out = cmd.output()?;
+/// Run `cmd` bounded by `DEFAULT_RUN_TIMEOUT_S` (PY:87) - used for `docker
+/// run` / `docker rm -f`, which get a longer bound than the 15s exec/tmux
+/// default since image pulls and container teardown can legitimately take
+/// longer than a single `docker exec`.
+fn run_capture(cmd: Command, what: &str) -> Result<Output> {
+    let out = tmux::run_bounded(cmd, Duration::from_secs_f64(tmux::DEFAULT_RUN_TIMEOUT_S))?;
     if !out.status.success() {
         let stderr = String::from_utf8_lossy(&out.stderr);
         return Err(Error::other(format!(
@@ -202,7 +206,7 @@ impl Workspace {
             let argv = build_docker_run_argv(&container, &opts.workdir, &opts.image);
             let mut run = Command::new("docker");
             run.args(&argv);
-            run_capture(&mut run, "docker run")?;
+            run_capture(run, "docker run")?;
 
             // Container is up; push each agent's staged credentials into it
             // over `docker exec` and lock down ownership/permissions
@@ -217,10 +221,12 @@ impl Workspace {
             Err(e) => {
                 // Best-effort: `docker run -d` (or the credential transfer
                 // that follows it) can fail after the container is
-                // created, so remove it too.
-                let _ = Command::new("docker")
-                    .args(["rm", "-f", &container])
-                    .output();
+                // created, so remove it too. Bounded by
+                // `DEFAULT_RUN_TIMEOUT_S` like every other docker/tmux
+                // shell-out - cleanup must not be able to hang forever.
+                let mut rm = Command::new("docker");
+                rm.args(["rm", "-f", &container]);
+                let _ = tmux::run_bounded(rm, Duration::from_secs_f64(tmux::DEFAULT_RUN_TIMEOUT_S));
                 let _ = fs::remove_dir_all(&throwaway);
                 return Err(e);
             }
@@ -407,10 +413,11 @@ impl Workspace {
 
     pub fn stop(&self) -> Result<()> {
         // Best-effort `docker rm -f` + rm of throwaway dir. Matches Python's
-        // `subprocess.run(check=False)` semantics.
-        let _ = Command::new("docker")
-            .args(["rm", "-f", &self.container])
-            .output();
+        // `subprocess.run(check=False)` semantics, bounded by
+        // `DEFAULT_RUN_TIMEOUT_S` like every other docker/tmux shell-out.
+        let mut rm = Command::new("docker");
+        rm.args(["rm", "-f", &self.container]);
+        let _ = tmux::run_bounded(rm, Duration::from_secs_f64(tmux::DEFAULT_RUN_TIMEOUT_S));
         let _ = fs::remove_dir_all(&self.host_throwaway_dir);
         Ok(())
     }

--- a/providers/workspaces/interactive-tmux/driver-rs/tests/exec_timeout.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/tests/exec_timeout.rs
@@ -1,0 +1,80 @@
+//! Parity: every docker/tmux shell-out is bounded by a timeout
+//! (PY:86-87 `DEFAULT_EXEC_TIMEOUT_S` / `DEFAULT_RUN_TIMEOUT_S`), so a
+//! wedged child process can never hang the driver forever.
+//!
+//! These tests exercise `itmux::tmux::run_bounded` directly against real
+//! `sh` subprocesses - no docker daemon required.
+
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use itmux::tmux::run_bounded;
+
+#[test]
+fn run_bounded_kills_and_errors_on_timeout_without_blocking() {
+    let mut cmd = Command::new("sh");
+    cmd.args(["-c", "sleep 5"]);
+
+    let start = Instant::now();
+    let result = run_bounded(cmd, Duration::from_millis(200));
+    let elapsed = start.elapsed();
+
+    assert!(result.is_err(), "expected a timeout error, got: {result:?}");
+    let err = result.unwrap_err();
+    assert_eq!(
+        err.kind(),
+        std::io::ErrorKind::TimedOut,
+        "expected ErrorKind::TimedOut, got: {:?} ({err})",
+        err.kind()
+    );
+
+    // The whole point: we must NOT have waited out the 5s sleep. Give a
+    // generous margin for the kill round-trip (spawning `kill -9` is
+    // itself a subprocess) but this must stay well under 1s.
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "run_bounded blocked for {elapsed:?}, expected well under 1s (child should have been killed)"
+    );
+}
+
+#[test]
+fn run_bounded_returns_output_for_a_fast_command() {
+    let mut cmd = Command::new("sh");
+    cmd.args(["-c", "echo hi"]);
+
+    let out = run_bounded(cmd, Duration::from_secs(5)).expect("fast command should not time out");
+
+    assert!(
+        out.status.success(),
+        "expected success, got: {:?}",
+        out.status
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("hi"),
+        "expected stdout to contain 'hi', got: {stdout:?}"
+    );
+}
+
+#[test]
+fn run_bounded_does_not_leak_a_hung_child_process() {
+    // Best-effort leak check: run_bounded on a long sleeper with a short
+    // timeout must return promptly. If the child were not killed, this
+    // test process would still exit fine (children don't block process
+    // exit on unix), but the *call* itself hanging would be the real bug -
+    // already covered above. Here we additionally check that issuing the
+    // call twice in a row is still fast, which would not be true if kills
+    // were failing to fire and something was accumulating wait time.
+    let start = Instant::now();
+    for _ in 0..2 {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "sleep 5"]);
+        let result = run_bounded(cmd, Duration::from_millis(150));
+        assert!(result.is_err());
+    }
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "two bounded calls took {elapsed:?}, expected well under 2s"
+    );
+}


### PR DESCRIPTION
Plan 1a Task 3. Routes every docker/tmux shell-out through `run_bounded`/`wait_bounded` (15s exec / 30s run, named constants matching Python `DEFAULT_EXEC_TIMEOUT_S`/`DEFAULT_RUN_TIMEOUT_S`). A wedged container can no longer hang `start_workspace` forever. Also resolves the top MINOR from PR #231's security review.

**Stacked on #231** (base = fix/itmux-dood-creds). std-only (kill-by-pid, no new deps, no unsafe). `cargo test`: 57 pass; clippy/fmt clean. Orchestrator review: PASS (pid captured before move; waiter thread drains pipes so no large-output deadlock; timeout bounded by kill, not command duration). Tracks okrs-51p.6.