### PR TITLE
fix(itmux): poll resilience + container_dead classification

### DIFF
--- a/providers/workspaces/interactive-tmux/driver-rs/src/result.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/result.rs
@@ -73,6 +73,28 @@ impl AwaitResult {
         }
     }
 
+    /// The workspace target itself is GONE (dead container, vanished tmux
+    /// session/server) rather than a transient capture hiccup. Mirrors the
+    /// Python driver's `AwaitResult(reason="container_dead", ...)`
+    /// constructed in `_wait_for_started`/`await_completion` (PY:1962-1987,
+    /// PY:2110-2138) once `_container_death_reason` finds a death marker.
+    pub fn container_dead(
+        duration_ms: f64,
+        stable: u32,
+        pane: String,
+        err: impl Into<String>,
+    ) -> Self {
+        Self {
+            ready: false,
+            timed_out: false,
+            reason: "container_dead".to_string(),
+            duration_ms,
+            stable_polls_observed: stable,
+            pane,
+            error: Some(err.into()),
+        }
+    }
+
     /// Convenience for CLI `await` exit codes (mirrors Python: 0 if ready, 2 if not).
     pub const fn cli_exit_code(&self) -> i32 {
         if self.ready {

--- a/providers/workspaces/interactive-tmux/driver-rs/src/workspace.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/workspace.rs
@@ -120,6 +120,87 @@ pub fn build_docker_run_argv(container: &str, workdir: &str, image: &str) -> Vec
     ]
 }
 
+/// Substrings docker/tmux emit when the workspace target itself is GONE
+/// (OOM-killed, `docker rm`'d, stopped, tmux session vanished) rather than a
+/// transient capture hiccup while the container is still alive. Matched
+/// case-insensitively against a failed exec's error message so the readiness
+/// pollers can break out immediately instead of spinning the full
+/// startup/await deadline and then reporting a misleading generic timeout (a
+/// "degraded" workspace that actually masks a hard container death).
+///
+/// Deliberately EXCLUDED: "cannot connect to the Docker daemon" / generic
+/// "error connecting to" - those signal a transient daemon or socket outage,
+/// NOT a dead container (the container is very likely still running once the
+/// daemon recovers). Treating them as death would abort a live workspace on
+/// a blip; they stay on the retry path and are bounded by the overall
+/// deadline. Mirrors Python's `_CONTAINER_DEAD_STDERR_MARKERS` (PY:1637-1652).
+const CONTAINER_DEAD_STDERR_MARKERS: &[&str] = &[
+    "no such container",
+    "is not running",
+    "no server running", // tmux daemon gone
+    "no such session",   // tmux session vanished
+    "can't find session",
+];
+
+/// Return a human-readable reason if `err` indicates the workspace target is
+/// GONE, else `None`. Mirrors Python's `_container_death_reason`
+/// (PY:1653-1666).
+///
+/// A timed-out capture (`run_bounded`'s `ErrorKind::TimedOut`, mirroring
+/// Python's `TimeoutExpired`) is always treated as transient - the container
+/// may just be slow this once. Only a failed exec whose error text names a
+/// dead container / tmux server / tmux session counts as death. This lets
+/// the readiness pollers distinguish "one failed capture while still alive"
+/// (keep retrying) from "the container died" (stop now, surface the real
+/// error) instead of blindly polling until the deadline.
+fn container_death_reason(err: &Error) -> Option<String> {
+    if err.kind() == ErrorKind::TimedOut {
+        return None;
+    }
+    let msg = err.to_string();
+    let low = msg.to_lowercase();
+    for marker in CONTAINER_DEAD_STDERR_MARKERS {
+        if low.contains(marker) {
+            let trimmed = msg.trim();
+            return Some(if trimmed.is_empty() {
+                (*marker).to_string()
+            } else {
+                trimmed.to_string()
+            });
+        }
+    }
+    None
+}
+
+/// Outcome of classifying a single poll's pane-capture attempt. Pure (no
+/// I/O, no sleeping) so the await/startup poll loops' resilience logic can
+/// be unit tested without a docker daemon - see `tests/poll_resilience.rs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PollStep {
+    /// Capture succeeded; caller evaluates readiness against this pane text.
+    Captured(String),
+    /// Capture failed but looks transient (container still alive) - keep
+    /// polling within the overall deadline instead of aborting.
+    Retry,
+    /// Capture failed because the workspace target itself is gone.
+    Dead(String),
+}
+
+/// Classify one `tmux::capture_pane` result into a `PollStep`. Mirrors the
+/// try/except branch structure of Python's `_wait_for_started`/
+/// `await_completion` (PY:1962-1987, PY:2110-2138): success -> `Captured`,
+/// a death marker -> `Dead`, anything else (including a timed-out capture)
+/// -> `Retry`.
+pub fn classify_poll(capture: Result<String>) -> PollStep {
+    match capture {
+        Ok(pane) => PollStep::Captured(pane),
+        Err(e) => match container_death_reason(&e) {
+            Some(reason) => PollStep::Dead(reason),
+            None => PollStep::Retry,
+        },
+    }
+}
+
 /// Run `cmd` bounded by `DEFAULT_RUN_TIMEOUT_S` (PY:87) - used for `docker
 /// run` / `docker rm -f`, which get a longer bound than the 15s exec/tmux
 /// default since image pulls and container teardown can legitimately take
