### PR TITLE
fix(itmux): skip codex plugins/ dir during auth staging

### DIFF
--- a/providers/workspaces/interactive-tmux/driver-rs/src/auth.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/auth.rs
@@ -248,8 +248,10 @@ pub fn prepare_codex(host_src: &Path, ctx: &AuthContext) -> Result<PreparedAuth>
     }
     let dst_dir = ctx.throwaway_dir.join("codex.dir");
     // Skip tmp/log/logs: codex races there during normal operation. The auth
-    // surface lives at `auth.json` / `config.toml` / `sessions/`.
-    copy_tree(host_src, &dst_dir, &["tmp", "log", "logs"])?;
+    // surface lives at `auth.json` / `config.toml` / `sessions/`. Also skip
+    // plugins/: a large plugin/dependency cache (node_modules), never auth,
+    // and staging it turns start_workspace into a multi-minute crawl.
+    copy_tree(host_src, &dst_dir, &["tmp", "log", "logs", "plugins"])?;
     Ok(PreparedAuth(vec![StagedPath {
         host: dst_dir,
         container: "/home/agent/.codex".to_string(),

--- a/providers/workspaces/interactive-tmux/driver-rs/tests/auth_parity.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/tests/auth_parity.rs
@@ -161,13 +161,15 @@ fn gemini_patches_folder_trust_in_settings() {
 }
 
 #[test]
-fn codex_skips_tmp_and_log_subdirs() {
+fn codex_skips_tmp_log_and_plugins_subdirs() {
     let host = tmp("codex-host");
     fs::create_dir_all(host.join("tmp")).unwrap();
     fs::create_dir_all(host.join("log")).unwrap();
+    fs::create_dir_all(host.join("plugins")).unwrap();
     fs::create_dir_all(host.join("sessions")).unwrap();
     fs::write(host.join("tmp").join("racy-argv.bin"), b"vanish").unwrap();
     fs::write(host.join("log").join("verbose.log"), b"noisy").unwrap();
+    fs::write(host.join("plugins").join("node_modules_stub"), b"heavy").unwrap();
     fs::write(host.join("auth.json"), b"{}").unwrap();
     fs::write(host.join("sessions").join("01.json"), b"{}").unwrap();
 
@@ -183,4 +185,5 @@ fn codex_skips_tmp_and_log_subdirs() {
     assert!(dst.join("sessions").join("01.json").is_file());
     assert!(!dst.join("tmp").exists(), "tmp/ must be skipped");
     assert!(!dst.join("log").exists(), "log/ must be skipped");
+    assert!(!dst.join("plugins").exists(), "plugins/ must be skipped");
 }


### PR DESCRIPTION
Plan 1a Task 6 (stacked on #234). Adds `plugins` to the codex auth skip set (`tmp,log,logs` -> `tmp,log,logs,plugins`), matching PY:1176, so staging a real `~/.codex` with a heavy `plugins/` tree does not copy node_modules. `auth_parity` test extended to assert `plugins/` exclusion. cargo test/clippy/fmt green. Tracks okrs-51p.6.