### PR TITLE
feat(isolation): RunSpec/RunResult contract + credentials + events (Plan 1b Task 2)

### DIFF
--- a/lib/python/agentic_isolation/agentic_isolation/run_events.py
+++ b/lib/python/agentic_isolation/agentic_isolation/run_events.py
@@ -1,0 +1,81 @@
+"""RunEvent: the live event stream emitted while executing a RunSpec.
+
+Implements Plan 1b Task 2 of the RunSpec/RunResult contract work: a
+discriminated union of event variants a harness adapter emits during
+a run (tool lifecycle, token usage, session end), plus the
+`EventCallback` signature callers register to observe them and a
+`CancelMode` used to request cancellation of an in-flight run.
+
+This is the live-streaming counterpart to the terminal `RunResult`
+(see `run_result.py`); `RunResult.observability` is the
+after-the-fact summary, `RunEvent` is the moment-by-moment feed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+CancelMode = Literal["graceful", "hard"]
+
+
+class ToolStartEvent(BaseModel):
+    """A tool invocation has started."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    type: Literal["tool_start"] = "tool_start"
+    tool_name: str = Field(min_length=1)
+    tool_use_id: str = Field(min_length=1)
+
+
+class ToolEndEvent(BaseModel):
+    """A tool invocation has finished."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    type: Literal["tool_end"] = "tool_end"
+    tool_name: str = Field(min_length=1)
+    tool_use_id: str = Field(min_length=1)
+    success: bool
+
+
+class TokenUsageEvent(BaseModel):
+    """A token usage sample for the in-progress run."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    type: Literal["token_usage"] = "token_usage"
+    input_tokens: int = Field(ge=0)
+    output_tokens: int = Field(ge=0)
+
+
+class SessionEndEvent(BaseModel):
+    """The run's session has ended."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    type: Literal["session_end"] = "session_end"
+    success: bool
+
+
+RunEvent = Annotated[
+    ToolStartEvent | ToolEndEvent | TokenUsageEvent | SessionEndEvent,
+    Field(discriminator="type"),
+]
+
+
+class RunEventEnvelope(BaseModel):
+    """Wraps a `RunEvent` so the discriminated union can be validated
+    directly (pydantic v2 requires a `BaseModel` field to trigger
+    union discrimination outside of a `TypeAdapter`).
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    event: RunEvent
+
+
+EventCallback = Callable[[RunEvent], None]

--- a/lib/python/agentic_isolation/agentic_isolation/run_result.py
+++ b/lib/python/agentic_isolation/agentic_isolation/run_result.py
@@ -1,0 +1,54 @@
+"""RunResult: the outcome contract for a completed RunSpec execution.
+
+Implements Plan 1b Task 2 of the RunSpec/RunResult contract work: a
+`RunResult` is what an isolation provider hands back after executing
+a `RunSpec` (see `run_spec.py`) - whether the run succeeded, what
+artifacts it produced, and the raw session log.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class RunOutcome(BaseModel):
+    """Whether a run succeeded and a short human-readable summary."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    success: bool
+    summary: str = Field(min_length=1)
+
+
+class ObservabilityBundle(BaseModel):
+    """Placeholder for the observability payload attached to a RunResult.
+
+    Minimal shape for Plan 1b Task 2: a `session_id` correlating this
+    bundle back to the run, and an opaque `metrics` bag. Plan 3 will
+    replace this with the full observability contract (tool traces,
+    token usage timelines, cost breakdown) once it lands.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    session_id: str = Field(min_length=1)
+    metrics: dict[str, float] = Field(default_factory=dict)
+
+
+class RunResult(BaseModel):
+    """The outcome of executing a RunSpec.
+
+    `result` carries the pass/fail summary, `output_artifacts` lists
+    any files the run produced, and `session_log` is the raw
+    harness transcript (e.g. JSONL stdout). `observability` is an
+    optional placeholder bundle (see `ObservabilityBundle`).
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    result: RunOutcome
+    output_artifacts: list[Path] = Field(default_factory=list)
+    session_log: str
+    observability: ObservabilityBundle | None = None

