### PR TITLE
fix(itmux): stage only codex auth surface via allowlist (fixes codex startup)

### DIFF
--- a/providers/workspaces/interactive-tmux/driver-rs/src/auth.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/auth.rs
@@ -108,6 +108,33 @@ fn copy_file(src: &Path, dst: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Copy only the top-level regular files of `src` whose names are in
+/// `allow_names` into `dst`. Directories and any other entries are ignored.
+///
+/// This is the allowlist counterpart to `copy_tree`'s denylist: for agents
+/// whose home directory mixes a tiny auth/config surface with hundreds of
+/// megabytes of operational state (caches, session transcripts, sqlite
+/// journals), an allowlist is the only stable way to keep credential staging
+/// from crawling. New bloat directories can appear at any release without
+/// breaking the stage, because nothing outside `allow_names` is ever copied.
+fn copy_named_files(src: &Path, dst: &Path, allow_names: &[&str]) -> Result<()> {
+    if !src.exists() {
+        return Ok(());
+    }
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        if !allow_names.iter().any(|s| **s == *name.to_string_lossy()) {
+            continue;
+        }
+        if entry.file_type()?.is_file() {
+            fs::copy(entry.path(), dst.join(&name))?;
+        }
+    }
+    Ok(())
+}
+
 fn copy_tree(src: &Path, dst: &Path, skip_names: &[&str]) -> Result<()> {
     if !src.exists() {
         return Ok(());
@@ -239,6 +266,12 @@ pub fn prepare_claude(host_src: &Path, ctx: &AuthContext) -> Result<PreparedAuth
 // ---------------------------------------------------------------------------
 // Codex - EXP-02
 
+/// Top-level `~/.codex` entries that make up the codex auth/config surface.
+/// Everything else (session transcripts, sqlite journals, caches, plugin
+/// bundles, `.tmp/`) is operational bloat and must never be staged. Keep in
+/// sync with the Python driver's `_CodexAdapter` allowlist.
+const CODEX_AUTH_FILES: [&str; 4] = ["auth.json", "config.toml", "config.json", "AGENTS.md"];
+
 pub fn prepare_codex(host_src: &Path, ctx: &AuthContext) -> Result<PreparedAuth> {
     if !host_src.is_dir() {
         return Err(Error::new(
@@ -247,11 +280,20 @@ pub fn prepare_codex(host_src: &Path, ctx: &AuthContext) -> Result<PreparedAuth>
         ));
     }
     let dst_dir = ctx.throwaway_dir.join("codex.dir");
-    // Skip tmp/log/logs: codex races there during normal operation. The auth
-    // surface lives at `auth.json` / `config.toml` / `sessions/`. Also skip
-    // plugins/: a large plugin/dependency cache (node_modules), never auth,
-    // and staging it turns start_workspace into a multi-minute crawl.
-    copy_tree(host_src, &dst_dir, &["tmp", "log", "logs", "plugins"])?;
+    // Stage ONLY the codex auth/config surface via an allowlist. A modern
+    // `~/.codex` (codex-cli 0.139.0) mixes a few small credential/config files
+    // (`auth.json`, `config.toml`) with hundreds of megabytes of operational
+    // state under directories that vary by release: `.tmp/`, `sessions/`,
+    // `archived_sessions/`, `logs_2.sqlite*`, `computer-use/`, `plugins/`,
+    // `cache/`, etc. The old `{tmp, log, logs, plugins}` denylist missed all of
+    // those, turning start_workspace into a multi-minute, thousands-of-`docker
+    // exec` crawl that never completes (the `--startup-timeout` bound only
+    // covers the post-launch readiness wait, not credential staging). An
+    // allowlist is the only stable fix: it can't regress when codex adds new
+    // state directories. `auth.json` carries the credentials; `config.toml`
+    // pins the model/approval settings; `config.json`/`AGENTS.md` are copied
+    // when present so per-user config/instructions survive.
+    copy_named_files(host_src, &dst_dir, &CODEX_AUTH_FILES)?;
     Ok(PreparedAuth(vec![StagedPath {
         host: dst_dir,
         container: "/home/agent/.codex".to_string(),

--- a/providers/workspaces/interactive-tmux/driver-rs/src/auth.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/auth.rs
@@ -117,6 +117,12 @@ fn copy_file(src: &Path, dst: &Path) -> Result<()> {
 /// journals), an allowlist is the only stable way to keep credential staging
 /// from crawling. New bloat directories can appear at any release without
 /// breaking the stage, because nothing outside `allow_names` is ever copied.
+///
+/// The file-type decision follows symlinks (`fs::metadata`, not
+/// `DirEntry::file_type`, which stats the link itself): dotfile managers like
+/// stow/chezmoi routinely symlink `auth.json`/`config.toml` into `~/.codex`,
+/// and those must be staged as their target regular files. This also keeps
+/// parity with the Python driver, whose `Path.is_file()` follows symlinks.
 fn copy_named_files(src: &Path, dst: &Path, allow_names: &[&str]) -> Result<()> {
     if !src.exists() {
         return Ok(());
@@ -128,8 +134,11 @@ fn copy_named_files(src: &Path, dst: &Path, allow_names: &[&str]) -> Result<()> 
         if !allow_names.iter().any(|s| **s == *name.to_string_lossy()) {
             continue;
         }
-        if entry.file_type()?.is_file() {
-            fs::copy(entry.path(), dst.join(&name))?;
+        let path = entry.path();
+        // `fs::metadata` follows symlinks; a symlink-to-regular-file counts as
+        // a file and is copied by-value (`fs::copy` also follows the link).
+        if fs::metadata(&path).map(|m| m.is_file()).unwrap_or(false) {
+            fs::copy(&path, dst.join(&name))?;
         }
     }
     Ok(())

--- a/providers/workspaces/interactive-tmux/driver-rs/tests/auth_parity.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/tests/auth_parity.rs
@@ -161,17 +161,25 @@ fn gemini_patches_folder_trust_in_settings() {
 }
 
 #[test]
-fn codex_skips_tmp_log_and_plugins_subdirs() {
+fn codex_stages_only_the_auth_allowlist() {
+    // Codex staging is an ALLOWLIST: only the small auth/config files at the
+    // top of `~/.codex` are staged. Every operational directory (`.tmp/`,
+    // `sessions/`, `logs_2.sqlite*`, `computer-use/`, `plugins/`, ...) is left
+    // behind so start_workspace can't crawl hundreds of megabytes over
+    // per-file `docker exec` and hang forever.
     let host = tmp("codex-host");
-    fs::create_dir_all(host.join("tmp")).unwrap();
-    fs::create_dir_all(host.join("log")).unwrap();
-    fs::create_dir_all(host.join("plugins")).unwrap();
-    fs::create_dir_all(host.join("sessions")).unwrap();
-    fs::write(host.join("tmp").join("racy-argv.bin"), b"vanish").unwrap();
-    fs::write(host.join("log").join("verbose.log"), b"noisy").unwrap();
-    fs::write(host.join("plugins").join("node_modules_stub"), b"heavy").unwrap();
+    // Allowed auth/config surface.
     fs::write(host.join("auth.json"), b"{}").unwrap();
+    fs::write(host.join("config.toml"), b"model = \"x\"").unwrap();
+    // Non-auth bloat that MUST NOT be staged.
+    fs::create_dir_all(host.join(".tmp")).unwrap();
+    fs::create_dir_all(host.join("sessions")).unwrap();
+    fs::create_dir_all(host.join("plugins")).unwrap();
+    fs::create_dir_all(host.join("computer-use")).unwrap();
+    fs::write(host.join(".tmp").join("racy-argv.bin"), b"vanish").unwrap();
     fs::write(host.join("sessions").join("01.json"), b"{}").unwrap();
+    fs::write(host.join("plugins").join("node_modules_stub"), b"heavy").unwrap();
+    fs::write(host.join("logs_2.sqlite"), vec![0u8; 4096]).unwrap();
 
     let ctx = AuthContext {
         workdir: "/workspace".to_string(),
@@ -181,9 +189,25 @@ fn codex_skips_tmp_log_and_plugins_subdirs() {
     let mounts = prepare(Agent::Codex, &host, &ctx).unwrap();
     assert_eq!(mounts.len(), 1);
     let dst = &mounts[0].host;
-    assert!(dst.join("auth.json").is_file());
-    assert!(dst.join("sessions").join("01.json").is_file());
-    assert!(!dst.join("tmp").exists(), "tmp/ must be skipped");
-    assert!(!dst.join("log").exists(), "log/ must be skipped");
-    assert!(!dst.join("plugins").exists(), "plugins/ must be skipped");
+    // Auth surface staged.
+    assert!(dst.join("auth.json").is_file(), "auth.json must be staged");
+    assert!(
+        dst.join("config.toml").is_file(),
+        "config.toml must be staged"
+    );
+    // Everything else left behind.
+    assert!(!dst.join(".tmp").exists(), ".tmp/ must NOT be staged");
+    assert!(
+        !dst.join("sessions").exists(),
+        "sessions/ must NOT be staged"
+    );
+    assert!(!dst.join("plugins").exists(), "plugins/ must NOT be staged");
+    assert!(
+        !dst.join("computer-use").exists(),
+        "computer-use/ must NOT be staged"
+    );
+    assert!(
+        !dst.join("logs_2.sqlite").exists(),
+        "sqlite journals must NOT be staged"
+    );
 }

--- a/providers/workspaces/interactive-tmux/driver-rs/tests/auth_parity.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/tests/auth_parity.rs
@@ -168,9 +168,11 @@ fn codex_stages_only_the_auth_allowlist() {
     // behind so start_workspace can't crawl hundreds of megabytes over
     // per-file `docker exec` and hang forever.
     let host = tmp("codex-host");
-    // Allowed auth/config surface.
+    // Allowed auth/config surface (full declared allowlist).
     fs::write(host.join("auth.json"), b"{}").unwrap();
     fs::write(host.join("config.toml"), b"model = \"x\"").unwrap();
+    fs::write(host.join("config.json"), b"{}").unwrap();
+    fs::write(host.join("AGENTS.md"), b"# global instructions").unwrap();
     // Non-auth bloat that MUST NOT be staged.
     fs::create_dir_all(host.join(".tmp")).unwrap();
     fs::create_dir_all(host.join("sessions")).unwrap();
@@ -195,6 +197,11 @@ fn codex_stages_only_the_auth_allowlist() {
         dst.join("config.toml").is_file(),
         "config.toml must be staged"
     );
+    assert!(
+        dst.join("config.json").is_file(),
+        "config.json must be staged"
+    );
+    assert!(dst.join("AGENTS.md").is_file(), "AGENTS.md must be staged");
     // Everything else left behind.
     assert!(!dst.join(".tmp").exists(), ".tmp/ must NOT be staged");
     assert!(
@@ -209,5 +216,45 @@ fn codex_stages_only_the_auth_allowlist() {
     assert!(
         !dst.join("logs_2.sqlite").exists(),
         "sqlite journals must NOT be staged"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn codex_stages_symlinked_auth_files() {
+    // Dotfile managers (stow/chezmoi) symlink `auth.json`/`config.toml` into
+    // `~/.codex`. The allowlist decision must follow symlinks (parity with
+    // Python's `Path.is_file()`), or the exact files the fix exists to
+    // preserve get silently dropped.
+    use std::os::unix::fs::symlink;
+
+    let real = tmp("codex-real-store");
+    fs::write(real.join("auth.json"), b"{\"token\":\"real\"}").unwrap();
+    fs::write(real.join("config.toml"), b"model = \"y\"").unwrap();
+
+    let host = tmp("codex-symlink-host");
+    symlink(real.join("auth.json"), host.join("auth.json")).unwrap();
+    symlink(real.join("config.toml"), host.join("config.toml")).unwrap();
+
+    let ctx = AuthContext {
+        workdir: "/workspace".to_string(),
+        throwaway_dir: tmp("codex-symlink-throwaway"),
+        host_claude_dotjson: None,
+    };
+    let mounts = prepare(Agent::Codex, &host, &ctx).unwrap();
+    let dst = &mounts[0].host;
+    // Symlinked entries are staged as their target's regular-file contents.
+    assert!(
+        dst.join("auth.json").is_file(),
+        "symlinked auth.json must be staged"
+    );
+    assert!(
+        dst.join("config.toml").is_file(),
+        "symlinked config.toml must be staged"
+    );
+    assert_eq!(
+        fs::read(dst.join("auth.json")).unwrap(),
+        b"{\"token\":\"real\"}",
+        "staged copy must carry the symlink target's bytes"
     );
 }

--- a/providers/workspaces/interactive-tmux/driver-rs/tests/fixtures/codex/ready_fresh_launch.txt
+++ b/providers/workspaces/interactive-tmux/driver-rs/tests/fixtures/codex/ready_fresh_launch.txt
@@ -1,0 +1,37 @@
+agent@4c561bbe841c:/workspace$ codex --no-alt-screen
+> You are in /workspace
+
+  Do you trust the contents of this directory? Working with untrusted contents comes with higher risk of prompt injection. Trusting the directory allows project-local config, hooks, and exec policies
+  to load.
+
+› 1. Yes, continue
+  2. No, quit
+
+  Press enter to continue
+
+╭─────────────────────────────────────────────────╮
+│ ✨ Update available! 0.139.0 -> 0.142.5         │
+│ Run npm install -g @openai/codex to update.     │
+│                                                 │
+│ See full release notes:                         │
+│ https://github.com/openai/codex/releases/latest │
+╰─────────────────────────────────────────────────╯
+
+╭────────────────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.139.0)                     │
+│                                                │
+│ model:       gpt-5.5 medium   /model to change │
+│ directory:   /workspace                        │
+│ permissions: YOLO mode                         │
+╰────────────────────────────────────────────────╯
+
+  Tip: [tui.keymap] in ~/.codex/config.toml lets you rebind supported shortcuts.
+
+⚠ MCP client for `node_repl` failed to start: MCP startup failed: No such file or directory (os error 2)
+
+⚠ MCP startup incomplete (failed: node_repl)
+
+
+› Explain this codebase
+
+  gpt-5.5 medium · /workspace

--- a/providers/workspaces/interactive-tmux/driver-rs/tests/readiness.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/tests/readiness.rs
@@ -16,6 +16,10 @@ const CLAUDE_WELCOME: &str = include_str!("fixtures/claude/welcome_started.txt")
 const CODEX_READY: &str = include_str!("fixtures/codex/ready_post_turn.txt");
 const CODEX_WORKING: &str = include_str!("fixtures/codex/working.txt");
 const CODEX_IDLE_HINT: &str = include_str!("fixtures/codex/idle_hint_only.txt");
+/// Real `itmux start --agents codex` first-ready pane captured live from
+/// codex-cli 0.139.0 in the fat image (trust banner accepted, hooks modal
+/// dismissed, composer visible). Guards the actual start path predicate.
+const CODEX_FRESH_LAUNCH: &str = include_str!("fixtures/codex/ready_fresh_launch.txt");
 
 const GEMINI_READY: &str = include_str!("fixtures/gemini/ready_post_turn.txt");
 const GEMINI_THINKING: &str = include_str!("fixtures/gemini/thinking.txt");
@@ -89,6 +93,21 @@ fn codex_idle_with_hint_only_is_ready() {
 #[test]
 fn codex_empty_pane_is_not_ready() {
     assert!(!codex_is_ready(""));
+}
+
+#[test]
+fn codex_fresh_launch_pane_is_ready() {
+    // The real 0.139.0 first-ready pane after `itmux start --agents codex`:
+    // the composer shows `› Explain this codebase` and a `Tip:` line, and no
+    // `• Working` marker. Both the ready and started predicates must pass so
+    // start_workspace reports the codex agent ready (rc=0). Regression guard
+    // for the credential-staging fix that lets start_workspace reach this pane
+    // at all.
+    assert!(
+        codex_is_ready(CODEX_FRESH_LAUNCH),
+        "real 0.139.0 fresh-launch pane must satisfy codex_is_ready"
+    );
+    assert!(codex_is_started(CODEX_FRESH_LAUNCH));
 }
 
 #[test]

--- a/providers/workspaces/interactive-tmux/driver/interactive_tmux.py
+++ b/providers/workspaces/interactive-tmux/driver/interactive_tmux.py
@@ -1165,29 +1165,23 @@ class _CodexAdapter:
             raise FileNotFoundError(f"codex auth dir not found: {host_src}")
         dst_dir = ctx.host_throwaway_dir / "codex.dir"
         dst_dir.mkdir(parents=True, exist_ok=True)
-        # Copy the .codex/ tree but skip the live tmp/ subdir - codex races
-        # there (creates and deletes argv files during normal operation), so
-        # copytree against it sees vanished files. The auth lives in
-        # auth.json / config.toml / sessions/ at the top level. `plugins/` is
-        # a large plugin/dependency cache (node_modules), never auth, and
-        # staging it turns start_workspace into a multi-minute, thousands-of-
-        # exec crawl - skip it (node_modules/.git anywhere are skipped by the
-        # copytree ignore filter as defense in depth).
-        skip = {"tmp", "log", "logs", "plugins"}
-        for item in host_src.iterdir():
-            if item.name in skip:
-                continue
-            target = dst_dir / item.name
-            if item.is_dir():
-                shutil.copytree(
-                    item,
-                    target,
-                    dirs_exist_ok=True,
-                    ignore_dangling_symlinks=True,
-                    ignore=_ignore_uncopyable,
-                )
-            else:
-                shutil.copy2(item, target)
+        # Stage ONLY the codex auth/config surface via an allowlist. A modern
+        # `~/.codex` (codex-cli 0.139.0) mixes a few small credential/config
+        # files (`auth.json`, `config.toml`) with hundreds of megabytes of
+        # operational state under directories that vary by release: `.tmp/`,
+        # `sessions/`, `archived_sessions/`, `logs_2.sqlite*`, `computer-use/`,
+        # `plugins/`, `cache/`, etc. The old `{tmp, log, logs, plugins}`
+        # denylist missed all of those, turning start_workspace into a
+        # multi-minute, thousands-of-`docker exec` crawl that never completes
+        # (the startup-timeout bound covers only the post-launch readiness
+        # wait, not credential staging). An allowlist is the only stable fix:
+        # it can't regress when codex adds new state directories. Keep in sync
+        # with the Rust driver's `CODEX_AUTH_FILES`.
+        allow = ("auth.json", "config.toml", "config.json", "AGENTS.md")
+        for name in allow:
+            item = host_src / name
+            if item.is_file():
+                shutil.copy2(item, dst_dir / name)
         _chown_recursive(dst_dir, 1000, 1000)
         return {"codex_dir": (dst_dir, "/home/agent/.codex")}
 


### PR DESCRIPTION
**Plan 2 / okrs-51p.7.** Root-causes and fixes why codex never reached ready under itmux (claude did in ~634ms).

**Root cause (not a readiness-heuristic bug):** codex 0.139.0's `~/.codex` is ~785MB (`.tmp/` 250M, `sessions/` 81M, `logs_2.sqlite` 100M, `computer-use/` 53M...). The DooD credential transfer copies directories file-by-file over `docker exec` base64, so codex staging was a thousands-of-exec multi-minute crawl that never completed - itmux was stuck in `stage_into_container` before ever launching tmux. The readiness predicate + launch sequence were correct.

**Fix:** replace the fragile denylist (`{tmp,log,logs,plugins}`) with an **allowlist** - stage only `auth.json`/`config.toml`/`config.json`/`AGENTS.md`, skip all dirs. An allowlist can't regress when codex adds new state dirs. Applied to both Rust (`auth.rs`) and the Python driver (`_CodexAdapter`) for parity. **Supersedes the denylist `plugins` addition from #235.**

**Live-validated:** `itmux start --agents codex` -> rc=0, StartReport `ready:true, duration_ms:75`. New fixture-based readiness test + rewritten auth-allowlist test. cargo test/clippy/fmt green.

Note: the allowlist intentionally drops `sessions/` (past transcripts, not auth) - a fresh workspace starts clean. Stacked on the Plan 1a stack (#236).