### PR TITLE
ci(itmux): run cargo test/clippy/fmt in CI + justfile

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,43 @@
+name: Rust
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Cancel in-progress runs on same PR/branch
+concurrency:
+  group: rust-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: providers/workspaces/interactive-tmux/driver-rs
+
+jobs:
+  itmux:
+    name: itmux (fmt, clippy, test)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.3
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy, rustfmt
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2.9.1
+        with:
+          workspaces: "providers/workspaces/interactive-tmux/driver-rs -> target"
+
+      - name: Check formatting
+        run: cargo fmt -- --check
+
+      - name: Lint
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Run tests
+        run: cargo test

--- a/justfile
+++ b/justfile
@@ -115,20 +115,51 @@ python-test-integration:
     @echo '{{ GREEN }}✓ Python integration tests passed{{ NORMAL }}'
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# RUST (itmux driver)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Run itmux Rust tests
+[group('rust')]
+rust-test:
+    @echo '{{ YELLOW }}Running itmux Rust tests...{{ NORMAL }}'
+    cd providers/workspaces/interactive-tmux/driver-rs && cargo test
+    @echo '{{ GREEN }}✓ itmux Rust tests passed{{ NORMAL }}'
+
+# Lint itmux Rust code
+[group('rust')]
+rust-lint:
+    @echo '{{ YELLOW }}Linting itmux Rust code...{{ NORMAL }}'
+    cd providers/workspaces/interactive-tmux/driver-rs && cargo clippy --all-targets -- -D warnings
+    @echo '{{ GREEN }}✓ itmux Rust linting complete{{ NORMAL }}'
+
+# Check itmux Rust formatting
+[group('rust')]
+rust-fmt-check:
+    @echo '{{ YELLOW }}Checking itmux Rust formatting...{{ NORMAL }}'
+    cd providers/workspaces/interactive-tmux/driver-rs && cargo fmt -- --check
+
+# Format itmux Rust code
+[group('rust')]
+rust-fmt:
+    @echo '{{ YELLOW }}Formatting itmux Rust code...{{ NORMAL }}'
+    cd providers/workspaces/interactive-tmux/driver-rs && cargo fmt
+    @echo '{{ GREEN }}✓ itmux Rust formatting complete{{ NORMAL }}'
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # COMBINED OPERATIONS
 # ═══════════════════════════════════════════════════════════════════════════════
 
 # Format all code
 [group('all')]
-fmt: python-fmt
+fmt: python-fmt rust-fmt
 
 # Check all formatting
 [group('all')]
-fmt-check: python-fmt-check
+fmt-check: python-fmt-check rust-fmt-check
 
 # Lint all code
 [group('all')]
-lint: python-lint
+lint: python-lint rust-lint
 
 # Auto-fix linting issues
 [group('all')]
@@ -136,7 +167,7 @@ lint-fix: python-lint-fix
 
 # Run all tests
 [group('all')]
-test: python-test
+test: python-test rust-test
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # QUALITY ASSURANCE

--- a/providers/workspaces/interactive-tmux/driver-rs/src/auth.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/auth.rs
@@ -513,3 +513,37 @@ pub fn stage_into_container(container: &str, prepared: &PreparedAuth) -> Result<
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod base64_tests {
+    use super::base64_encode;
+
+    // RFC 4648 section 10 test vectors, plus high-bit bytes to guard the
+    // std-only encoder against sign/padding regressions (the whole credential
+    // path depends on this being byte-exact; the container-side `base64 -d`
+    // only runs under real docker).
+    #[test]
+    fn rfc4648_and_high_bit_vectors() {
+        let cases: &[(&[u8], &[u8])] = &[
+            (b"", b""),
+            (b"f", b"Zg=="),
+            (b"fo", b"Zm8="),
+            (b"foo", b"Zm9v"),
+            (b"foob", b"Zm9vYg=="),
+            (b"fooba", b"Zm9vYmE="),
+            (b"foobar", b"Zm9vYmFy"),
+            (b"\x00", b"AA=="),
+            (b"\xff", b"/w=="),
+            (b"\xff\xff", b"//8="),
+            (b"\xff\xff\xff", b"////"),
+            (b"\x00\x10\x83", b"ABCD"),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(
+                base64_encode(input),
+                expected.to_vec(),
+                "base64_encode({input:?}) mismatch"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Plan 1a Task 7 (final, stacked on #235). Wires the `itmux` Rust crate into CI + justfile (previously Python-only).

- `justfile`: `rust-test`/`rust-lint`/`rust-fmt-check` (+ `rust-fmt`), folded into `fmt-check`/`lint`/`test` so `qa`/`ci`/`check` now transitively run the Rust gates.
- `.github/workflows/rust.yml`: new 'Rust' workflow (PR + push main), toolchain + clippy + rustfmt + cargo test in the crate dir. Action refs verified to exist; tag-pinned to match this repo's own qa.yml convention.

`just rust-test` 28 pass; clippy/fmt clean.

**Follow-up (recommended, not blocking):** SHA-pin `dtolnay/rust-toolchain` + `Swatinem/rust-cache` to match the sibling event-sourcing-platform repo's supply-chain convention (this repo's qa.yml currently tag-pins). **Manual gate still open:** live DooD smoke of itmux (real Docker + creds) before the Python driver is deleted in Plan 1b. Tracks okrs-51p.6.