--- a/lib/python/agentic_isolation/agentic_isolation/run_spec.py
+++ b/lib/python/agentic_isolation/agentic_isolation/run_spec.py
@@ -1,0 +1,101 @@
+"""RunSpec: task-specific invocation contract for an agent recipe.
+
+Implements Plan 1b Task 2 of the RunSpec/RunResult contract work: a
+`RunSpec` pairs a harness-neutral `AgentRecipe` (see `recipe.py`) with
+the task-specific input, credentials, and limits needed to actually
+execute a run. Recipes stay reusable and credential-free; `RunSpec` is
+the per-invocation envelope.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from agentic_isolation.recipe import AgentRecipe
+
+
+class RunLimits(BaseModel):
+    """Resource limits for a single run."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    timeout_s: float | None = None
+    token_budget: int | None = None
+
+
+class ClaudeCredentials(BaseModel):
+    """Credentials for the `claude` harness.
+
+    `oauth_token` corresponds to the `CLAUDE_CODE_OAUTH_TOKEN`
+    environment variable consumed by the Claude Code CLI.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    oauth_token: str = Field(min_length=1)
+
+
+class CodexCredentials(BaseModel):
+    """Credentials for the `codex` harness.
+
+    `auth_json` holds the raw contents of `~/.codex/auth.json` (not a
+    filesystem path). Callers read the file once and pass its
+    contents through; the isolation layer writes it into the
+    workspace at execution time. This avoids leaking host filesystem
+    paths into a contract that may cross a process or network
+    boundary.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    auth_json: str = Field(min_length=1)
+
+
+class RunCredentials(BaseModel):
+    """Per-harness credentials for a run, keyed by harness name.
+
+    Only known harnesses (`claude`, `codex`) are accepted as keys;
+    `extra="forbid"` rejects any other harness name at validation
+    time rather than silently ignoring it.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    claude: ClaudeCredentials | None = None
+    codex: CodexCredentials | None = None
+
+
+class ObservabilityExporter(BaseModel):
+    """Placeholder for an observability exporter configuration.
+
+    Minimal shape for Plan 1b Task 2: a `name` identifying the
+    exporter and an opaque `config` bag. Plan 3 will replace this
+    with a fully typed, per-exporter model (e.g. OTLP endpoint,
+    headers, sampling) once the observability contract is designed.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    name: str = Field(min_length=1)
+    config: dict[str, str] = Field(default_factory=dict)
+
+
+class RunSpec(BaseModel):
+    """A single task-specific invocation of an agent recipe.
+
+    Pairs a harness-neutral `recipe` with the `task` description,
+    optional `input_artifacts`, per-harness `credentials`, and
+    resource `limits`. `observability` is a placeholder list of
+    exporters (see `ObservabilityExporter`).
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    recipe: AgentRecipe
+    task: str = Field(min_length=1)
+    input_artifacts: list[Path] = Field(default_factory=list)
+    credentials: RunCredentials
+    observability: list[ObservabilityExporter] = Field(default_factory=list)
+    limits: RunLimits | None = None

--- a/lib/python/agentic_isolation/tests/test_run_contract.py
+++ b/lib/python/agentic_isolation/tests/test_run_contract.py
@@ -1,0 +1,243 @@
+"""Tests for RunSpec/RunResult contract (Plan 1b Task 2).
+
+Covers: RunSpec (recipe + task + credentials + limits) validation,
+RunCredentials rejecting unknown harness keys, RunResult required
+fields, and the RunEvent discriminated union.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from agentic_isolation.recipe import AgentRecipe
+from agentic_isolation.run_events import (
+    RunEvent,
+    RunEventEnvelope,
+    SessionEndEvent,
+    TokenUsageEvent,
+    ToolEndEvent,
+    ToolStartEvent,
+)
+from agentic_isolation.run_result import RunOutcome, RunResult
+from agentic_isolation.run_spec import (
+    ClaudeCredentials,
+    CodexCredentials,
+    ObservabilityExporter,
+    RunCredentials,
+    RunSpec,
+)
+
+RECIPE: dict[str, Any] = {
+    "name": "quick-fix",
+    "agent": "claude",
+    "model": {
+        "name": "anthropic/claude-opus-4-8",
+        "effort": "low",
+    },
+}
+
+
+class TestRunSpec:
+    def test_full_run_spec_validates(self) -> None:
+        spec = RunSpec.model_validate(
+            {
+                "recipe": RECIPE,
+                "task": "Fix the failing test in test_foo.py",
+                "input_artifacts": ["/tmp/input.txt"],
+                "credentials": {"claude": {"oauth_token": "sk-oauth-token"}},
+                "observability": [{"name": "otel", "config": {"endpoint": "http://x"}}],
+                "limits": {"timeout_s": 300.0, "token_budget": 100000},
+            }
+        )
+
+        assert isinstance(spec.recipe, AgentRecipe)
+        assert spec.task == "Fix the failing test in test_foo.py"
+        assert spec.input_artifacts == [Path("/tmp/input.txt")]
+        assert spec.credentials.claude is not None
+        assert spec.credentials.claude.oauth_token == "sk-oauth-token"
+        assert spec.limits is not None
+        assert spec.limits.timeout_s == 300.0
+        assert spec.limits.token_budget == 100000
+
+    def test_minimal_run_spec_defaults(self) -> None:
+        spec = RunSpec.model_validate(
+            {
+                "recipe": RECIPE,
+                "task": "Do the thing",
+                "credentials": {},
+            }
+        )
+
+        assert spec.input_artifacts == []
+        assert spec.observability == []
+        assert spec.limits is None
+        assert spec.credentials.claude is None
+        assert spec.credentials.codex is None
+
+    def test_run_spec_is_frozen(self) -> None:
+        spec = RunSpec.model_validate({"recipe": RECIPE, "task": "task", "credentials": {}})
+        with pytest.raises(ValidationError):
+            spec.task = "renamed"  # type: ignore[misc]
+
+    def test_unknown_top_level_field_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            RunSpec.model_validate(
+                {
+                    "recipe": RECIPE,
+                    "task": "task",
+                    "credentials": {},
+                    "temperature": 0.7,
+                }
+            )
+
+
+class TestRunCredentials:
+    def test_claude_credentials(self) -> None:
+        creds = RunCredentials.model_validate({"claude": {"oauth_token": "tok"}})
+        assert creds.claude == ClaudeCredentials(oauth_token="tok")
+        assert creds.codex is None
+
+    def test_codex_credentials(self) -> None:
+        creds = RunCredentials.model_validate({"codex": {"auth_json": "{}"}})
+        assert creds.codex == CodexCredentials(auth_json="{}")
+        assert creds.claude is None
+
+    def test_both_credentials(self) -> None:
+        creds = RunCredentials.model_validate(
+            {
+                "claude": {"oauth_token": "tok"},
+                "codex": {"auth_json": "{}"},
+            }
+        )
+        assert creds.claude is not None
+        assert creds.codex is not None
+
+    def test_unknown_harness_key_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            RunCredentials.model_validate({"gemini": {"api_key": "x"}})
+
+    def test_empty_credentials_allowed(self) -> None:
+        creds = RunCredentials.model_validate({})
+        assert creds.claude is None
+        assert creds.codex is None
+
+    def test_claude_credentials_frozen_and_forbid_extra(self) -> None:
+        creds = ClaudeCredentials(oauth_token="tok")
+        with pytest.raises(ValidationError):
+            creds.oauth_token = "other"  # type: ignore[misc]
+        with pytest.raises(ValidationError):
+            ClaudeCredentials.model_validate({"oauth_token": "tok", "extra": "nope"})
+
+    def test_codex_credentials_missing_field_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            CodexCredentials.model_validate({})
+
+
+class TestObservabilityExporter:
+    def test_minimal_exporter(self) -> None:
+        exporter = ObservabilityExporter.model_validate({"name": "otel"})
+        assert exporter.name == "otel"
+        assert exporter.config == {}
+
+    def test_unknown_field_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ObservabilityExporter.model_validate({"name": "otel", "endpoint": "x"})
+
+
+class TestRunResult:
+    def test_requires_result_and_session_log(self) -> None:
+        with pytest.raises(ValidationError):
+            RunResult.model_validate({})
+
+    def test_valid_run_result(self) -> None:
+        result = RunResult.model_validate(
+            {
+                "result": {"success": True, "summary": "Fixed the test"},
+                "output_artifacts": ["/tmp/output.txt"],
+                "session_log": "session-log-contents",
+            }
+        )
+        assert result.result == RunOutcome(success=True, summary="Fixed the test")
+        assert result.output_artifacts == [Path("/tmp/output.txt")]
+        assert result.session_log == "session-log-contents"
+        assert result.observability is None
+
+    def test_run_result_is_frozen(self) -> None:
+        result = RunResult.model_validate(
+            {
+                "result": {"success": False, "summary": "failed"},
+                "session_log": "log",
+            }
+        )
+        with pytest.raises(ValidationError):
+            result.session_log = "other"  # type: ignore[misc]
+
+    def test_unknown_field_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            RunResult.model_validate(
+                {
+                    "result": {"success": True, "summary": "ok"},
+                    "session_log": "log",
+                    "extra": "nope",
+                }
+            )
+
+
+class TestRunEvents:
+    def test_tool_start_event(self) -> None:
+        event: RunEvent = ToolStartEvent.model_validate(
+            {"type": "tool_start", "tool_name": "bash", "tool_use_id": "t1"}
+        )
+        assert isinstance(event, ToolStartEvent)
+        assert event.tool_name == "bash"
+
+    def test_tool_end_event(self) -> None:
+        event: RunEvent = ToolEndEvent.model_validate(
+            {
+                "type": "tool_end",
+                "tool_name": "bash",
+                "tool_use_id": "t1",
+                "success": True,
+            }
+        )
+        assert isinstance(event, ToolEndEvent)
+        assert event.success is True
+
+    def test_token_usage_event(self) -> None:
+        event: RunEvent = TokenUsageEvent.model_validate(
+            {
+                "type": "token_usage",
+                "input_tokens": 100,
+                "output_tokens": 50,
+            }
+        )
+        assert isinstance(event, TokenUsageEvent)
+        assert event.input_tokens == 100
+
+    def test_session_end_event(self) -> None:
+        event: RunEvent = SessionEndEvent.model_validate({"type": "session_end", "success": True})
+        assert isinstance(event, SessionEndEvent)
+
+    def test_discriminated_union_dispatches_on_type(self) -> None:
+        envelope = RunEventEnvelope.model_validate(
+            {"event": {"type": "tool_start", "tool_name": "bash", "tool_use_id": "t1"}}
+        )
+        assert isinstance(envelope.event, ToolStartEvent)
+
+        envelope2 = RunEventEnvelope.model_validate(
+            {"event": {"type": "session_end", "success": False}}
+        )
+        assert isinstance(envelope2.event, SessionEndEvent)
+
+    def test_unknown_type_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            RunEventEnvelope.model_validate({"event": {"type": "bogus_event"}})
+
+    def test_event_variants_are_frozen_and_forbid_extra(self) -> None:
+        event = SessionEndEvent(type="session_end", success=True)
+        with pytest.raises(ValidationError):
+            event.success = False  # type: ignore[misc]
+        with pytest.raises(ValidationError):
+            SessionEndEvent.model_validate({"type": "session_end", "success": True, "extra": 1})


### PR DESCRIPTION
Plan 1b Task 2 (stacked on #237). `RunSpec` (recipe + task + input_artifacts + per-harness credentials + observability + limits) and `RunResult` (outcome + artifacts + session_log + observability), plus `RunCredentials` (`extra=forbid` rejects unknown harness keys; `CodexCredentials.auth_json` holds file contents not a path, avoiding host-path leakage) and a discriminated `RunEvent` union (ToolStart/ToolEnd/TokenUsage/SessionEnd) + `CancelMode`. Observability types are documented Plan 3 placeholders. 24 tests; mypy strict + ruff clean; full suite 400 pass. Tracks okrs-51p.3 / okrs-o78.