@@ -292,8 +373,8 @@ impl Workspace {
         let deadline = start + Duration::from_secs_f64(timeout_s);
         let mut pane = String::new();
         while Instant::now() < deadline {
-            match tmux::capture_pane(&self.container, agent.window()) {
-                Ok(p) => {
+            match classify_poll(tmux::capture_pane(&self.container, agent.window())) {
+                PollStep::Captured(p) => {
                     // D-block-2 fix (Syntropic137 stress): predicate runs
                     // against the bottom-of-pane tail so historical text
                     // in the now-included scrollback can't fool absence
@@ -305,9 +386,14 @@ impl Workspace {
                     }
                     pane = p;
                 }
-                Err(e) => {
+                PollStep::Dead(reason) => {
                     let elapsed = start.elapsed().as_secs_f64() * 1000.0;
-                    return AwaitResult::error(elapsed, pane, e.to_string());
+                    return AwaitResult::container_dead(elapsed, 0, pane, reason);
+                }
+                PollStep::Retry => {
+                    // Phase 3 (PY:1962-1987): a single wedged/failed capture
+                    // while the container is still alive must not abort the
+                    // whole wait - keep polling until the overall deadline.
                 }
             }
             thread::sleep(Duration::from_millis(500));
@@ -366,23 +452,48 @@ impl Workspace {
         let mut ever_ready = false;
         let mut pane = String::new();
         while Instant::now() < deadline {
-            pane = tmux::capture_pane(&self.container, agent.window())?;
-            let tail = tmux::pane_tail(&pane, self.tmux_size.1 as usize);
-            if adapter::is_ready(agent, &tail) {
-                ever_ready = true;
-                if last_tail.as_deref() == Some(&tail) {
-                    consecutive_stable_ready += 1;
-                    if consecutive_stable_ready >= stable_polls {
-                        let elapsed = start.elapsed().as_secs_f64() * 1000.0;
-                        return Ok(AwaitResult::ready(elapsed, consecutive_stable_ready, pane));
+            match classify_poll(tmux::capture_pane(&self.container, agent.window())) {
+                PollStep::Captured(p) => {
+                    pane = p;
+                    let tail = tmux::pane_tail(&pane, self.tmux_size.1 as usize);
+                    if adapter::is_ready(agent, &tail) {
+                        ever_ready = true;
+                        if last_tail.as_deref() == Some(&tail) {
+                            consecutive_stable_ready += 1;
+                            if consecutive_stable_ready >= stable_polls {
+                                let elapsed = start.elapsed().as_secs_f64() * 1000.0;
+                                return Ok(AwaitResult::ready(
+                                    elapsed,
+                                    consecutive_stable_ready,
+                                    pane,
+                                ));
+                            }
+                        } else {
+                            consecutive_stable_ready = 0;
+                        }
+                    } else {
+                        consecutive_stable_ready = 0;
                     }
-                } else {
-                    consecutive_stable_ready = 0;
+                    last_tail = Some(tail);
                 }
-            } else {
-                consecutive_stable_ready = 0;
+                PollStep::Dead(reason) => {
+                    let elapsed = start.elapsed().as_secs_f64() * 1000.0;
+                    return Ok(AwaitResult::container_dead(
+                        elapsed,
+                        consecutive_stable_ready,
+                        pane,
+                        reason,
+                    ));
+                }
+                PollStep::Retry => {
+                    // Phase 3 (PY:2110-2138): a single failed/wedged poll
+                    // (container still alive) must not abort the whole
+                    // await - treat it as "not ready this round" and keep
+                    // polling until the overall deadline above.
+                    consecutive_stable_ready = 0;
+                    last_tail = None;
+                }
             }
-            last_tail = Some(tail);
             thread::sleep(Duration::from_secs_f64(poll_interval));
         }
         let elapsed = start.elapsed().as_secs_f64() * 1000.0;

--- a/providers/workspaces/interactive-tmux/driver-rs/tests/poll_resilience.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/tests/poll_resilience.rs
@@ -1,0 +1,124 @@
+//! Poll-resilience parity tests (Plan 1a, Task 4).
+//!
+//! Exercises the pure `itmux::workspace::classify_poll` step function that
+//! `await_completion`/`wait_for_started` use to decide, per poll, whether to
+//! keep waiting, treat the pane as captured, or bail out because the
+//! workspace target itself is dead. No docker daemon involved - every case
+//! feeds a synthetic `std::io::Result<String>` (the same shape
+//! `tmux::capture_pane` returns) straight into `classify_poll`.
+//!
+//! Parity source: `driver/interactive_tmux.py` `_wait_for_started`
+//! (PY:1962-1987), `await_completion` (PY:2110-2138), and
+//! `_container_death_reason` / `_CONTAINER_DEAD_STDERR_MARKERS`
+//! (PY:1637-1666).
+
+use std::io::{Error, ErrorKind, Result};
+
+use itmux::workspace::{classify_poll, PollStep};
+
+fn transient_timeout() -> Result<String> {
+    Err(Error::new(
+        ErrorKind::TimedOut,
+        "command timed out after 15s",
+    ))
+}
+
+fn transient_exec_failure() -> Result<String> {
+    // A generic docker exec failure whose stderr does not name a dead
+    // container/session - e.g. a one-off wedge. Must be retried, not fatal.
+    Err(Error::other(
+        "docker exec c1 tmux capture-pane failed (exit 1): unexpected error",
+    ))
+}
+
+fn ready_pane(text: &str) -> Result<String> {
+    Ok(text.to_string())
+}
+
+#[test]
+fn poll_sequence_transient_transient_ready_does_not_abort_on_first_error() {
+    // (a) capture sequence [transient_err, transient_err, ready_pane] ->
+    // classification never returns Dead, and the final capture is surfaced
+    // for the readiness predicate to evaluate. This is the resilience gap:
+    // a naive `?`-on-first-error loop would have aborted after step 1.
+    let sequence = [
+        transient_timeout(),
+        transient_exec_failure(),
+        ready_pane("agent is idle"),
+    ];
+
+    let mut captured: Option<String> = None;
+    for capture in sequence {
+        match classify_poll(capture) {
+            PollStep::Retry => continue,
+            PollStep::Captured(pane) => {
+                captured = Some(pane);
+            }
+            PollStep::Dead(reason) => panic!("unexpectedly classified as dead: {reason}"),
+        }
+    }
+
+    assert_eq!(captured.as_deref(), Some("agent is idle"));
+}
+
+#[test]
+fn timed_out_capture_is_always_transient() {
+    assert_eq!(classify_poll(transient_timeout()), PollStep::Retry);
+}
+
+#[test]
+fn generic_capture_failure_is_transient() {
+    assert_eq!(classify_poll(transient_exec_failure()), PollStep::Retry);
+}
+
+#[test]
+fn real_container_dead_markers_are_classified_as_dead() {
+    let cases = [
+        "docker exec c1 tmux capture-pane failed (exit 1): Error: No such container: c1",
+        "docker exec c1 tmux capture-pane failed (exit 1): container c1 is not running",
+        "docker exec c1 tmux capture-pane failed (exit 1): no server running on /tmp/tmux-0/default",
+        "docker exec c1 tmux capture-pane failed (exit 1): no such session: agents",
+        "docker exec c1 tmux capture-pane failed (exit 1): can't find session agents",
+    ];
+
+    for case in cases {
+        let step = classify_poll(Err(Error::other(case)));
+        match step {
+            PollStep::Dead(reason) => assert!(!reason.is_empty(), "empty reason for: {case}"),
+            other => panic!("expected Dead for {case:?}, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn docker_daemon_outage_strings_are_not_classified_as_container_dead() {
+    // (c) "cannot connect to the Docker daemon" must NOT be treated as
+    // container death - it is a transient daemon/socket outage, and the
+    // container is very likely still running once the daemon recovers.
+    // Treating it as death would abort a live workspace on a blip.
+    let daemon_outage_cases = [
+        "Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?",
+        "error connecting to docker socket: dial unix /var/run/docker.sock: connect: no such file or directory",
+    ];
+
+    for case in daemon_outage_cases {
+        let step = classify_poll(Err(Error::other(case)));
+        assert_eq!(
+            step,
+            PollStep::Retry,
+            "daemon-outage string wrongly classified as dead: {case}"
+        );
+    }
+}
+
+#[test]
+fn timeout_is_never_classified_as_dead_even_with_a_death_marker_in_the_message() {
+    // A `TimedOut` kind must short-circuit to transient regardless of
+    // message content - mirrors Python's `isinstance(exc, TimeoutExpired)`
+    // check running before any string matching (PY:1657-1658).
+    let step = classify_poll(Err(Error::new(
+        ErrorKind::TimedOut,
+        "no such container: timed out waiting for capture",
+    )));
+    assert_eq!(step, PollStep::Retry);
+}


### PR DESCRIPTION
Plan 1a Task 4 (stacked on #232). Extracts a pure `classify_poll` (Captured/Retry/Dead); `await_completion`/`wait_for_started` keep polling across a transient capture failure instead of `?`-aborting, and classify genuine container death (`reason=container_dead`) via the corrected Python marker set. Daemon-outage strings ("cannot connect to the Docker daemon") are explicitly NOT classified as death (tested). `cargo test` green (6 new); clippy/fmt clean. Minor parity note: the dead-reason `error` field carries the formatted io::Error message rather than isolated stderr. Tracks okrs-51p.6.