### PR TITLE
fix(itmux): paste-buffer path for >12KB prompts (bracketed paste + named buffer)

### DIFF
--- a/providers/workspaces/interactive-tmux/driver-rs/src/tmux.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/tmux.rs
@@ -7,6 +7,7 @@
 
 use std::io::{Error, ErrorKind, Result, Write};
 use std::process::{Child, Command, Output, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc;
 use std::time::Duration;
 
@@ -173,18 +174,153 @@ pub fn send_keys(container: &str, window: &str, keys: &[&str]) -> Result<()> {
     Ok(())
 }
 
-/// `docker exec <container> tmux send-keys -l -t <session>:<window> <text>`.
+/// Bound above which `send-keys -l` is skipped in favour of the
+/// load-buffer/paste-buffer path. Mirrors the Python driver's
+/// `TMUX_SEND_KEYS_MAX_BYTES` (PY:91): tmux's `send-keys -l` has a ~16KB
+/// cap and silently truncates larger payloads, so anything bigger is
+/// staged through a tmux paste buffer instead (PY:645-707).
+pub const TMUX_SEND_KEYS_MAX_BYTES: usize = 12_000;
+
+/// Monotonic per-process counter feeding the unique paste-buffer name.
+/// Combined with the process id it makes each large-payload send use its
+/// own named tmux buffer, so concurrent sends never race on the shared
+/// default buffer (Python uses a `uuid4` token for the same reason,
+/// PY:684-686). `std`-only, no `unsafe`, no new deps.
+static PASTE_BUFFER_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// The command plan `send_literal` will execute for a given payload,
+/// factored out as a pure, assertable value so tests can cover the
+/// threshold logic without a docker daemon.
+#[derive(Debug, PartialEq, Eq)]
+pub enum SendLiteralPlan {
+    /// `tmux send-keys -t <pane> -l -- <text>` - payload at or under
+    /// `TMUX_SEND_KEYS_MAX_BYTES` (PY:666 uses `<=` for this path).
+    SendKeys { pane: String, text: String },
+    /// `tmux load-buffer -b <buffer> -` (fed `payload` via stdin) followed
+    /// by `tmux paste-buffer -p -b <buffer> -d -t <pane>` - payload over
+    /// the threshold (PY:683-702). `-p` sends a bracketed paste so a
+    /// multiline prompt is delivered atomically instead of each newline
+    /// submitting early; `-b <buffer>` uses a unique named buffer to avoid
+    /// racing the shared default buffer; `-d` deletes that buffer after
+    /// pasting, covering Python's `finally` cleanup.
+    PasteBuffer {
+        pane: String,
+        buffer: String,
+        payload: Vec<u8>,
+    },
+}
+
+impl SendLiteralPlan {
+    /// `tmux load-buffer` argv for the large path (stdin carries the
+    /// payload). Empty for the `SendKeys` variant.
+    pub fn load_buffer_args(&self) -> Vec<String> {
+        match self {
+            SendLiteralPlan::SendKeys { .. } => Vec::new(),
+            SendLiteralPlan::PasteBuffer { buffer, .. } => {
+                vec![
+                    "tmux".into(),
+                    "load-buffer".into(),
+                    "-b".into(),
+                    buffer.clone(),
+                    "-".into(),
+                ]
+            }
+        }
+    }
+
+    /// `tmux paste-buffer` argv for the large path. Empty for the
+    /// `SendKeys` variant.
+    pub fn paste_buffer_args(&self) -> Vec<String> {
+        match self {
+            SendLiteralPlan::SendKeys { .. } => Vec::new(),
+            SendLiteralPlan::PasteBuffer { pane, buffer, .. } => {
+                vec![
+                    "tmux".into(),
+                    "paste-buffer".into(),
+                    "-p".into(),
+                    "-b".into(),
+                    buffer.clone(),
+                    "-d".into(),
+                    "-t".into(),
+                    pane.clone(),
+                ]
+            }
+        }
+    }
+}
+
+/// Derive a unique-per-call tmux buffer name. `std`-only: process id plus a
+/// monotonic counter, prefixed to mirror the Python driver's `itmux-<hex>`
+/// naming (PY:686). Two sends from the same process get distinct counter
+/// values; two sends from different processes get distinct pids.
+fn next_paste_buffer_name() -> String {
+    let seq = PASTE_BUFFER_SEQ.fetch_add(1, Ordering::Relaxed);
+    format!("itmux-{}-{seq}", std::process::id())
+}
+
+/// Decide how `text` should be delivered into `pane`, without touching
+/// docker or tmux. Mirrors the Python driver's byte-length branch
+/// (PY:665-666): the threshold is measured against the UTF-8 byte length
+/// of the payload, not its character count. The large path mints a unique
+/// buffer name so concurrent callers never collide.
+pub fn plan_send_literal(pane: &str, text: &str) -> SendLiteralPlan {
+    let payload = text.as_bytes();
+    if payload.len() <= TMUX_SEND_KEYS_MAX_BYTES {
+        SendLiteralPlan::SendKeys {
+            pane: pane.to_string(),
+            text: text.to_string(),
+        }
+    } else {
+        SendLiteralPlan::PasteBuffer {
+            pane: pane.to_string(),
+            buffer: next_paste_buffer_name(),
+            payload: payload.to_vec(),
+        }
+    }
+}
+
+/// `docker exec <container> tmux send-keys -l -t <session>:<window> <text>`,
+/// or - for payloads over `TMUX_SEND_KEYS_MAX_BYTES` - a
+/// `load-buffer`/`paste-buffer` round trip that avoids tmux's ~16KB
+/// `send-keys -l` truncation cap (PY:645-707).
 ///
 /// The `-l` flag tells tmux to deliver the bytes literally (no special-key
 /// interpretation) - the canonical pattern for the body of a user message.
 pub fn send_literal(container: &str, window: &str, text: &str) -> Result<()> {
     let target = format!("{TMUX_SESSION}:{window}");
-    // `--` ends option parsing so a prompt beginning with `-` (e.g. "-R",
-    // "--help") is treated as literal text, not a tmux send-keys flag.
-    docker_exec(
-        container,
-        &["tmux", "send-keys", "-t", &target, "-l", "--", text],
-    )?;
+    let plan = plan_send_literal(&target, text);
+    match &plan {
+        SendLiteralPlan::SendKeys { pane, text } => {
+            // `--` ends option parsing so a prompt beginning with `-` (e.g.
+            // "-R", "--help") is treated as literal text, not a tmux
+            // send-keys flag.
+            docker_exec(
+                container,
+                &["tmux", "send-keys", "-t", pane, "-l", "--", text],
+            )?;
+        }
+        SendLiteralPlan::PasteBuffer {
+            pane,
+            buffer,
+            payload,
+        } => {
+            // `load-buffer -b <name> -` reads the buffer contents from
+            // stdin (which `docker_exec_with_stdin` already pipes in - no
+            // container-side temp file needed) into a unique named buffer.
+            docker_exec_with_stdin(
+                container,
+                &["tmux", "load-buffer", "-b", buffer, "-"],
+                payload,
+            )?;
+            // `-p` = bracketed paste (atomic multiline); `-d` deletes the
+            // named buffer afterwards so large sends don't accumulate stale
+            // buffers and can't leak payload bytes into a later paste.
+            docker_exec(
+                container,
+                &["tmux", "paste-buffer", "-p", "-b", buffer, "-d", "-t", pane],
+            )?;
+        }
+    }
     Ok(())
 }
 

--- a/providers/workspaces/interactive-tmux/driver-rs/tests/send_literal.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/tests/send_literal.rs
@@ -1,0 +1,151 @@
+//! Regression tests for the paste-buffer fallback in `send_literal`.
+//!
+//! Mirrors the Python driver's `_tmux_send_literal` (PY:645-707): tmux's
+//! `send-keys -l` has a ~16KB cap and silently truncates larger payloads.
+//! Above `TMUX_SEND_KEYS_MAX_BYTES` (PY:91, `12_000`) the driver instead
+//! stages the payload into a tmux buffer via `load-buffer -` (stdin) and
+//! dispatches it with `paste-buffer`.
+//!
+//! These tests exercise the pure planning function only - no docker
+//! daemon involved - so they run in any environment.
+
+use itmux::tmux::{plan_send_literal, SendLiteralPlan, TMUX_SEND_KEYS_MAX_BYTES};
+
+const PANE: &str = "agents:0";
+
+#[test]
+fn small_payload_uses_send_keys() {
+    let text = "x".repeat(100);
+    match plan_send_literal(PANE, &text) {
+        SendLiteralPlan::SendKeys { pane, text: t } => {
+            assert_eq!(pane, PANE);
+            assert_eq!(t, text);
+        }
+        SendLiteralPlan::PasteBuffer { .. } => panic!("100-byte payload must use send-keys -l"),
+    }
+}
+
+#[test]
+fn large_payload_uses_paste_buffer() {
+    let text = "y".repeat(20 * 1024);
+    match plan_send_literal(PANE, &text) {
+        SendLiteralPlan::PasteBuffer {
+            pane,
+            buffer,
+            payload,
+        } => {
+            assert_eq!(pane, PANE);
+            assert_eq!(payload, text.as_bytes());
+            assert!(!buffer.is_empty(), "large path must mint a buffer name");
+        }
+        SendLiteralPlan::SendKeys { .. } => panic!("20KB payload must use paste-buffer"),
+    }
+}
+
+#[test]
+fn large_payload_plan_uses_bracketed_paste_and_named_buffer() {
+    let text = "y".repeat(20 * 1024);
+    let plan = plan_send_literal(PANE, &text);
+    let buffer = match &plan {
+        SendLiteralPlan::PasteBuffer { buffer, .. } => buffer.clone(),
+        SendLiteralPlan::SendKeys { .. } => panic!("20KB payload must use paste-buffer"),
+    };
+
+    // load-buffer stages the payload into the NAMED buffer via stdin (`-`).
+    let load = plan.load_buffer_args();
+    assert_eq!(
+        load,
+        vec![
+            "tmux".to_string(),
+            "load-buffer".to_string(),
+            "-b".to_string(),
+            buffer.clone(),
+            "-".to_string(),
+        ],
+    );
+
+    // paste-buffer MUST carry `-p` (bracketed paste) and `-b <name>`
+    // (named buffer), plus `-d` to delete it after paste. PY:698-702.
+    let paste = plan.paste_buffer_args();
+    assert!(
+        paste.iter().any(|a| a == "-p"),
+        "paste-buffer plan must include -p (bracketed paste): {paste:?}"
+    );
+    let b_pos = paste
+        .iter()
+        .position(|a| a == "-b")
+        .expect("paste-buffer plan must include -b");
+    assert_eq!(
+        paste.get(b_pos + 1),
+        Some(&buffer),
+        "-b must be followed by the minted buffer name"
+    );
+    assert!(
+        paste.iter().any(|a| a == "-d"),
+        "paste-buffer plan must include -d (delete buffer after paste): {paste:?}"
+    );
+    assert_eq!(
+        paste,
+        vec![
+            "tmux".to_string(),
+            "paste-buffer".to_string(),
+            "-p".to_string(),
+            "-b".to_string(),
+            buffer.clone(),
+            "-d".to_string(),
+            "-t".to_string(),
+            PANE.to_string(),
+        ],
+    );
+}
+
+#[test]
+fn buffer_names_are_unique_per_call() {
+    let text = "y".repeat(20 * 1024);
+    let a = match plan_send_literal(PANE, &text) {
+        SendLiteralPlan::PasteBuffer { buffer, .. } => buffer,
+        SendLiteralPlan::SendKeys { .. } => unreachable!(),
+    };
+    let b = match plan_send_literal(PANE, &text) {
+        SendLiteralPlan::PasteBuffer { buffer, .. } => buffer,
+        SendLiteralPlan::SendKeys { .. } => unreachable!(),
+    };
+    assert_ne!(a, b, "each large send must mint a distinct buffer name");
+}
+
+#[test]
+fn small_payload_plan_has_no_paste_buffer_args() {
+    let plan = plan_send_literal(PANE, "small");
+    assert!(plan.load_buffer_args().is_empty());
+    assert!(plan.paste_buffer_args().is_empty());
+}
+
+#[test]
+fn boundary_exactly_at_threshold_uses_send_keys() {
+    // PY:666 uses `<=` for the small-path check, so a payload of exactly
+    // `TMUX_SEND_KEYS_MAX_BYTES` bytes still takes the send-keys path.
+    let text = "z".repeat(TMUX_SEND_KEYS_MAX_BYTES);
+    match plan_send_literal(PANE, &text) {
+        SendLiteralPlan::SendKeys { .. } => {}
+        SendLiteralPlan::PasteBuffer { .. } => {
+            panic!("payload of exactly the threshold must use send-keys -l")
+        }
+    }
+}
+
+#[test]
+fn boundary_one_byte_over_threshold_uses_paste_buffer() {
+    let text = "z".repeat(TMUX_SEND_KEYS_MAX_BYTES + 1);
+    match plan_send_literal(PANE, &text) {
+        SendLiteralPlan::PasteBuffer { .. } => {}
+        SendLiteralPlan::SendKeys { .. } => {
+            panic!("payload one byte over the threshold must use paste-buffer")
+        }
+    }
+}
+
+#[test]
+fn threshold_constant_matches_python_parity() {
+    // PY:91 `TMUX_SEND_KEYS_MAX_BYTES = 12_000`.
+    assert_eq!(TMUX_SEND_KEYS_MAX_BYTES, 12_000);
+}


### PR DESCRIPTION
Plan 1a Task 5 (stacked on #233). `send_literal` switches to a load-buffer/paste-buffer path above 12,000 bytes so large prompts are not truncated by tmux send-keys (~16KB cap). Full parity with PY:645-707: `load-buffer -b <name> -` (payload via stdin, no temp file), `paste-buffer -p -b <name> -d -t <pane>`. The `-p` (bracketed paste) makes a multiline prompt paste atomically instead of each newline acting as Enter (fixes the historical early-submit fragmentation); named buffer avoids default-buffer races; `-d` cleans up. `cargo test` green (8 send_literal); clippy/fmt clean. Tracks okrs-51p.6.