### PR TITLE
feat(itmux): production parity + claude/codex support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,43 @@
+name: Rust
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Cancel in-progress runs on same PR/branch
+concurrency:
+  group: rust-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: providers/workspaces/interactive-tmux/driver-rs
+
+jobs:
+  itmux:
+    name: itmux (fmt, clippy, test)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.3
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy, rustfmt
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2.9.1
+        with:
+          workspaces: "providers/workspaces/interactive-tmux/driver-rs -> target"
+
+      - name: Check formatting
+        run: cargo fmt -- --check
+
+      - name: Lint
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Run tests
+        run: cargo test

--- a/justfile
+++ b/justfile
@@ -115,20 +115,51 @@ python-test-integration:
     @echo '{{ GREEN }}✓ Python integration tests passed{{ NORMAL }}'
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# RUST (itmux driver)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Run itmux Rust tests
+[group('rust')]
+rust-test:
+    @echo '{{ YELLOW }}Running itmux Rust tests...{{ NORMAL }}'
+    cd providers/workspaces/interactive-tmux/driver-rs && cargo test
+    @echo '{{ GREEN }}✓ itmux Rust tests passed{{ NORMAL }}'
+
+# Lint itmux Rust code
+[group('rust')]
+rust-lint:
+    @echo '{{ YELLOW }}Linting itmux Rust code...{{ NORMAL }}'
+    cd providers/workspaces/interactive-tmux/driver-rs && cargo clippy --all-targets -- -D warnings
+    @echo '{{ GREEN }}✓ itmux Rust linting complete{{ NORMAL }}'
+
+# Check itmux Rust formatting
+[group('rust')]
+rust-fmt-check:
+    @echo '{{ YELLOW }}Checking itmux Rust formatting...{{ NORMAL }}'
+    cd providers/workspaces/interactive-tmux/driver-rs && cargo fmt -- --check
+
+# Format itmux Rust code
+[group('rust')]
+rust-fmt:
+    @echo '{{ YELLOW }}Formatting itmux Rust code...{{ NORMAL }}'
+    cd providers/workspaces/interactive-tmux/driver-rs && cargo fmt
+    @echo '{{ GREEN }}✓ itmux Rust formatting complete{{ NORMAL }}'
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # COMBINED OPERATIONS
 # ═══════════════════════════════════════════════════════════════════════════════
 
 # Format all code
 [group('all')]
-fmt: python-fmt
+fmt: python-fmt rust-fmt
 
 # Check all formatting
 [group('all')]
-fmt-check: python-fmt-check
+fmt-check: python-fmt-check rust-fmt-check
 
 # Lint all code
 [group('all')]
-lint: python-lint
+lint: python-lint rust-lint
 
 # Auto-fix linting issues
 [group('all')]
@@ -136,7 +167,7 @@ lint-fix: python-lint-fix
 
 # Run all tests
 [group('all')]
-test: python-test
+test: python-test rust-test
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # QUALITY ASSURANCE

--- a/providers/workspaces/interactive-tmux/driver-rs/src/auth.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/auth.rs
@@ -32,6 +32,7 @@ use std::fs;
 use std::io::{Error, ErrorKind, Result};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 use serde_json::{json, Map, Value};
 
@@ -140,32 +141,6 @@ fn copy_named_files(src: &Path, dst: &Path, allow_names: &[&str]) -> Result<()> 
         if fs::metadata(&path).map(|m| m.is_file()).unwrap_or(false) {
             fs::copy(&path, dst.join(&name))?;
         }
-    }
-    Ok(())
-}
-
-fn copy_tree(src: &Path, dst: &Path, skip_names: &[&str]) -> Result<()> {
-    if !src.exists() {
-        return Ok(());
-    }
-    fs::create_dir_all(dst)?;
-    for entry in fs::read_dir(src)? {
-        let entry = entry?;
-        let name = entry.file_name();
-        if skip_names.iter().any(|s| **s == *name.to_string_lossy()) {
-            continue;
-        }
-        let kind = entry.file_type()?;
-        let src_path = entry.path();
-        let dst_path = dst.join(&name);
-        if kind.is_dir() {
-            copy_tree(&src_path, &dst_path, &[])?;
-        } else if kind.is_file() {
-            fs::copy(&src_path, &dst_path)?;
-        }
-        // Ignore unsupported entries (symlinks to vanished files, sockets):
-        // the Python adapter does the same - the auth surface is regular
-        // files in practice.
     }
     Ok(())
 }
@@ -312,6 +287,22 @@ pub fn prepare_codex(host_src: &Path, ctx: &AuthContext) -> Result<PreparedAuth>
 // ---------------------------------------------------------------------------
 // Gemini - EXP-03
 
+/// Gemini's durable authentication/configuration surface. Session recordings,
+/// temporary files and caches are recreated by the CLI and must not turn
+/// workspace startup into a per-file Docker transfer crawl.
+///
+/// `oauth_creds.json` holds OAuth refresh credentials; `settings.json`
+/// selects the auth mode and is patched below; `google_accounts.json` and
+/// `projects.json` preserve the selected account/project for Code Assist;
+/// `user_id` is Gemini's stable local installation identity.
+const GEMINI_AUTH_FILES: [&str; 5] = [
+    "oauth_creds.json",
+    "settings.json",
+    "google_accounts.json",
+    "projects.json",
+    "user_id",
+];
+
 pub fn prepare_gemini(host_src: &Path, ctx: &AuthContext) -> Result<PreparedAuth> {
     if !host_src.is_dir() {
         return Err(Error::new(
@@ -320,7 +311,7 @@ pub fn prepare_gemini(host_src: &Path, ctx: &AuthContext) -> Result<PreparedAuth
         ));
     }
     let dst_dir = ctx.throwaway_dir.join("gemini.dir");
-    copy_tree(host_src, &dst_dir, &[])?;
+    copy_named_files(host_src, &dst_dir, &GEMINI_AUTH_FILES)?;
     // Patch settings.json with security.folderTrust.enabled = false (EXP-03).
     let settings_path = dst_dir.join("settings.json");
     let mut settings: Value = if settings_path.is_file() {
@@ -536,14 +527,14 @@ pub fn plan_for_staged_path(staged: &StagedPath) -> Result<Vec<ExecStep>> {
     Ok(steps)
 }
 
-fn run_exec_step(container: &str, step: &ExecStep) -> Result<()> {
+fn run_exec_step(container: &str, step: &ExecStep, timeout: Duration) -> Result<()> {
     let argv_refs: Vec<&str> = step.argv.iter().map(String::as_str).collect();
     match &step.stdin {
         Some(bytes) => {
-            tmux::docker_exec_with_stdin(container, &argv_refs, bytes)?;
+            tmux::docker_exec_with_stdin_timeout(container, &argv_refs, bytes, timeout)?;
         }
         None => {
-            tmux::docker_exec(container, &argv_refs)?;
+            tmux::docker_exec_timeout(container, &argv_refs, timeout)?;
         }
     }
     Ok(())
@@ -557,9 +548,27 @@ fn run_exec_step(container: &str, step: &ExecStep) -> Result<()> {
 /// This is the "PUSHES credential files ... then secures them in-container"
 /// half of the docker-out-of-docker fix (PY:1850-1869).
 pub fn stage_into_container(container: &str, prepared: &PreparedAuth) -> Result<()> {
+    // Per-command bounds prevent a wedged Docker operation; this aggregate
+    // deadline prevents a large (or accidentally unbounded) credential tree
+    // from converting startup into an unbounded sequence of otherwise-valid
+    // transfers. Each command receives only the remaining budget.
+    const STAGING_TIMEOUT: Duration = Duration::from_secs(60);
+    let deadline = Instant::now() + STAGING_TIMEOUT;
     for staged in prepared.iter() {
         for step in plan_for_staged_path(staged)? {
-            run_exec_step(container, &step)?;
+            let remaining = deadline
+                .checked_duration_since(Instant::now())
+                .ok_or_else(|| {
+                    Error::new(
+                        ErrorKind::TimedOut,
+                        "credential staging exceeded the 60s total deadline",
+                    )
+                })?;
+            run_exec_step(
+                container,
+                &step,
+                remaining.min(Duration::from_secs_f64(tmux::DEFAULT_EXEC_TIMEOUT_S)),
+            )?;
         }
     }
     Ok(())

--- a/providers/workspaces/interactive-tmux/driver-rs/src/auth.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/auth.rs
@@ -513,3 +513,37 @@ pub fn stage_into_container(container: &str, prepared: &PreparedAuth) -> Result<
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod base64_tests {
+    use super::base64_encode;
+
+    // RFC 4648 section 10 test vectors, plus high-bit bytes to guard the
+    // std-only encoder against sign/padding regressions (the whole credential
+    // path depends on this being byte-exact; the container-side `base64 -d`
+    // only runs under real docker).
+    #[test]
+    fn rfc4648_and_high_bit_vectors() {
+        let cases: &[(&[u8], &[u8])] = &[
+            (b"", b""),
+            (b"f", b"Zg=="),
+            (b"fo", b"Zm8="),
+            (b"foo", b"Zm9v"),
+            (b"foob", b"Zm9vYg=="),
+            (b"fooba", b"Zm9vYmE="),
+            (b"foobar", b"Zm9vYmFy"),
+            (b"\x00", b"AA=="),
+            (b"\xff", b"/w=="),
+            (b"\xff\xff", b"//8="),
+            (b"\xff\xff\xff", b"////"),
+            (b"\x00\x10\x83", b"ABCD"),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(
+                base64_encode(input),
+                expected.to_vec(),
+                "base64_encode({input:?}) mismatch"
+            );
+        }
+    }
+}

--- a/providers/workspaces/interactive-tmux/driver-rs/src/auth.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/auth.rs
@@ -112,8 +112,7 @@ fn copy_file(src: &Path, dst: &Path) -> Result<()> {
 /// Copy only the top-level regular files of `src` whose names are in
 /// `allow_names` into `dst`. Directories and any other entries are ignored.
 ///
-/// This is the allowlist counterpart to `copy_tree`'s denylist: for agents
-/// whose home directory mixes a tiny auth/config surface with hundreds of
+/// For agents whose home directory mixes a tiny auth/config surface with hundreds of
 /// megabytes of operational state (caches, session transcripts, sqlite
 /// journals), an allowlist is the only stable way to keep credential staging
 /// from crawling. New bloat directories can appear at any release without
@@ -540,6 +539,18 @@ fn run_exec_step(container: &str, step: &ExecStep, timeout: Duration) -> Result<
     Ok(())
 }
 
+fn staging_step_timeout(deadline: Instant, now: Instant) -> Result<Duration> {
+    deadline
+        .checked_duration_since(now)
+        .ok_or_else(|| {
+            Error::new(
+                ErrorKind::TimedOut,
+                "credential staging exceeded the 60s total deadline",
+            )
+        })
+        .map(|remaining| remaining.min(Duration::from_secs_f64(tmux::DEFAULT_EXEC_TIMEOUT_S)))
+}
+
 /// Push every staged path in `prepared` into `container`'s filesystem over
 /// `docker exec` and lock down ownership/permissions in-container.
 ///
@@ -556,19 +567,8 @@ pub fn stage_into_container(container: &str, prepared: &PreparedAuth) -> Result<
     let deadline = Instant::now() + STAGING_TIMEOUT;
     for staged in prepared.iter() {
         for step in plan_for_staged_path(staged)? {
-            let remaining = deadline
-                .checked_duration_since(Instant::now())
-                .ok_or_else(|| {
-                    Error::new(
-                        ErrorKind::TimedOut,
-                        "credential staging exceeded the 60s total deadline",
-                    )
-                })?;
-            run_exec_step(
-                container,
-                &step,
-                remaining.min(Duration::from_secs_f64(tmux::DEFAULT_EXEC_TIMEOUT_S)),
-            )?;
+            let timeout = staging_step_timeout(deadline, Instant::now())?;
+            run_exec_step(container, &step, timeout)?;
         }
     }
     Ok(())
@@ -576,7 +576,9 @@ pub fn stage_into_container(container: &str, prepared: &PreparedAuth) -> Result<
 
 #[cfg(test)]
 mod base64_tests {
-    use super::base64_encode;
+    use super::{base64_encode, staging_step_timeout};
+    use std::io::ErrorKind;
+    use std::time::{Duration, Instant};
 
     // RFC 4648 section 10 test vectors, plus high-bit bytes to guard the
     // std-only encoder against sign/padding regressions (the whole credential
@@ -605,5 +607,16 @@ mod base64_tests {
                 "base64_encode({input:?}) mismatch"
             );
         }
+    }
+
+    #[test]
+    fn staging_timeout_caps_each_step_and_rejects_an_expired_deadline() {
+        let start = Instant::now();
+        assert_eq!(
+            staging_step_timeout(start + Duration::from_secs(60), start).unwrap(),
+            Duration::from_secs(15)
+        );
+        let err = staging_step_timeout(start, start + Duration::from_nanos(1)).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::TimedOut);
     }
 }

--- a/providers/workspaces/interactive-tmux/driver-rs/src/auth.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/auth.rs
@@ -108,6 +108,33 @@ fn copy_file(src: &Path, dst: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Copy only the top-level regular files of `src` whose names are in
+/// `allow_names` into `dst`. Directories and any other entries are ignored.
+///
+/// This is the allowlist counterpart to `copy_tree`'s denylist: for agents
+/// whose home directory mixes a tiny auth/config surface with hundreds of
+/// megabytes of operational state (caches, session transcripts, sqlite
+/// journals), an allowlist is the only stable way to keep credential staging
+/// from crawling. New bloat directories can appear at any release without
+/// breaking the stage, because nothing outside `allow_names` is ever copied.
+fn copy_named_files(src: &Path, dst: &Path, allow_names: &[&str]) -> Result<()> {
+    if !src.exists() {
+        return Ok(());
+    }
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        if !allow_names.iter().any(|s| **s == *name.to_string_lossy()) {
+            continue;
+        }
+        if entry.file_type()?.is_file() {
+            fs::copy(entry.path(), dst.join(&name))?;
+        }
+    }
+    Ok(())
+}
+
 fn copy_tree(src: &Path, dst: &Path, skip_names: &[&str]) -> Result<()> {
     if !src.exists() {
         return Ok(());
@@ -239,6 +266,12 @@ pub fn prepare_claude(host_src: &Path, ctx: &AuthContext) -> Result<PreparedAuth
 // ---------------------------------------------------------------------------
 // Codex - EXP-02
 
+/// Top-level `~/.codex` entries that make up the codex auth/config surface.
+/// Everything else (session transcripts, sqlite journals, caches, plugin
+/// bundles, `.tmp/`) is operational bloat and must never be staged. Keep in
+/// sync with the Python driver's `_CodexAdapter` allowlist.
+const CODEX_AUTH_FILES: [&str; 4] = ["auth.json", "config.toml", "config.json", "AGENTS.md"];
+
 pub fn prepare_codex(host_src: &Path, ctx: &AuthContext) -> Result<PreparedAuth> {
     if !host_src.is_dir() {
         return Err(Error::new(
@@ -247,11 +280,20 @@ pub fn prepare_codex(host_src: &Path, ctx: &AuthContext) -> Result<PreparedAuth>
         ));
     }
     let dst_dir = ctx.throwaway_dir.join("codex.dir");
-    // Skip tmp/log/logs: codex races there during normal operation. The auth
-    // surface lives at `auth.json` / `config.toml` / `sessions/`. Also skip
-    // plugins/: a large plugin/dependency cache (node_modules), never auth,
-    // and staging it turns start_workspace into a multi-minute crawl.
-    copy_tree(host_src, &dst_dir, &["tmp", "log", "logs", "plugins"])?;
+    // Stage ONLY the codex auth/config surface via an allowlist. A modern
+    // `~/.codex` (codex-cli 0.139.0) mixes a few small credential/config files
+    // (`auth.json`, `config.toml`) with hundreds of megabytes of operational
+    // state under directories that vary by release: `.tmp/`, `sessions/`,
+    // `archived_sessions/`, `logs_2.sqlite*`, `computer-use/`, `plugins/`,
+    // `cache/`, etc. The old `{tmp, log, logs, plugins}` denylist missed all of
+    // those, turning start_workspace into a multi-minute, thousands-of-`docker
+    // exec` crawl that never completes (the `--startup-timeout` bound only
+    // covers the post-launch readiness wait, not credential staging). An
+    // allowlist is the only stable fix: it can't regress when codex adds new
+    // state directories. `auth.json` carries the credentials; `config.toml`
+    // pins the model/approval settings; `config.json`/`AGENTS.md` are copied
+    // when present so per-user config/instructions survive.
+    copy_named_files(host_src, &dst_dir, &CODEX_AUTH_FILES)?;
     Ok(PreparedAuth(vec![StagedPath {
         host: dst_dir,
         container: "/home/agent/.codex".to_string(),

--- a/providers/workspaces/interactive-tmux/driver-rs/src/auth.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/auth.rs
@@ -1,13 +1,32 @@
-//! Per-agent host-auth mount preparation.
+//! Per-agent credential staging and in-container transfer.
 //!
 //! Each adapter copies (never moves) the relevant host directory under a
 //! per-workspace throwaway dir (`/tmp/interactive-tmux-<name>-<random>/`)
-//! so the container can bind-mount fresh credential bytes without ever
+//! so the container can receive fresh credential bytes without ever
 //! mutating the operator's live `~/.claude`, `~/.codex`, `~/.gemini`.
 //!
 //! Synthesised files (claude's `~/.claude.json`, gemini's `settings.json`
 //! patch) follow the Python driver's policy bit-for-bit so the two
-//! implementations produce interchangeable mounts.
+//! implementations produce interchangeable payloads.
+//!
+//! # Delivery: `docker exec` transfer, not `-v` bind mounts
+//!
+//! Syntropic137 runs this driver INSIDE a container (docker-out-of-docker).
+//! A `docker run -v host:container` bind mount is resolved by the *outer*
+//! docker daemon against its own filesystem - it cannot see a staging dir
+//! that only exists in this driver's own mount namespace. So instead of
+//! bind-mounting, the container is started bare (`docker run ... sleep
+//! infinity`, see `workspace::Workspace::start`) and credential bytes are
+//! pushed into the already-running container over `docker exec` stdin:
+//! files via base64, directories file-by-file (mirrors the Python driver's
+//! `os.walk` transfer at PY:1540-1563 exactly, rather than a `tar` stream,
+//! for byte-for-byte parity with the source of truth). See
+//! `_write_bytes_to_container` / `_transfer_path_to_container` /
+//! `_secure_container_path` in `driver/interactive_tmux.py` (PY:1493-1583).
+//!
+//! Credentials never appear in `docker exec` argv - only ever in stdin
+//! (PY:1506-1517). `argv` is world-readable via `ps` / `/proc/<pid>/cmdline`
+//! for the lifetime of the exec; stdin is not.
 
 use std::fs;
 use std::io::{Error, ErrorKind, Result};
@@ -17,17 +36,47 @@ use std::path::{Path, PathBuf};
 use serde_json::{json, Map, Value};
 
 use crate::adapter::Agent;
+use crate::tmux;
 
-/// One `-v host:container` pair to hand to `docker run`.
+/// One credential file or directory staged locally, awaiting transfer into
+/// the container's filesystem at `container` via `stage_into_container`.
+///
+/// Replaces the old `-v host:container` bind-mount shape (docker-out-of-
+/// docker fix, see module docs).
 #[derive(Debug, Clone)]
-pub struct Mount {
+pub struct StagedPath {
     pub host: PathBuf,
     pub container: String,
 }
 
-impl Mount {
-    pub fn as_docker_arg(&self) -> String {
-        format!("{}:{}", self.host.display(), self.container)
+/// All per-agent staged credential paths for one workspace, ready to be
+/// pushed into the running container.
+///
+/// Derefs to `Vec<StagedPath>` so callers can use slice/iterator methods
+/// (`len()`, `iter()`, indexing) directly.
+#[derive(Debug, Clone, Default)]
+pub struct PreparedAuth(pub Vec<StagedPath>);
+
+impl PreparedAuth {
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn extend(&mut self, other: PreparedAuth) {
+        self.0.extend(other.0);
+    }
+}
+
+impl std::ops::Deref for PreparedAuth {
+    type Target = Vec<StagedPath>;
+    fn deref(&self) -> &Vec<StagedPath> {
+        &self.0
+    }
+}
+
+impl FromIterator<StagedPath> for PreparedAuth {
+    fn from_iter<T: IntoIterator<Item = StagedPath>>(iter: T) -> Self {
+        Self(iter.into_iter().collect())
     }
 }
 
@@ -38,13 +87,15 @@ pub struct AuthContext {
     /// Explicit override for the operator's `~/.claude.json` source. `None`
     /// falls back to `host_src.parent() / .claude.json`. Set by callers that
     /// run from inside another container where the host's dotjson is mounted
-    /// at an unrelated path — see `StartOptions::host_claude_dotjson` and
+    /// at an unrelated path - see `StartOptions::host_claude_dotjson` and
     /// the DooD discussion in `_default_claude_dotjson_from_env` (Python).
     pub host_claude_dotjson: Option<PathBuf>,
 }
 
-/// Best-effort chmod (non-fatal — docker will run as the requested uid
-/// inside the container regardless).
+/// Best-effort chmod on the LOCAL staging copy (defense in depth only - the
+/// bytes are re-secured again in-container by `secure_path_plan` once
+/// transferred, which is the guarantee that actually matters since the
+/// staging dir is transient and never mounted into anything).
 fn chmod_file(path: &Path, mode: u32) {
     let _ = fs::set_permissions(path, fs::Permissions::from_mode(mode));
 }
@@ -77,14 +128,14 @@ fn copy_tree(src: &Path, dst: &Path, skip_names: &[&str]) -> Result<()> {
             fs::copy(&src_path, &dst_path)?;
         }
         // Ignore unsupported entries (symlinks to vanished files, sockets):
-        // the Python adapter does the same — the auth surface is regular
+        // the Python adapter does the same - the auth surface is regular
         // files in practice.
     }
     Ok(())
 }
 
 // ---------------------------------------------------------------------------
-// Claude — EXP-01 + EXP-05a
+// Claude - EXP-01 + EXP-05a
 
 /// Build the synthetic `~/.claude.json` (mirrors Python
 /// `_build_seeded_claude_dotjson`): copies `oauthAccount` through, forces
@@ -131,7 +182,7 @@ fn build_seeded_claude_dotjson(host_dotjson: &Path, workdir: &str) -> Value {
     Value::Object(seeded)
 }
 
-pub fn prepare_claude(host_src: &Path, ctx: &AuthContext) -> Result<Vec<Mount>> {
+pub fn prepare_claude(host_src: &Path, ctx: &AuthContext) -> Result<PreparedAuth> {
     if !host_src.is_dir() {
         return Err(Error::new(
             ErrorKind::NotFound,
@@ -149,14 +200,14 @@ pub fn prepare_claude(host_src: &Path, ctx: &AuthContext) -> Result<Vec<Mount>> 
         ));
     }
 
-    // Throwaway ~/.claude/ — copy only .credentials.json (no session history).
+    // Throwaway ~/.claude/ - copy only .credentials.json (no session history).
     let dst_dir = ctx.throwaway_dir.join("claude.dir");
     fs::create_dir_all(&dst_dir)?;
     let dst_creds = dst_dir.join(".credentials.json");
     copy_file(&creds, &dst_creds)?;
     chmod_file(&dst_creds, 0o600);
 
-    // Throwaway ~/.claude.json — synthesised regardless of host presence.
+    // Throwaway ~/.claude.json - synthesised regardless of host presence.
     // Resolution order (caller > sibling > nothing): if the caller passed
     // `host_claude_dotjson` (via `StartOptions` or the `ITMUX_CLAUDE_JSON`
     // env var), use it directly. Otherwise fall back to the sibling-of-
@@ -173,22 +224,22 @@ pub fn prepare_claude(host_src: &Path, ctx: &AuthContext) -> Result<Vec<Mount>> 
     fs::write(&dotjson_dst, serde_json::to_vec_pretty(&seeded)?)?;
     chmod_file(&dotjson_dst, 0o600);
 
-    Ok(vec![
-        Mount {
+    Ok(PreparedAuth(vec![
+        StagedPath {
             host: dst_dir,
             container: "/home/agent/.claude".to_string(),
         },
-        Mount {
+        StagedPath {
             host: dotjson_dst,
             container: "/home/agent/.claude.json".to_string(),
         },
-    ])
+    ]))
 }
 
 // ---------------------------------------------------------------------------
-// Codex — EXP-02
+// Codex - EXP-02
 
-pub fn prepare_codex(host_src: &Path, ctx: &AuthContext) -> Result<Vec<Mount>> {
+pub fn prepare_codex(host_src: &Path, ctx: &AuthContext) -> Result<PreparedAuth> {
     if !host_src.is_dir() {
         return Err(Error::new(
             ErrorKind::NotFound,
@@ -199,16 +250,16 @@ pub fn prepare_codex(host_src: &Path, ctx: &AuthContext) -> Result<Vec<Mount>> {
     // Skip tmp/log/logs: codex races there during normal operation. The auth
     // surface lives at `auth.json` / `config.toml` / `sessions/`.
     copy_tree(host_src, &dst_dir, &["tmp", "log", "logs"])?;
-    Ok(vec![Mount {
+    Ok(PreparedAuth(vec![StagedPath {
         host: dst_dir,
         container: "/home/agent/.codex".to_string(),
-    }])
+    }]))
 }
 
 // ---------------------------------------------------------------------------
-// Gemini — EXP-03
+// Gemini - EXP-03
 
-pub fn prepare_gemini(host_src: &Path, ctx: &AuthContext) -> Result<Vec<Mount>> {
+pub fn prepare_gemini(host_src: &Path, ctx: &AuthContext) -> Result<PreparedAuth> {
     if !host_src.is_dir() {
         return Err(Error::new(
             ErrorKind::NotFound,
@@ -245,19 +296,218 @@ pub fn prepare_gemini(host_src: &Path, ctx: &AuthContext) -> Result<Vec<Mount>> 
     folder_trust_obj.insert("enabled".to_string(), Value::Bool(false));
     fs::write(&settings_path, serde_json::to_vec_pretty(&settings)?)?;
 
-    Ok(vec![Mount {
+    Ok(PreparedAuth(vec![StagedPath {
         host: dst_dir,
         container: "/home/agent/.gemini".to_string(),
-    }])
+    }]))
 }
 
 // ---------------------------------------------------------------------------
 // Dispatch
 
-pub fn prepare(agent: Agent, host_src: &Path, ctx: &AuthContext) -> Result<Vec<Mount>> {
+pub fn prepare(agent: Agent, host_src: &Path, ctx: &AuthContext) -> Result<PreparedAuth> {
     match agent {
         Agent::Claude => prepare_claude(host_src, ctx),
         Agent::Codex => prepare_codex(host_src, ctx),
         Agent::Gemini => prepare_gemini(host_src, ctx),
     }
+}
+
+// ---------------------------------------------------------------------------
+// Transfer plan (pure, testable without a docker daemon) + execution.
+
+/// One step of a credential transfer/secure plan: a `docker exec <container>
+/// <argv...>` invocation, optionally fed `stdin` bytes.
+///
+/// Built as plain data (rather than shelling out directly) so the plan can
+/// be asserted on in tests without a running docker daemon - see
+/// `tests/cred_transfer.rs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecStep {
+    pub argv: Vec<String>,
+    pub stdin: Option<Vec<u8>>,
+}
+
+/// POSIX `dirname`, matching Python's `posixpath.dirname` for the ASCII
+/// forward-slash paths this driver deals with exclusively (in-container
+/// Linux paths).
+fn posix_dirname(path: &str) -> String {
+    match path.rfind('/') {
+        Some(0) => "/".to_string(),
+        Some(idx) => path[..idx].to_string(),
+        None => String::new(),
+    }
+}
+
+/// Shell-quote a single argument, matching Python's `shlex.quote`: safe
+/// (alnum + `-_./:`) strings pass through unquoted; anything else is
+/// wrapped in single quotes with embedded quotes escaped as `'\''`.
+fn shell_quote(s: &str) -> String {
+    if !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || "-_./:".contains(c))
+    {
+        return s.to_string();
+    }
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// Minimal std-only base64 encoder (standard alphabet, `=` padding)  -
+/// avoids pulling in a dependency for the one encode call this crate needs
+/// (decoding happens in-container via the coreutils `base64 -d`).
+fn base64_encode(data: &[u8]) -> Vec<u8> {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = Vec::with_capacity(data.len().div_ceil(3) * 4);
+    for chunk in data.chunks(3) {
+        let b0 = chunk[0];
+        let b1 = chunk.get(1).copied();
+        let b2 = chunk.get(2).copied();
+        out.push(ALPHABET[(b0 >> 2) as usize]);
+        out.push(ALPHABET[(((b0 & 0x03) << 4) | (b1.unwrap_or(0) >> 4)) as usize]);
+        if let Some(b1) = b1 {
+            out.push(ALPHABET[(((b1 & 0x0F) << 2) | (b2.unwrap_or(0) >> 6)) as usize]);
+        } else {
+            out.push(b'=');
+        }
+        if let Some(b2) = b2 {
+            out.push(ALPHABET[(b2 & 0x3F) as usize]);
+        } else {
+            out.push(b'=');
+        }
+    }
+    out
+}
+
+/// Mirrors Python `_write_bytes_to_container`: `mkdir -p` the destination's
+/// parent (if non-empty), truncate/create the destination, then push the
+/// payload as base64 over stdin to an in-container `base64 -d`. Credentials
+/// never appear in argv (PY:1506-1517) - only inside `ExecStep::stdin`.
+pub fn write_bytes_plan(container_path: &str, data: &[u8]) -> Vec<ExecStep> {
+    let mut steps = Vec::new();
+    let parent = posix_dirname(container_path);
+    if !parent.is_empty() {
+        steps.push(ExecStep {
+            argv: vec!["mkdir".to_string(), "-p".to_string(), parent],
+            stdin: None,
+        });
+    }
+    let quoted = shell_quote(container_path);
+    steps.push(ExecStep {
+        argv: vec!["sh".to_string(), "-c".to_string(), format!("> {quoted}")],
+        stdin: None,
+    });
+    steps.push(ExecStep {
+        argv: vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            format!("base64 -d >> {quoted}"),
+        ],
+        stdin: Some(base64_encode(data)),
+    });
+    steps
+}
+
+fn walk_files_sorted(dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        for entry in fs::read_dir(&d)? {
+            let entry = entry?;
+            let path = entry.path();
+            let kind = entry.file_type()?;
+            if kind.is_dir() {
+                stack.push(path);
+            } else if kind.is_file() {
+                out.push(path);
+            }
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+/// Mirrors Python `_transfer_path_to_container`'s directory branch: walks
+/// `host_dir` (matching `os.walk`) and builds a `write_bytes_plan` for every
+/// regular file, keyed by its path relative to `host_dir` joined onto
+/// `container_path`. Deliberately per-file (not a `tar` stream) for exact
+/// parity with the Python source of truth (PY:1554-1561).
+pub fn transfer_dir_plan(host_dir: &Path, container_path: &str) -> Result<Vec<ExecStep>> {
+    let mut steps = Vec::new();
+    let base = container_path.trim_end_matches('/');
+    for file in walk_files_sorted(host_dir)? {
+        let rel = file
+            .strip_prefix(host_dir)
+            .expect("walked file is under host_dir")
+            .to_string_lossy()
+            .replace(std::path::MAIN_SEPARATOR, "/");
+        let dst = format!("{base}/{rel}");
+        let data = fs::read(&file)?;
+        steps.extend(write_bytes_plan(&dst, &data));
+    }
+    Ok(steps)
+}
+
+/// Mirrors Python `_secure_container_path`: chown the transferred path to
+/// the in-container `agent` user (uid/gid 1000) and lock file permissions
+/// to 0600. For a directory, `chown -R` the whole tree and `chmod 600`
+/// every regular file under it via `find` - matching PY:1566-1583 exactly,
+/// including that the directory's own mode is intentionally left
+/// untouched (Python does not `chmod` the directory itself, only the files
+/// inside it).
+pub fn secure_path_plan(container_path: &str, is_dir: bool) -> ExecStep {
+    let quoted = shell_quote(container_path);
+    let cmd = if is_dir {
+        format!("chown -R 1000:1000 {quoted} && find {quoted} -type f -exec chmod 600 {{}} +")
+    } else {
+        format!("chown 1000:1000 {quoted} && chmod 600 {quoted}")
+    };
+    ExecStep {
+        argv: vec!["sh".to_string(), "-c".to_string(), cmd],
+        stdin: None,
+    }
+}
+
+/// Full plan (transfer steps + trailing secure step) for one staged path.
+/// Pure and side-effect-free: reads the local staged bytes (needed to embed
+/// them in the plan) but performs no `docker exec` calls. Exposed for
+/// tests that assert the plan shape without a docker daemon.
+pub fn plan_for_staged_path(staged: &StagedPath) -> Result<Vec<ExecStep>> {
+    let is_dir = staged.host.is_dir();
+    let mut steps = if is_dir {
+        transfer_dir_plan(&staged.host, &staged.container)?
+    } else {
+        let data = fs::read(&staged.host)?;
+        write_bytes_plan(&staged.container, &data)
+    };
+    steps.push(secure_path_plan(&staged.container, is_dir));
+    Ok(steps)
+}
+
+fn run_exec_step(container: &str, step: &ExecStep) -> Result<()> {
+    let argv_refs: Vec<&str> = step.argv.iter().map(String::as_str).collect();
+    match &step.stdin {
+        Some(bytes) => {
+            tmux::docker_exec_with_stdin(container, &argv_refs, bytes)?;
+        }
+        None => {
+            tmux::docker_exec(container, &argv_refs)?;
+        }
+    }
+    Ok(())
+}
+
+/// Push every staged path in `prepared` into `container`'s filesystem over
+/// `docker exec` and lock down ownership/permissions in-container.
+///
+/// The container is assumed already started (bare `docker run ... sleep
+/// infinity`, no credential bind mounts - see `workspace::Workspace::start`).
+/// This is the "PUSHES credential files ... then secures them in-container"
+/// half of the docker-out-of-docker fix (PY:1850-1869).
+pub fn stage_into_container(container: &str, prepared: &PreparedAuth) -> Result<()> {
+    for staged in prepared.iter() {
+        for step in plan_for_staged_path(staged)? {
+            run_exec_step(container, &step)?;
+        }
+    }
+    Ok(())
 }

--- a/providers/workspaces/interactive-tmux/driver-rs/src/auth.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/auth.rs
@@ -248,8 +248,10 @@ pub fn prepare_codex(host_src: &Path, ctx: &AuthContext) -> Result<PreparedAuth>
     }
     let dst_dir = ctx.throwaway_dir.join("codex.dir");
     // Skip tmp/log/logs: codex races there during normal operation. The auth
-    // surface lives at `auth.json` / `config.toml` / `sessions/`.
-    copy_tree(host_src, &dst_dir, &["tmp", "log", "logs"])?;
+    // surface lives at `auth.json` / `config.toml` / `sessions/`. Also skip
+    // plugins/: a large plugin/dependency cache (node_modules), never auth,
+    // and staging it turns start_workspace into a multi-minute crawl.
+    copy_tree(host_src, &dst_dir, &["tmp", "log", "logs", "plugins"])?;
     Ok(PreparedAuth(vec![StagedPath {
         host: dst_dir,
         container: "/home/agent/.codex".to_string(),

--- a/providers/workspaces/interactive-tmux/driver-rs/src/auth.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/auth.rs
@@ -117,6 +117,12 @@ fn copy_file(src: &Path, dst: &Path) -> Result<()> {
 /// journals), an allowlist is the only stable way to keep credential staging
 /// from crawling. New bloat directories can appear at any release without
 /// breaking the stage, because nothing outside `allow_names` is ever copied.
+///
+/// The file-type decision follows symlinks (`fs::metadata`, not
+/// `DirEntry::file_type`, which stats the link itself): dotfile managers like
+/// stow/chezmoi routinely symlink `auth.json`/`config.toml` into `~/.codex`,
+/// and those must be staged as their target regular files. This also keeps
+/// parity with the Python driver, whose `Path.is_file()` follows symlinks.
 fn copy_named_files(src: &Path, dst: &Path, allow_names: &[&str]) -> Result<()> {
     if !src.exists() {
         return Ok(());
@@ -128,8 +134,11 @@ fn copy_named_files(src: &Path, dst: &Path, allow_names: &[&str]) -> Result<()> 
         if !allow_names.iter().any(|s| **s == *name.to_string_lossy()) {
             continue;
         }
-        if entry.file_type()?.is_file() {
-            fs::copy(entry.path(), dst.join(&name))?;
+        let path = entry.path();
+        // `fs::metadata` follows symlinks; a symlink-to-regular-file counts as
+        // a file and is copied by-value (`fs::copy` also follows the link).
+        if fs::metadata(&path).map(|m| m.is_file()).unwrap_or(false) {
+            fs::copy(&path, dst.join(&name))?;
         }
     }
     Ok(())

--- a/providers/workspaces/interactive-tmux/driver-rs/src/result.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/result.rs
@@ -73,6 +73,28 @@ impl AwaitResult {
         }
     }
 
+    /// The workspace target itself is GONE (dead container, vanished tmux
+    /// session/server) rather than a transient capture hiccup. Mirrors the
+    /// Python driver's `AwaitResult(reason="container_dead", ...)`
+    /// constructed in `_wait_for_started`/`await_completion` (PY:1962-1987,
+    /// PY:2110-2138) once `_container_death_reason` finds a death marker.
+    pub fn container_dead(
+        duration_ms: f64,
+        stable: u32,
+        pane: String,
+        err: impl Into<String>,
+    ) -> Self {
+        Self {
+            ready: false,
+            timed_out: false,
+            reason: "container_dead".to_string(),
+            duration_ms,
+            stable_polls_observed: stable,
+            pane,
+            error: Some(err.into()),
+        }
+    }
+
     /// Convenience for CLI `await` exit codes (mirrors Python: 0 if ready, 2 if not).
     pub const fn cli_exit_code(&self) -> i32 {
         if self.ready {

--- a/providers/workspaces/interactive-tmux/driver-rs/src/tmux.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/tmux.rs
@@ -5,8 +5,8 @@
 //! without a docker daemon (the per-agent readiness logic lives in
 //! `adapter` and only needs strings).
 
-use std::io::{Error, Result};
-use std::process::{Command, Output};
+use std::io::{Error, Result, Write};
+use std::process::{Command, Output, Stdio};
 
 pub const TMUX_SESSION: &str = "agents";
 
@@ -55,6 +55,41 @@ pub fn docker_exec(container: &str, args: &[&str]) -> Result<Output> {
     )
 }
 
+/// `docker exec -i <container> <args...>`, feeding `stdin_data` to the
+/// process's stdin and returning its `Output`.
+///
+/// Used by credential transfer (`auth::stage_into_container`) to push file
+/// bytes / base64 payloads into the container without ever putting them in
+/// argv (PY:1506-1517) - argv is world-readable via `ps` /
+/// `/proc/<pid>/cmdline` for the lifetime of the exec; stdin is not.
+pub fn docker_exec_with_stdin(container: &str, args: &[&str], stdin_data: &[u8]) -> Result<Output> {
+    let mut cmd = Command::new("docker");
+    cmd.arg("exec").arg("-i").arg(container);
+    cmd.args(args);
+    cmd.stdin(Stdio::piped());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    let mut child = cmd.spawn()?;
+    // Feed stdin from a dedicated thread so a payload larger than the pipe
+    // buffer can't deadlock against `wait_with_output` reading stdout/stderr
+    // (classic "write blocks because the child is blocked writing its own
+    // full stdout pipe, which we haven't started draining yet" deadlock).
+    let mut stdin = child
+        .stdin
+        .take()
+        .expect("stdin piped above via Stdio::piped()");
+    let payload = stdin_data.to_vec();
+    let writer = std::thread::spawn(move || stdin.write_all(&payload));
+    let out = child.wait_with_output()?;
+    writer
+        .join()
+        .map_err(|_| Error::other("stdin-writer thread panicked"))??;
+    check_output(
+        out,
+        &format!("docker exec -i {container} {}", redact_args(args)),
+    )
+}
+
 /// `docker exec <container> tmux send-keys -t <session>:<window> <keys...>`.
 /// Each `key` is one tmux send-keys argument (special-key names like
 /// `Enter`, `C-j`, or `Escape` are honoured by tmux).
@@ -69,7 +104,7 @@ pub fn send_keys(container: &str, window: &str, keys: &[&str]) -> Result<()> {
 /// `docker exec <container> tmux send-keys -l -t <session>:<window> <text>`.
 ///
 /// The `-l` flag tells tmux to deliver the bytes literally (no special-key
-/// interpretation) — the canonical pattern for the body of a user message.
+/// interpretation) - the canonical pattern for the body of a user message.
 pub fn send_literal(container: &str, window: &str, text: &str) -> Result<()> {
     let target = format!("{TMUX_SESSION}:{window}");
     // `--` ends option parsing so a prompt beginning with `-` (e.g. "-R",
@@ -115,7 +150,7 @@ pub fn capture_pane(container: &str, window: &str) -> Result<String> {
 /// Mirrors the Python driver's `_pane_tail`: with the full-scrollback
 /// capture above, the buffer contains every prompt and every prior
 /// generation. The per-agent `is_started` / `is_ready` predicates would
-/// be fooled by old text — `"esc to interrupt" not in pane` flips false
+/// be fooled by old text - `"esc to interrupt" not in pane` flips false
 /// after the first generation, and Claude's empty-chevron regex matches
 /// against ancient prompts. Evaluating against the tail preserves the
 /// pre-fix "check the visible window" semantics on a full-history capture.

--- a/providers/workspaces/interactive-tmux/driver-rs/src/tmux.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/tmux.rs
@@ -312,18 +312,16 @@ pub fn plan_send_literal(pane: &str, text: &str) -> SendLiteralPlan {
 ///
 /// The `-l` flag tells tmux to deliver the bytes literally (no special-key
 /// interpretation) - the canonical pattern for the body of a user message.
-pub fn send_literal(container: &str, window: &str, text: &str) -> Result<()> {
-    let target = format!("{TMUX_SESSION}:{window}");
-    let plan = plan_send_literal(&target, text);
-    match &plan {
+fn run_send_literal_plan<F>(plan: &SendLiteralPlan, mut exec: F) -> Result<()>
+where
+    F: FnMut(&[&str], Option<&[u8]>) -> Result<()>,
+{
+    match plan {
         SendLiteralPlan::SendKeys { pane, text } => {
             // `--` ends option parsing so a prompt beginning with `-` (e.g.
             // "-R", "--help") is treated as literal text, not a tmux
             // send-keys flag.
-            docker_exec(
-                container,
-                &["tmux", "send-keys", "-t", pane, "-l", "--", text],
-            )?;
+            exec(&["tmux", "send-keys", "-t", pane, "-l", "--", text], None)?;
         }
         SendLiteralPlan::PasteBuffer {
             pane,
@@ -333,27 +331,32 @@ pub fn send_literal(container: &str, window: &str, text: &str) -> Result<()> {
             // `load-buffer -b <name> -` reads the buffer contents from
             // stdin (which `docker_exec_with_stdin` already pipes in - no
             // container-side temp file needed) into a unique named buffer.
-            docker_exec_with_stdin(
-                container,
-                &["tmux", "load-buffer", "-b", buffer, "-"],
-                payload,
-            )?;
+            exec(&["tmux", "load-buffer", "-b", buffer, "-"], Some(payload))?;
             // `-p` = bracketed paste (atomic multiline); `-d` deletes the
             // named buffer afterwards so large sends don't accumulate stale
             // buffers and can't leak payload bytes into a later paste.
-            if let Err(error) = docker_exec(
-                container,
+            if let Err(error) = exec(
                 &["tmux", "paste-buffer", "-p", "-b", buffer, "-d", "-t", pane],
+                None,
             ) {
                 // `-d` only cleans up after a successful paste. If the paste
                 // command itself fails, remove the named buffer best-effort so
                 // its prompt payload cannot remain readable in the container.
-                let _ = docker_exec(container, &["tmux", "delete-buffer", "-b", buffer]);
+                let _ = exec(&["tmux", "delete-buffer", "-b", buffer], None);
                 return Err(error);
             }
         }
     }
     Ok(())
+}
+
+pub fn send_literal(container: &str, window: &str, text: &str) -> Result<()> {
+    let target = format!("{TMUX_SESSION}:{window}");
+    let plan = plan_send_literal(&target, text);
+    run_send_literal_plan(&plan, |args, stdin| match stdin {
+        Some(payload) => docker_exec_with_stdin(container, args, payload).map(|_| ()),
+        None => docker_exec(container, args).map(|_| ()),
+    })
 }
 
 /// Capture the full pane buffer including scrollback.
@@ -463,5 +466,30 @@ mod tests {
     fn redact_args_leaves_non_literal_commands_intact() {
         let args = ["tmux", "capture-pane", "-p", "-t", "agents:claude"];
         assert_eq!(redact_args(&args), "tmux capture-pane -p -t agents:claude");
+    }
+
+    #[test]
+    fn failed_paste_buffer_is_followed_by_best_effort_delete() {
+        let plan = plan_send_literal("agents:0", &"x".repeat(TMUX_SEND_KEYS_MAX_BYTES + 1));
+        let mut calls = Vec::new();
+        let err = run_send_literal_plan(&plan, |args, _stdin| {
+            calls.push(
+                args.iter()
+                    .map(|arg| (*arg).to_string())
+                    .collect::<Vec<_>>(),
+            );
+            if args.get(1) == Some(&"paste-buffer") {
+                return Err(Error::other("paste failed"));
+            }
+            Ok(())
+        })
+        .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::Other);
+        assert_eq!(calls.len(), 3);
+        assert_eq!(calls[0][1], "load-buffer");
+        assert_eq!(calls[1][1], "paste-buffer");
+        assert_eq!(calls[2][0..3], ["tmux", "delete-buffer", "-b"]);
+        assert_eq!(calls[2][3], calls[1][4]);
     }
 }

--- a/providers/workspaces/interactive-tmux/driver-rs/src/tmux.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/tmux.rs
@@ -5,10 +5,77 @@
 //! without a docker daemon (the per-agent readiness logic lives in
 //! `adapter` and only needs strings).
 
-use std::io::{Error, Result, Write};
-use std::process::{Command, Output, Stdio};
+use std::io::{Error, ErrorKind, Result, Write};
+use std::process::{Child, Command, Output, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
 
 pub const TMUX_SESSION: &str = "agents";
+
+/// Bound for one `docker exec` / `tmux` operation. Mirrors the Python
+/// driver's `DEFAULT_EXEC_TIMEOUT_S` (PY:86): a single wedged exec must not
+/// be able to hang the workflow forever.
+pub const DEFAULT_EXEC_TIMEOUT_S: f64 = 15.0;
+
+/// Bound for `docker run` / `docker rm -f`. Mirrors the Python driver's
+/// `DEFAULT_RUN_TIMEOUT_S` (PY:87).
+pub const DEFAULT_RUN_TIMEOUT_S: f64 = 30.0;
+
+/// Run `cmd`, bounding its execution to `timeout`.
+///
+/// std-only, no `unsafe`: spawns the child (stdout/stderr always piped, so
+/// the returned `Output` is populated the same way `Command::output()`
+/// would populate it), then waits for it on a dedicated thread and races
+/// that wait against `timeout` via `mpsc::recv_timeout`. On timeout the
+/// child is best-effort killed and an `ErrorKind::TimedOut` error is
+/// returned. Mirrors Python's `subprocess.run(..., timeout=...)` bound
+/// (PY:222-280, PY:576-626) without pulling in an async runtime or a new
+/// dependency.
+pub fn run_bounded(mut cmd: Command, timeout: Duration) -> Result<Output> {
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    let child = cmd.spawn()?;
+    wait_bounded(child, timeout)
+}
+
+/// Wait on an already-spawned `child`, bounded by `timeout`.
+///
+/// Shared by `run_bounded` and the stdin-writer path
+/// (`docker_exec_with_stdin`), which needs to feed the child's stdin from
+/// its own thread before this bound takes over waiting on exit.
+///
+/// On timeout, the child is killed (best-effort - `Child::kill` is a plain
+/// signal send, not a guarantee the process has fully exited by the time
+/// this function returns) and the waiter thread is left to finish and drop
+/// its result on the floor; we do not block joining it; the timeout error
+/// is returned immediately so a wedged process can never make this
+/// function itself hang.
+pub fn wait_bounded(child: Child, timeout: Duration) -> Result<Output> {
+    let pid = child.id();
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let result = child.wait_with_output();
+        let _ = tx.send(result);
+    });
+    match rx.recv_timeout(timeout) {
+        Ok(result) => result,
+        Err(_) => {
+            // Best-effort: ask the process (and, since docker/tmux
+            // children are frequently themselves a fork/exec wrapper,
+            // just its own pid - not a process group) to die. We do not
+            // have a `Child` handle here anymore (it was moved into the
+            // waiter thread so that thread can drain stdout/stderr without
+            // deadlocking on a full pipe buffer), so killing by pid via
+            // the `kill` utility is the only std-only, `unsafe`-free way
+            // to reach it from this side.
+            let _ = Command::new("kill").args(["-9", &pid.to_string()]).output();
+            Err(Error::new(
+                ErrorKind::TimedOut,
+                format!("command timed out after {timeout:?}"),
+            ))
+        }
+    }
+}
 
 fn check_output(out: Output, what: &str) -> Result<Output> {
     if out.status.success() {
@@ -43,12 +110,13 @@ fn redact_args(args: &[&str]) -> String {
     parts.join(" ")
 }
 
-/// Run `docker exec <container> <args...>` and return its `Output`.
+/// Run `docker exec <container> <args...>` and return its `Output`, bounded
+/// by `DEFAULT_EXEC_TIMEOUT_S` (PY:86) so a wedged exec can't hang forever.
 pub fn docker_exec(container: &str, args: &[&str]) -> Result<Output> {
     let mut cmd = Command::new("docker");
     cmd.arg("exec").arg(container);
     cmd.args(args);
-    let out = cmd.output()?;
+    let out = run_bounded(cmd, Duration::from_secs_f64(DEFAULT_EXEC_TIMEOUT_S))?;
     check_output(
         out,
         &format!("docker exec {container} {}", redact_args(args)),
@@ -80,7 +148,11 @@ pub fn docker_exec_with_stdin(container: &str, args: &[&str], stdin_data: &[u8])
         .expect("stdin piped above via Stdio::piped()");
     let payload = stdin_data.to_vec();
     let writer = std::thread::spawn(move || stdin.write_all(&payload));
-    let out = child.wait_with_output()?;
+    // Bounded wait (PY:86 `DEFAULT_EXEC_TIMEOUT_S`): if this times out, `?`
+    // returns immediately and the writer thread is left detached - once the
+    // killed child's stdin pipe closes its `write_all` fails fast and the
+    // thread exits on its own; there is nothing useful left to join.
+    let out = wait_bounded(child, Duration::from_secs_f64(DEFAULT_EXEC_TIMEOUT_S))?;
     writer
         .join()
         .map_err(|_| Error::other("stdin-writer thread panicked"))??;

--- a/providers/workspaces/interactive-tmux/driver-rs/src/tmux.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/tmux.rs
@@ -69,7 +69,11 @@ pub fn wait_bounded(child: Child, timeout: Duration) -> Result<Output> {
             // deadlocking on a full pipe buffer), so killing by pid via
             // the `kill` utility is the only std-only, `unsafe`-free way
             // to reach it from this side.
-            let _ = Command::new("kill").args(["-9", &pid.to_string()]).output();
+            let _ = Command::new("kill")
+                .args(["-9", &pid.to_string()])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn();
             Err(Error::new(
                 ErrorKind::TimedOut,
                 format!("command timed out after {timeout:?}"),

--- a/providers/workspaces/interactive-tmux/driver-rs/src/tmux.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/tmux.rs
@@ -117,14 +117,22 @@ fn redact_args(args: &[&str]) -> String {
 
 /// Run `docker exec <container> <args...>` and return its `Output`, bounded
 /// by `DEFAULT_EXEC_TIMEOUT_S` (PY:86) so a wedged exec can't hang forever.
-pub fn docker_exec(container: &str, args: &[&str]) -> Result<Output> {
+pub fn docker_exec_timeout(container: &str, args: &[&str], timeout: Duration) -> Result<Output> {
     let mut cmd = Command::new("docker");
     cmd.arg("exec").arg(container);
     cmd.args(args);
-    let out = run_bounded(cmd, Duration::from_secs_f64(DEFAULT_EXEC_TIMEOUT_S))?;
+    let out = run_bounded(cmd, timeout)?;
     check_output(
         out,
         &format!("docker exec {container} {}", redact_args(args)),
+    )
+}
+
+pub fn docker_exec(container: &str, args: &[&str]) -> Result<Output> {
+    docker_exec_timeout(
+        container,
+        args,
+        Duration::from_secs_f64(DEFAULT_EXEC_TIMEOUT_S),
     )
 }
 
@@ -135,7 +143,12 @@ pub fn docker_exec(container: &str, args: &[&str]) -> Result<Output> {
 /// bytes / base64 payloads into the container without ever putting them in
 /// argv (PY:1506-1517) - argv is world-readable via `ps` /
 /// `/proc/<pid>/cmdline` for the lifetime of the exec; stdin is not.
-pub fn docker_exec_with_stdin(container: &str, args: &[&str], stdin_data: &[u8]) -> Result<Output> {
+pub fn docker_exec_with_stdin_timeout(
+    container: &str,
+    args: &[&str],
+    stdin_data: &[u8],
+    timeout: Duration,
+) -> Result<Output> {
     let mut cmd = Command::new("docker");
     cmd.arg("exec").arg("-i").arg(container);
     cmd.args(args);
@@ -157,13 +170,22 @@ pub fn docker_exec_with_stdin(container: &str, args: &[&str], stdin_data: &[u8])
     // returns immediately and the writer thread is left detached - once the
     // killed child's stdin pipe closes its `write_all` fails fast and the
     // thread exits on its own; there is nothing useful left to join.
-    let out = wait_bounded(child, Duration::from_secs_f64(DEFAULT_EXEC_TIMEOUT_S))?;
+    let out = wait_bounded(child, timeout)?;
     writer
         .join()
         .map_err(|_| Error::other("stdin-writer thread panicked"))??;
     check_output(
         out,
         &format!("docker exec -i {container} {}", redact_args(args)),
+    )
+}
+
+pub fn docker_exec_with_stdin(container: &str, args: &[&str], stdin_data: &[u8]) -> Result<Output> {
+    docker_exec_with_stdin_timeout(
+        container,
+        args,
+        stdin_data,
+        Duration::from_secs_f64(DEFAULT_EXEC_TIMEOUT_S),
     )
 }
 
@@ -319,10 +341,16 @@ pub fn send_literal(container: &str, window: &str, text: &str) -> Result<()> {
             // `-p` = bracketed paste (atomic multiline); `-d` deletes the
             // named buffer afterwards so large sends don't accumulate stale
             // buffers and can't leak payload bytes into a later paste.
-            docker_exec(
+            if let Err(error) = docker_exec(
                 container,
                 &["tmux", "paste-buffer", "-p", "-b", buffer, "-d", "-t", pane],
-            )?;
+            ) {
+                // `-d` only cleans up after a successful paste. If the paste
+                // command itself fails, remove the named buffer best-effort so
+                // its prompt payload cannot remain readable in the container.
+                let _ = docker_exec(container, &["tmux", "delete-buffer", "-b", buffer]);
+                return Err(error);
+            }
         }
     }
     Ok(())

--- a/providers/workspaces/interactive-tmux/driver-rs/src/tmux.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/tmux.rs
@@ -7,6 +7,7 @@
 
 use std::io::{Error, ErrorKind, Result, Write};
 use std::process::{Child, Command, Output, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc;
 use std::time::Duration;
 
@@ -173,18 +174,153 @@ pub fn send_keys(container: &str, window: &str, keys: &[&str]) -> Result<()> {
     Ok(())
 }
 
-/// `docker exec <container> tmux send-keys -l -t <session>:<window> <text>`.
+/// Bound above which `send-keys -l` is skipped in favour of the
+/// load-buffer/paste-buffer path. Mirrors the Python driver's
+/// `TMUX_SEND_KEYS_MAX_BYTES` (PY:91): tmux's `send-keys -l` has a ~16KB
+/// cap and silently truncates larger payloads, so anything bigger is
+/// staged through a tmux paste buffer instead (PY:645-707).
+pub const TMUX_SEND_KEYS_MAX_BYTES: usize = 12_000;
+
+/// Monotonic per-process counter feeding the unique paste-buffer name.
+/// Combined with the process id it makes each large-payload send use its
+/// own named tmux buffer, so concurrent sends never race on the shared
+/// default buffer (Python uses a `uuid4` token for the same reason,
+/// PY:684-686). `std`-only, no `unsafe`, no new deps.
+static PASTE_BUFFER_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// The command plan `send_literal` will execute for a given payload,
+/// factored out as a pure, assertable value so tests can cover the
+/// threshold logic without a docker daemon.
+#[derive(Debug, PartialEq, Eq)]
+pub enum SendLiteralPlan {
+    /// `tmux send-keys -t <pane> -l -- <text>` - payload at or under
+    /// `TMUX_SEND_KEYS_MAX_BYTES` (PY:666 uses `<=` for this path).
+    SendKeys { pane: String, text: String },
+    /// `tmux load-buffer -b <buffer> -` (fed `payload` via stdin) followed
+    /// by `tmux paste-buffer -p -b <buffer> -d -t <pane>` - payload over
+    /// the threshold (PY:683-702). `-p` sends a bracketed paste so a
+    /// multiline prompt is delivered atomically instead of each newline
+    /// submitting early; `-b <buffer>` uses a unique named buffer to avoid
+    /// racing the shared default buffer; `-d` deletes that buffer after
+    /// pasting, covering Python's `finally` cleanup.
+    PasteBuffer {
+        pane: String,
+        buffer: String,
+        payload: Vec<u8>,
+    },
+}
+
+impl SendLiteralPlan {
+    /// `tmux load-buffer` argv for the large path (stdin carries the
+    /// payload). Empty for the `SendKeys` variant.
+    pub fn load_buffer_args(&self) -> Vec<String> {
+        match self {
+            SendLiteralPlan::SendKeys { .. } => Vec::new(),
+            SendLiteralPlan::PasteBuffer { buffer, .. } => {
+                vec![
+                    "tmux".into(),
+                    "load-buffer".into(),
+                    "-b".into(),
+                    buffer.clone(),
+                    "-".into(),
+                ]
+            }
+        }
+    }
+
+    /// `tmux paste-buffer` argv for the large path. Empty for the
+    /// `SendKeys` variant.
+    pub fn paste_buffer_args(&self) -> Vec<String> {
+        match self {
+            SendLiteralPlan::SendKeys { .. } => Vec::new(),
+            SendLiteralPlan::PasteBuffer { pane, buffer, .. } => {
+                vec![
+                    "tmux".into(),
+                    "paste-buffer".into(),
+                    "-p".into(),
+                    "-b".into(),
+                    buffer.clone(),
+                    "-d".into(),
+                    "-t".into(),
+                    pane.clone(),
+                ]
+            }
+        }
+    }
+}
+
+/// Derive a unique-per-call tmux buffer name. `std`-only: process id plus a
+/// monotonic counter, prefixed to mirror the Python driver's `itmux-<hex>`
+/// naming (PY:686). Two sends from the same process get distinct counter
+/// values; two sends from different processes get distinct pids.
+fn next_paste_buffer_name() -> String {
+    let seq = PASTE_BUFFER_SEQ.fetch_add(1, Ordering::Relaxed);
+    format!("itmux-{}-{seq}", std::process::id())
+}
+
+/// Decide how `text` should be delivered into `pane`, without touching
+/// docker or tmux. Mirrors the Python driver's byte-length branch
+/// (PY:665-666): the threshold is measured against the UTF-8 byte length
+/// of the payload, not its character count. The large path mints a unique
+/// buffer name so concurrent callers never collide.
+pub fn plan_send_literal(pane: &str, text: &str) -> SendLiteralPlan {
+    let payload = text.as_bytes();
+    if payload.len() <= TMUX_SEND_KEYS_MAX_BYTES {
+        SendLiteralPlan::SendKeys {
+            pane: pane.to_string(),
+            text: text.to_string(),
+        }
+    } else {
+        SendLiteralPlan::PasteBuffer {
+            pane: pane.to_string(),
+            buffer: next_paste_buffer_name(),
+            payload: payload.to_vec(),
+        }
+    }
+}
+
+/// `docker exec <container> tmux send-keys -l -t <session>:<window> <text>`,
+/// or - for payloads over `TMUX_SEND_KEYS_MAX_BYTES` - a
+/// `load-buffer`/`paste-buffer` round trip that avoids tmux's ~16KB
+/// `send-keys -l` truncation cap (PY:645-707).
 ///
 /// The `-l` flag tells tmux to deliver the bytes literally (no special-key
 /// interpretation) - the canonical pattern for the body of a user message.
 pub fn send_literal(container: &str, window: &str, text: &str) -> Result<()> {
     let target = format!("{TMUX_SESSION}:{window}");
-    // `--` ends option parsing so a prompt beginning with `-` (e.g. "-R",
-    // "--help") is treated as literal text, not a tmux send-keys flag.
-    docker_exec(
-        container,
-        &["tmux", "send-keys", "-t", &target, "-l", "--", text],
-    )?;
+    let plan = plan_send_literal(&target, text);
+    match &plan {
+        SendLiteralPlan::SendKeys { pane, text } => {
+            // `--` ends option parsing so a prompt beginning with `-` (e.g.
+            // "-R", "--help") is treated as literal text, not a tmux
+            // send-keys flag.
+            docker_exec(
+                container,
+                &["tmux", "send-keys", "-t", pane, "-l", "--", text],
+            )?;
+        }
+        SendLiteralPlan::PasteBuffer {
+            pane,
+            buffer,
+            payload,
+        } => {
+            // `load-buffer -b <name> -` reads the buffer contents from
+            // stdin (which `docker_exec_with_stdin` already pipes in - no
+            // container-side temp file needed) into a unique named buffer.
+            docker_exec_with_stdin(
+                container,
+                &["tmux", "load-buffer", "-b", buffer, "-"],
+                payload,
+            )?;
+            // `-p` = bracketed paste (atomic multiline); `-d` deletes the
+            // named buffer afterwards so large sends don't accumulate stale
+            // buffers and can't leak payload bytes into a later paste.
+            docker_exec(
+                container,
+                &["tmux", "paste-buffer", "-p", "-b", buffer, "-d", "-t", pane],
+            )?;
+        }
+    }
     Ok(())
 }
 

--- a/providers/workspaces/interactive-tmux/driver-rs/src/workspace.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/workspace.rs
@@ -120,8 +120,12 @@ pub fn build_docker_run_argv(container: &str, workdir: &str, image: &str) -> Vec
     ]
 }
 
-fn run_capture(cmd: &mut Command, what: &str) -> Result<Output> {
-    let out = cmd.output()?;
+/// Run `cmd` bounded by `DEFAULT_RUN_TIMEOUT_S` (PY:87) - used for `docker
+/// run` / `docker rm -f`, which get a longer bound than the 15s exec/tmux
+/// default since image pulls and container teardown can legitimately take
+/// longer than a single `docker exec`.
+fn run_capture(cmd: Command, what: &str) -> Result<Output> {
+    let out = tmux::run_bounded(cmd, Duration::from_secs_f64(tmux::DEFAULT_RUN_TIMEOUT_S))?;
     if !out.status.success() {
         let stderr = String::from_utf8_lossy(&out.stderr);
         return Err(Error::other(format!(
@@ -202,7 +206,7 @@ impl Workspace {
             let argv = build_docker_run_argv(&container, &opts.workdir, &opts.image);
             let mut run = Command::new("docker");
             run.args(&argv);
-            run_capture(&mut run, "docker run")?;
+            run_capture(run, "docker run")?;
 
             // Container is up; push each agent's staged credentials into it
             // over `docker exec` and lock down ownership/permissions
@@ -217,10 +221,12 @@ impl Workspace {
             Err(e) => {
                 // Best-effort: `docker run -d` (or the credential transfer
                 // that follows it) can fail after the container is
-                // created, so remove it too.
-                let _ = Command::new("docker")
-                    .args(["rm", "-f", &container])
-                    .output();
+                // created, so remove it too. Bounded by
+                // `DEFAULT_RUN_TIMEOUT_S` like every other docker/tmux
+                // shell-out - cleanup must not be able to hang forever.
+                let mut rm = Command::new("docker");
+                rm.args(["rm", "-f", &container]);
+                let _ = tmux::run_bounded(rm, Duration::from_secs_f64(tmux::DEFAULT_RUN_TIMEOUT_S));
                 let _ = fs::remove_dir_all(&throwaway);
                 return Err(e);
             }
@@ -407,10 +413,11 @@ impl Workspace {
 
     pub fn stop(&self) -> Result<()> {
         // Best-effort `docker rm -f` + rm of throwaway dir. Matches Python's
-        // `subprocess.run(check=False)` semantics.
-        let _ = Command::new("docker")
-            .args(["rm", "-f", &self.container])
-            .output();
+        // `subprocess.run(check=False)` semantics, bounded by
+        // `DEFAULT_RUN_TIMEOUT_S` like every other docker/tmux shell-out.
+        let mut rm = Command::new("docker");
+        rm.args(["rm", "-f", &self.container]);
+        let _ = tmux::run_bounded(rm, Duration::from_secs_f64(tmux::DEFAULT_RUN_TIMEOUT_S));
         let _ = fs::remove_dir_all(&self.host_throwaway_dir);
         Ok(())
     }

--- a/providers/workspaces/interactive-tmux/driver-rs/src/workspace.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/workspace.rs
@@ -10,7 +10,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::adapter::{self, Agent};
-use crate::auth::{self, AuthContext, Mount};
+use crate::auth::{self, AuthContext, PreparedAuth};
 use crate::registry::{self, WorkspaceRecord};
 use crate::result::AwaitResult;
 use crate::tmux;
@@ -84,7 +84,7 @@ pub struct Workspace {
 
 fn random_suffix() -> String {
     // 8 hex chars from a non-crypto seed mix (no `rand` dep). Mirrors the
-    // Python `uuid.uuid4().hex[:8]` slot — used only for container naming.
+    // Python `uuid.uuid4().hex[:8]` slot - used only for container naming.
     use std::time::{SystemTime, UNIX_EPOCH};
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -94,6 +94,30 @@ fn random_suffix() -> String {
     #[allow(clippy::cast_possible_truncation)]
     let low = (mix & 0xFFFF_FFFF) as u64;
     format!("{low:08x}")
+}
+
+/// Build the `docker run` argv for a bare, credential-free container:
+/// `docker run -d --name <c> --workdir <wd> <image> sleep infinity`.
+///
+/// Deliberately carries NO `-v` flags for credentials (docker-out-of-docker
+/// fix): a sibling `-v host:container` bind mount is resolved by the OUTER
+/// daemon against its own filesystem, which cannot see this driver's own
+/// staging dir when the driver itself runs inside a container. Credentials
+/// are pushed in afterwards over `docker exec` - see
+/// `auth::stage_into_container`. Pure (no I/O) so it can be asserted on
+/// without a docker daemon; see `tests/cred_transfer.rs`.
+pub fn build_docker_run_argv(container: &str, workdir: &str, image: &str) -> Vec<String> {
+    vec![
+        "run".to_string(),
+        "-d".to_string(),
+        "--name".to_string(),
+        container.to_string(),
+        "--workdir".to_string(),
+        workdir.to_string(),
+        image.to_string(),
+        "sleep".to_string(),
+        "infinity".to_string(),
+    ]
 }
 
 fn run_capture(cmd: &mut Command, what: &str) -> Result<Output> {
@@ -150,9 +174,9 @@ impl Workspace {
         // must clean up the staged credential copies on failure; otherwise
         // a failed `docker run` (or a bad host auth dir) leaks auth
         // material under the temp dir.
-        let docker_run = (|| -> Result<Vec<Agent>> {
+        let provision = (|| -> Result<Vec<Agent>> {
             let mut enabled: Vec<Agent> = Vec::new();
-            let mut mounts: Vec<Mount> = Vec::new();
+            let mut prepared_by_agent: Vec<PreparedAuth> = Vec::new();
             for agent in adapter::AGENTS {
                 let Some(Some(src)) = opts.host_auth.get(&agent) else {
                     continue;
@@ -162,7 +186,7 @@ impl Workspace {
                     continue;
                 }
                 enabled.push(agent);
-                mounts.extend(prepared);
+                prepared_by_agent.push(prepared);
             }
 
             if enabled.is_empty() {
@@ -172,28 +196,28 @@ impl Workspace {
                 ));
             }
 
-            // docker run -d --name <c> --workdir <wd> [-v host:container ...] <image> sleep infinity
+            // Provision a bare, credential-free container (docker-out-of-
+            // docker fix - see `build_docker_run_argv` and module docs on
+            // `auth::stage_into_container`).
+            let argv = build_docker_run_argv(&container, &opts.workdir, &opts.image);
             let mut run = Command::new("docker");
-            run.args([
-                "run",
-                "-d",
-                "--name",
-                &container,
-                "--workdir",
-                &opts.workdir,
-            ]);
-            for m in &mounts {
-                run.arg("-v").arg(m.as_docker_arg());
-            }
-            run.arg(&opts.image).args(["sleep", "infinity"]);
+            run.args(&argv);
             run_capture(&mut run, "docker run")?;
+
+            // Container is up; push each agent's staged credentials into it
+            // over `docker exec` and lock down ownership/permissions
+            // in-container (PY:1850-1869, PY:1566-1583).
+            for prepared in &prepared_by_agent {
+                auth::stage_into_container(&container, prepared)?;
+            }
             Ok(enabled)
         })();
-        let enabled = match docker_run {
+        let enabled = match provision {
             Ok(enabled) => enabled,
             Err(e) => {
-                // Best-effort: `docker run -d` can fail after the container
-                // is created (e.g. start failure), so remove it too.
+                // Best-effort: `docker run -d` (or the credential transfer
+                // that follows it) can fail after the container is
+                // created, so remove it too.
                 let _ = Command::new("docker")
                     .args(["rm", "-f", &container])
                     .output();
@@ -327,7 +351,7 @@ impl Workspace {
         // D-block-2 + D-block-3 fix (Syntropic137 stress): the readiness
         // predicate AND the stability comparison both operate on the
         // bottom-of-pane tail. Stability on the full scrollback buffer
-        // would fail forever — any new response token appended changes
+        // would fail forever - any new response token appended changes
         // the buffer, even when the live TUI window has settled.
         // Comparing tails matches the pre-fix "visible window" semantics
         // on the full-history capture introduced by `-S - -E -`.

--- a/providers/workspaces/interactive-tmux/driver-rs/src/workspace.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/workspace.rs
@@ -120,6 +120,87 @@ pub fn build_docker_run_argv(container: &str, workdir: &str, image: &str) -> Vec
     ]
 }
 
+/// Substrings docker/tmux emit when the workspace target itself is GONE
+/// (OOM-killed, `docker rm`'d, stopped, tmux session vanished) rather than a
+/// transient capture hiccup while the container is still alive. Matched
+/// case-insensitively against a failed exec's error message so the readiness
+/// pollers can break out immediately instead of spinning the full
+/// startup/await deadline and then reporting a misleading generic timeout (a
+/// "degraded" workspace that actually masks a hard container death).
+///
+/// Deliberately EXCLUDED: "cannot connect to the Docker daemon" / generic
+/// "error connecting to" - those signal a transient daemon or socket outage,
+/// NOT a dead container (the container is very likely still running once the
+/// daemon recovers). Treating them as death would abort a live workspace on
+/// a blip; they stay on the retry path and are bounded by the overall
+/// deadline. Mirrors Python's `_CONTAINER_DEAD_STDERR_MARKERS` (PY:1637-1652).
+const CONTAINER_DEAD_STDERR_MARKERS: &[&str] = &[
+    "no such container",
+    "is not running",
+    "no server running", // tmux daemon gone
+    "no such session",   // tmux session vanished
+    "can't find session",
+];
+
+/// Return a human-readable reason if `err` indicates the workspace target is
+/// GONE, else `None`. Mirrors Python's `_container_death_reason`
+/// (PY:1653-1666).
+///
+/// A timed-out capture (`run_bounded`'s `ErrorKind::TimedOut`, mirroring
+/// Python's `TimeoutExpired`) is always treated as transient - the container
+/// may just be slow this once. Only a failed exec whose error text names a
+/// dead container / tmux server / tmux session counts as death. This lets
+/// the readiness pollers distinguish "one failed capture while still alive"
+/// (keep retrying) from "the container died" (stop now, surface the real
+/// error) instead of blindly polling until the deadline.
+fn container_death_reason(err: &Error) -> Option<String> {
+    if err.kind() == ErrorKind::TimedOut {
+        return None;
+    }
+    let msg = err.to_string();
+    let low = msg.to_lowercase();
+    for marker in CONTAINER_DEAD_STDERR_MARKERS {
+        if low.contains(marker) {
+            let trimmed = msg.trim();
+            return Some(if trimmed.is_empty() {
+                (*marker).to_string()
+            } else {
+                trimmed.to_string()
+            });
+        }
+    }
+    None
+}
+
+/// Outcome of classifying a single poll's pane-capture attempt. Pure (no
+/// I/O, no sleeping) so the await/startup poll loops' resilience logic can
+/// be unit tested without a docker daemon - see `tests/poll_resilience.rs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PollStep {
+    /// Capture succeeded; caller evaluates readiness against this pane text.
+    Captured(String),
+    /// Capture failed but looks transient (container still alive) - keep
+    /// polling within the overall deadline instead of aborting.
+    Retry,
+    /// Capture failed because the workspace target itself is gone.
+    Dead(String),
+}
+
+/// Classify one `tmux::capture_pane` result into a `PollStep`. Mirrors the
+/// try/except branch structure of Python's `_wait_for_started`/
+/// `await_completion` (PY:1962-1987, PY:2110-2138): success -> `Captured`,
+/// a death marker -> `Dead`, anything else (including a timed-out capture)
+/// -> `Retry`.
+pub fn classify_poll(capture: Result<String>) -> PollStep {
+    match capture {
+        Ok(pane) => PollStep::Captured(pane),
+        Err(e) => match container_death_reason(&e) {
+            Some(reason) => PollStep::Dead(reason),
+            None => PollStep::Retry,
+        },
+    }
+}
+
 /// Run `cmd` bounded by `DEFAULT_RUN_TIMEOUT_S` (PY:87) - used for `docker
 /// run` / `docker rm -f`, which get a longer bound than the 15s exec/tmux
 /// default since image pulls and container teardown can legitimately take
@@ -292,8 +373,8 @@ impl Workspace {
         let deadline = start + Duration::from_secs_f64(timeout_s);
         let mut pane = String::new();
         while Instant::now() < deadline {
-            match tmux::capture_pane(&self.container, agent.window()) {
-                Ok(p) => {
+            match classify_poll(tmux::capture_pane(&self.container, agent.window())) {
+                PollStep::Captured(p) => {
                     // D-block-2 fix (Syntropic137 stress): predicate runs
                     // against the bottom-of-pane tail so historical text
                     // in the now-included scrollback can't fool absence
@@ -305,9 +386,14 @@ impl Workspace {
                     }
                     pane = p;
                 }
-                Err(e) => {
+                PollStep::Dead(reason) => {
                     let elapsed = start.elapsed().as_secs_f64() * 1000.0;
-                    return AwaitResult::error(elapsed, pane, e.to_string());
+                    return AwaitResult::container_dead(elapsed, 0, pane, reason);
+                }
+                PollStep::Retry => {
+                    // Phase 3 (PY:1962-1987): a single wedged/failed capture
+                    // while the container is still alive must not abort the
+                    // whole wait - keep polling until the overall deadline.
                 }
             }
             thread::sleep(Duration::from_millis(500));
@@ -366,23 +452,48 @@ impl Workspace {
         let mut ever_ready = false;
         let mut pane = String::new();
         while Instant::now() < deadline {
-            pane = tmux::capture_pane(&self.container, agent.window())?;
-            let tail = tmux::pane_tail(&pane, self.tmux_size.1 as usize);
-            if adapter::is_ready(agent, &tail) {
-                ever_ready = true;
-                if last_tail.as_deref() == Some(&tail) {
-                    consecutive_stable_ready += 1;
-                    if consecutive_stable_ready >= stable_polls {
-                        let elapsed = start.elapsed().as_secs_f64() * 1000.0;
-                        return Ok(AwaitResult::ready(elapsed, consecutive_stable_ready, pane));
+            match classify_poll(tmux::capture_pane(&self.container, agent.window())) {
+                PollStep::Captured(p) => {
+                    pane = p;
+                    let tail = tmux::pane_tail(&pane, self.tmux_size.1 as usize);
+                    if adapter::is_ready(agent, &tail) {
+                        ever_ready = true;
+                        if last_tail.as_deref() == Some(&tail) {
+                            consecutive_stable_ready += 1;
+                            if consecutive_stable_ready >= stable_polls {
+                                let elapsed = start.elapsed().as_secs_f64() * 1000.0;
+                                return Ok(AwaitResult::ready(
+                                    elapsed,
+                                    consecutive_stable_ready,
+                                    pane,
+                                ));
+                            }
+                        } else {
+                            consecutive_stable_ready = 0;
+                        }
+                    } else {
+                        consecutive_stable_ready = 0;
                     }
-                } else {
-                    consecutive_stable_ready = 0;
+                    last_tail = Some(tail);
                 }
-            } else {
-                consecutive_stable_ready = 0;
+                PollStep::Dead(reason) => {
+                    let elapsed = start.elapsed().as_secs_f64() * 1000.0;
+                    return Ok(AwaitResult::container_dead(
+                        elapsed,
+                        consecutive_stable_ready,
+                        pane,
+                        reason,
+                    ));
+                }
+                PollStep::Retry => {
+                    // Phase 3 (PY:2110-2138): a single failed/wedged poll
+                    // (container still alive) must not abort the whole
+                    // await - treat it as "not ready this round" and keep
+                    // polling until the overall deadline above.
+                    consecutive_stable_ready = 0;
+                    last_tail = None;
+                }
             }
-            last_tail = Some(tail);
             thread::sleep(Duration::from_secs_f64(poll_interval));
         }
         let elapsed = start.elapsed().as_secs_f64() * 1000.0;

--- a/providers/workspaces/interactive-tmux/driver-rs/tests/auth_parity.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/tests/auth_parity.rs
@@ -161,17 +161,25 @@ fn gemini_patches_folder_trust_in_settings() {
 }
 
 #[test]
-fn codex_skips_tmp_log_and_plugins_subdirs() {
+fn codex_stages_only_the_auth_allowlist() {
+    // Codex staging is an ALLOWLIST: only the small auth/config files at the
+    // top of `~/.codex` are staged. Every operational directory (`.tmp/`,
+    // `sessions/`, `logs_2.sqlite*`, `computer-use/`, `plugins/`, ...) is left
+    // behind so start_workspace can't crawl hundreds of megabytes over
+    // per-file `docker exec` and hang forever.
     let host = tmp("codex-host");
-    fs::create_dir_all(host.join("tmp")).unwrap();
-    fs::create_dir_all(host.join("log")).unwrap();
-    fs::create_dir_all(host.join("plugins")).unwrap();
-    fs::create_dir_all(host.join("sessions")).unwrap();
-    fs::write(host.join("tmp").join("racy-argv.bin"), b"vanish").unwrap();
-    fs::write(host.join("log").join("verbose.log"), b"noisy").unwrap();
-    fs::write(host.join("plugins").join("node_modules_stub"), b"heavy").unwrap();
+    // Allowed auth/config surface.
     fs::write(host.join("auth.json"), b"{}").unwrap();
+    fs::write(host.join("config.toml"), b"model = \"x\"").unwrap();
+    // Non-auth bloat that MUST NOT be staged.
+    fs::create_dir_all(host.join(".tmp")).unwrap();
+    fs::create_dir_all(host.join("sessions")).unwrap();
+    fs::create_dir_all(host.join("plugins")).unwrap();
+    fs::create_dir_all(host.join("computer-use")).unwrap();
+    fs::write(host.join(".tmp").join("racy-argv.bin"), b"vanish").unwrap();
     fs::write(host.join("sessions").join("01.json"), b"{}").unwrap();
+    fs::write(host.join("plugins").join("node_modules_stub"), b"heavy").unwrap();
+    fs::write(host.join("logs_2.sqlite"), vec![0u8; 4096]).unwrap();
 
     let ctx = AuthContext {
         workdir: "/workspace".to_string(),
@@ -181,9 +189,25 @@ fn codex_skips_tmp_log_and_plugins_subdirs() {
     let mounts = prepare(Agent::Codex, &host, &ctx).unwrap();
     assert_eq!(mounts.len(), 1);
     let dst = &mounts[0].host;
-    assert!(dst.join("auth.json").is_file());
-    assert!(dst.join("sessions").join("01.json").is_file());
-    assert!(!dst.join("tmp").exists(), "tmp/ must be skipped");
-    assert!(!dst.join("log").exists(), "log/ must be skipped");
-    assert!(!dst.join("plugins").exists(), "plugins/ must be skipped");
+    // Auth surface staged.
+    assert!(dst.join("auth.json").is_file(), "auth.json must be staged");
+    assert!(
+        dst.join("config.toml").is_file(),
+        "config.toml must be staged"
+    );
+    // Everything else left behind.
+    assert!(!dst.join(".tmp").exists(), ".tmp/ must NOT be staged");
+    assert!(
+        !dst.join("sessions").exists(),
+        "sessions/ must NOT be staged"
+    );
+    assert!(!dst.join("plugins").exists(), "plugins/ must NOT be staged");
+    assert!(
+        !dst.join("computer-use").exists(),
+        "computer-use/ must NOT be staged"
+    );
+    assert!(
+        !dst.join("logs_2.sqlite").exists(),
+        "sqlite journals must NOT be staged"
+    );
 }

--- a/providers/workspaces/interactive-tmux/driver-rs/tests/auth_parity.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/tests/auth_parity.rs
@@ -168,9 +168,11 @@ fn codex_stages_only_the_auth_allowlist() {
     // behind so start_workspace can't crawl hundreds of megabytes over
     // per-file `docker exec` and hang forever.
     let host = tmp("codex-host");
-    // Allowed auth/config surface.
+    // Allowed auth/config surface (full declared allowlist).
     fs::write(host.join("auth.json"), b"{}").unwrap();
     fs::write(host.join("config.toml"), b"model = \"x\"").unwrap();
+    fs::write(host.join("config.json"), b"{}").unwrap();
+    fs::write(host.join("AGENTS.md"), b"# global instructions").unwrap();
     // Non-auth bloat that MUST NOT be staged.
     fs::create_dir_all(host.join(".tmp")).unwrap();
     fs::create_dir_all(host.join("sessions")).unwrap();
@@ -195,6 +197,11 @@ fn codex_stages_only_the_auth_allowlist() {
         dst.join("config.toml").is_file(),
         "config.toml must be staged"
     );
+    assert!(
+        dst.join("config.json").is_file(),
+        "config.json must be staged"
+    );
+    assert!(dst.join("AGENTS.md").is_file(), "AGENTS.md must be staged");
     // Everything else left behind.
     assert!(!dst.join(".tmp").exists(), ".tmp/ must NOT be staged");
     assert!(
@@ -209,5 +216,45 @@ fn codex_stages_only_the_auth_allowlist() {
     assert!(
         !dst.join("logs_2.sqlite").exists(),
         "sqlite journals must NOT be staged"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn codex_stages_symlinked_auth_files() {
+    // Dotfile managers (stow/chezmoi) symlink `auth.json`/`config.toml` into
+    // `~/.codex`. The allowlist decision must follow symlinks (parity with
+    // Python's `Path.is_file()`), or the exact files the fix exists to
+    // preserve get silently dropped.
+    use std::os::unix::fs::symlink;
+
+    let real = tmp("codex-real-store");
+    fs::write(real.join("auth.json"), b"{\"token\":\"real\"}").unwrap();
+    fs::write(real.join("config.toml"), b"model = \"y\"").unwrap();
+
+    let host = tmp("codex-symlink-host");
+    symlink(real.join("auth.json"), host.join("auth.json")).unwrap();
+    symlink(real.join("config.toml"), host.join("config.toml")).unwrap();
+
+    let ctx = AuthContext {
+        workdir: "/workspace".to_string(),
+        throwaway_dir: tmp("codex-symlink-throwaway"),
+        host_claude_dotjson: None,
+    };
+    let mounts = prepare(Agent::Codex, &host, &ctx).unwrap();
+    let dst = &mounts[0].host;
+    // Symlinked entries are staged as their target's regular-file contents.
+    assert!(
+        dst.join("auth.json").is_file(),
+        "symlinked auth.json must be staged"
+    );
+    assert!(
+        dst.join("config.toml").is_file(),
+        "symlinked config.toml must be staged"
+    );
+    assert_eq!(
+        fs::read(dst.join("auth.json")).unwrap(),
+        b"{\"token\":\"real\"}",
+        "staged copy must carry the symlink target's bytes"
     );
 }

--- a/providers/workspaces/interactive-tmux/driver-rs/tests/auth_parity.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/tests/auth_parity.rs
@@ -161,13 +161,15 @@ fn gemini_patches_folder_trust_in_settings() {
 }
 
 #[test]
-fn codex_skips_tmp_and_log_subdirs() {
+fn codex_skips_tmp_log_and_plugins_subdirs() {
     let host = tmp("codex-host");
     fs::create_dir_all(host.join("tmp")).unwrap();
     fs::create_dir_all(host.join("log")).unwrap();
+    fs::create_dir_all(host.join("plugins")).unwrap();
     fs::create_dir_all(host.join("sessions")).unwrap();
     fs::write(host.join("tmp").join("racy-argv.bin"), b"vanish").unwrap();
     fs::write(host.join("log").join("verbose.log"), b"noisy").unwrap();
+    fs::write(host.join("plugins").join("node_modules_stub"), b"heavy").unwrap();
     fs::write(host.join("auth.json"), b"{}").unwrap();
     fs::write(host.join("sessions").join("01.json"), b"{}").unwrap();
 
@@ -183,4 +185,5 @@ fn codex_skips_tmp_and_log_subdirs() {
     assert!(dst.join("sessions").join("01.json").is_file());
     assert!(!dst.join("tmp").exists(), "tmp/ must be skipped");
     assert!(!dst.join("log").exists(), "log/ must be skipped");
+    assert!(!dst.join("plugins").exists(), "plugins/ must be skipped");
 }

--- a/providers/workspaces/interactive-tmux/driver-rs/tests/cred_transfer.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/tests/cred_transfer.rs
@@ -1,0 +1,191 @@
+//! Docker-out-of-docker credential transfer parity tests.
+//!
+//! Syntropic137 runs this driver INSIDE a container. A sibling
+//! `docker run -v host:container` bind mount resolves `host` against the
+//! OUTER daemon's filesystem and can't see this driver's own staging dir  -
+//! so credentials must be pushed into the container over `docker exec`
+//! stdin instead (mirrors `driver/interactive_tmux.py` PY:1493-1583,
+//! PY:1850-1869). These tests assert the command *plan* built by pure
+//! functions in `auth` and `workspace` - no docker daemon required.
+
+use std::fs;
+use std::path::PathBuf;
+
+use itmux::auth::{prepare, secure_path_plan, stage_into_container, write_bytes_plan, AuthContext};
+use itmux::workspace::build_docker_run_argv;
+use itmux::Agent;
+
+fn tmp(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "itmux-cred-transfer-{name}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+#[test]
+fn docker_run_argv_carries_no_v_flags() {
+    let argv = build_docker_run_argv(
+        "interactive-tmux-foo-abcd1234",
+        "/workspace",
+        "my-image:latest",
+    );
+    assert!(
+        !argv.iter().any(|a| a == "-v"),
+        "docker run argv must not bind-mount credentials in DooD: {argv:?}"
+    );
+    assert_eq!(
+        argv,
+        vec![
+            "run",
+            "-d",
+            "--name",
+            "interactive-tmux-foo-abcd1234",
+            "--workdir",
+            "/workspace",
+            "my-image:latest",
+            "sleep",
+            "infinity",
+        ]
+    );
+}
+
+#[test]
+fn prepare_yields_staged_destination_paths_not_mount_bind_args() {
+    let host_root = tmp("claude-host-root");
+    let claude_dir = host_root.join(".claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    fs::write(claude_dir.join(".credentials.json"), b"{}").unwrap();
+
+    let ctx = AuthContext {
+        workdir: "/workspace".to_string(),
+        throwaway_dir: tmp("claude-throwaway"),
+        host_claude_dotjson: None,
+    };
+
+    let prepared = prepare(Agent::Claude, &claude_dir, &ctx).unwrap();
+    assert_eq!(prepared.len(), 2);
+    // Destinations are in-container paths meant for exec-transfer, never a
+    // "host:container" bind-mount argument string.
+    for staged in prepared.iter() {
+        assert!(staged.container.starts_with("/home/agent/"));
+        assert!(
+            !staged.container.contains(':'),
+            "container dest must not look like a `-v host:container` arg: {}",
+            staged.container
+        );
+        assert!(staged.host.exists(), "locally staged file must exist");
+    }
+}
+
+#[test]
+fn write_bytes_plan_never_puts_payload_in_argv() {
+    let secret = b"super-secret-oauth-token-xyz";
+    let steps = write_bytes_plan("/home/agent/.claude.json", secret);
+
+    // mkdir -p parent, truncate, then base64-decode-from-stdin.
+    assert_eq!(steps.len(), 3);
+    assert_eq!(steps[0].argv, vec!["mkdir", "-p", "/home/agent"]);
+    assert!(steps[0].stdin.is_none());
+
+    assert_eq!(steps[1].argv[0], "sh");
+    assert!(steps[1].argv[2].starts_with('>'));
+    assert!(steps[1].stdin.is_none());
+
+    assert_eq!(steps[2].argv[0], "sh");
+    assert!(steps[2].argv[2].contains("base64 -d"));
+    let stdin = steps[2].stdin.as_ref().expect("payload travels via stdin");
+
+    // The secret bytes must never appear in any argv string.
+    for step in &steps {
+        for arg in &step.argv {
+            assert!(
+                !arg.as_bytes()
+                    .windows(secret.len())
+                    .any(|w| w == secret.as_slice()),
+                "credential payload leaked into argv: {arg}"
+            );
+        }
+    }
+    // But the (base64-encoded) payload must be present in stdin somewhere.
+    assert!(!stdin.is_empty());
+}
+
+#[test]
+fn secure_path_plan_chowns_1000_1000_and_chmods_600_for_a_file() {
+    let step = secure_path_plan("/home/agent/.claude.json", false);
+    assert_eq!(step.argv[0], "sh");
+    assert_eq!(step.argv[1], "-c");
+    let cmd = &step.argv[2];
+    assert!(cmd.contains("chown 1000:1000"), "got: {cmd}");
+    assert!(cmd.contains("chmod 600"), "got: {cmd}");
+    assert!(step.stdin.is_none());
+}
+
+#[test]
+fn secure_path_plan_chowns_recursively_and_chmods_600_every_file_for_a_dir() {
+    let step = secure_path_plan("/home/agent/.codex", true);
+    let cmd = &step.argv[2];
+    assert!(cmd.contains("chown -R 1000:1000"), "got: {cmd}");
+    assert!(cmd.contains("chmod 600"), "got: {cmd}");
+    assert!(cmd.contains("find"), "dir secure step must use find: {cmd}");
+}
+
+#[test]
+fn plan_for_prepared_claude_auth_includes_transfer_and_secure_steps_for_every_staged_path() {
+    let host_root = tmp("claude-host-root-2");
+    let claude_dir = host_root.join(".claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    fs::write(claude_dir.join(".credentials.json"), b"{}").unwrap();
+
+    let ctx = AuthContext {
+        workdir: "/workspace".to_string(),
+        throwaway_dir: tmp("claude-throwaway-2"),
+        host_claude_dotjson: None,
+    };
+    let prepared = prepare(Agent::Claude, &claude_dir, &ctx).unwrap();
+
+    // Two staged paths (the .claude dir, the synthesised .claude.json)  -
+    // each must get its own secure (chown+chmod) step after transfer.
+    let mut secure_steps_seen = 0;
+    for staged in prepared.iter() {
+        let plan = itmux::auth::plan_for_staged_path(staged).unwrap();
+        let last = plan.last().expect("plan has at least the secure step");
+        assert!(last.argv[2].contains("chown"));
+        assert!(last.argv[2].contains("1000:1000"));
+        assert!(last.argv[2].contains("chmod 600"));
+        secure_steps_seen += 1;
+    }
+    assert_eq!(secure_steps_seen, 2);
+}
+
+#[test]
+fn stage_into_container_without_docker_fails_cleanly_not_via_v_mount() {
+    // No docker daemon / container named this in the test environment  -
+    // `stage_into_container` must attempt a `docker exec` (and fail with an
+    // I/O or nonzero-exit error) rather than silently succeeding via some
+    // bind-mount fallback. This exercises the real code path end-to-end
+    // (argv construction, stdin plumbing) even though the outer assertion
+    // is just "it does not panic and returns a Result".
+    let host_root = tmp("claude-host-root-3");
+    let claude_dir = host_root.join(".claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    fs::write(claude_dir.join(".credentials.json"), b"{}").unwrap();
+    let ctx = AuthContext {
+        workdir: "/workspace".to_string(),
+        throwaway_dir: tmp("claude-throwaway-3"),
+        host_claude_dotjson: None,
+    };
+    let prepared = prepare(Agent::Claude, &claude_dir, &ctx).unwrap();
+
+    let result = stage_into_container("itmux-cred-transfer-test-nonexistent-container", &prepared);
+    // Either docker isn't installed (I/O error) or the container doesn't
+    // exist (nonzero exit) - both surface as Err, never a silent Ok that
+    // would mean credentials were dropped via some other, unaudited path.
+    assert!(result.is_err());
+}

--- a/providers/workspaces/interactive-tmux/driver-rs/tests/cred_transfer.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/tests/cred_transfer.rs
@@ -11,7 +11,10 @@
 use std::fs;
 use std::path::PathBuf;
 
-use itmux::auth::{prepare, secure_path_plan, stage_into_container, write_bytes_plan, AuthContext};
+use itmux::auth::{
+    plan_for_staged_path, prepare, secure_path_plan, stage_into_container, write_bytes_plan,
+    AuthContext,
+};
 use itmux::workspace::build_docker_run_argv;
 use itmux::Agent;
 
@@ -188,4 +191,38 @@ fn stage_into_container_without_docker_fails_cleanly_not_via_v_mount() {
     // exist (nonzero exit) - both surface as Err, never a silent Ok that
     // would mean credentials were dropped via some other, unaudited path.
     assert!(result.is_err());
+}
+
+#[test]
+fn gemini_stages_only_durable_auth_and_config_files() {
+    let host_root = tmp("gemini-host-root");
+    let gemini_dir = host_root.join(".gemini");
+    fs::create_dir_all(gemini_dir.join("tmp/session-1")).unwrap();
+    fs::create_dir_all(gemini_dir.join("cache")).unwrap();
+    for name in [
+        "oauth_creds.json",
+        "settings.json",
+        "google_accounts.json",
+        "projects.json",
+        "user_id",
+    ] {
+        fs::write(gemini_dir.join(name), b"{}").unwrap();
+    }
+    fs::write(gemini_dir.join("tmp/session-1/chat.json"), b"history").unwrap();
+    fs::write(gemini_dir.join("cache/blob"), b"cache").unwrap();
+
+    let ctx = AuthContext {
+        workdir: "/workspace".to_string(),
+        throwaway_dir: tmp("gemini-throwaway"),
+        host_claude_dotjson: None,
+    };
+    let prepared = prepare(Agent::Gemini, &gemini_dir, &ctx).unwrap();
+    let staged = prepared.first().expect("Gemini has one staged directory");
+    assert!(staged.host.join("oauth_creds.json").is_file());
+    assert!(staged.host.join("settings.json").is_file());
+    assert!(!staged.host.join("tmp").exists());
+    assert!(!staged.host.join("cache").exists());
+
+    let plan = plan_for_staged_path(staged).unwrap();
+    assert!(plan.len() < 20, "only durable Gemini files are transferred");
 }

--- a/providers/workspaces/interactive-tmux/driver-rs/tests/exec_timeout.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/tests/exec_timeout.rs
@@ -29,8 +29,8 @@ fn run_bounded_kills_and_errors_on_timeout_without_blocking() {
     );
 
     // The whole point: we must NOT have waited out the 5s sleep. Give a
-    // generous margin for the kill round-trip (spawning `kill -9` is
-    // itself a subprocess) but this must stay well under 1s.
+    // generous scheduler margin, but this must stay well under 1s. Timeout
+    // cleanup dispatches `kill -9` without waiting for that subprocess.
     assert!(
         elapsed < Duration::from_secs(1),
         "run_bounded blocked for {elapsed:?}, expected well under 1s (child should have been killed)"

--- a/providers/workspaces/interactive-tmux/driver-rs/tests/exec_timeout.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/tests/exec_timeout.rs
@@ -1,0 +1,80 @@
+//! Parity: every docker/tmux shell-out is bounded by a timeout
+//! (PY:86-87 `DEFAULT_EXEC_TIMEOUT_S` / `DEFAULT_RUN_TIMEOUT_S`), so a
+//! wedged child process can never hang the driver forever.
+//!
+//! These tests exercise `itmux::tmux::run_bounded` directly against real
+//! `sh` subprocesses - no docker daemon required.
+
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use itmux::tmux::run_bounded;
+
+#[test]
+fn run_bounded_kills_and_errors_on_timeout_without_blocking() {
+    let mut cmd = Command::new("sh");
+    cmd.args(["-c", "sleep 5"]);
+
+    let start = Instant::now();
+    let result = run_bounded(cmd, Duration::from_millis(200));
+    let elapsed = start.elapsed();
+
+    assert!(result.is_err(), "expected a timeout error, got: {result:?}");
+    let err = result.unwrap_err();
+    assert_eq!(
+        err.kind(),
+        std::io::ErrorKind::TimedOut,
+        "expected ErrorKind::TimedOut, got: {:?} ({err})",
+        err.kind()
+    );
+
+    // The whole point: we must NOT have waited out the 5s sleep. Give a
+    // generous margin for the kill round-trip (spawning `kill -9` is
+    // itself a subprocess) but this must stay well under 1s.
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "run_bounded blocked for {elapsed:?}, expected well under 1s (child should have been killed)"
+    );
+}
+
+#[test]
+fn run_bounded_returns_output_for_a_fast_command() {
+    let mut cmd = Command::new("sh");
+    cmd.args(["-c", "echo hi"]);
+
+    let out = run_bounded(cmd, Duration::from_secs(5)).expect("fast command should not time out");
+
+    assert!(
+        out.status.success(),
+        "expected success, got: {:?}",
+        out.status
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("hi"),
+        "expected stdout to contain 'hi', got: {stdout:?}"
+    );
+}
+
+#[test]
+fn run_bounded_does_not_leak_a_hung_child_process() {
+    // Best-effort leak check: run_bounded on a long sleeper with a short
+    // timeout must return promptly. If the child were not killed, this
+    // test process would still exit fine (children don't block process
+    // exit on unix), but the *call* itself hanging would be the real bug -
+    // already covered above. Here we additionally check that issuing the
+    // call twice in a row is still fast, which would not be true if kills
+    // were failing to fire and something was accumulating wait time.
+    let start = Instant::now();
+    for _ in 0..2 {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "sleep 5"]);
+        let result = run_bounded(cmd, Duration::from_millis(150));
+        assert!(result.is_err());
+    }
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "two bounded calls took {elapsed:?}, expected well under 2s"
+    );
+}

--- a/providers/workspaces/interactive-tmux/driver-rs/tests/fixtures/codex/ready_fresh_launch.txt
+++ b/providers/workspaces/interactive-tmux/driver-rs/tests/fixtures/codex/ready_fresh_launch.txt
@@ -1,0 +1,37 @@
+agent@4c561bbe841c:/workspace$ codex --no-alt-screen
+> You are in /workspace
+
+  Do you trust the contents of this directory? Working with untrusted contents comes with higher risk of prompt injection. Trusting the directory allows project-local config, hooks, and exec policies
+  to load.
+
+› 1. Yes, continue
+  2. No, quit
+
+  Press enter to continue
+
+╭─────────────────────────────────────────────────╮
+│ ✨ Update available! 0.139.0 -> 0.142.5         │
+│ Run npm install -g @openai/codex to update.     │
+│                                                 │
+│ See full release notes:                         │
+│ https://github.com/openai/codex/releases/latest │
+╰─────────────────────────────────────────────────╯
+
+╭────────────────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.139.0)                     │
+│                                                │
+│ model:       gpt-5.5 medium   /model to change │
+│ directory:   /workspace                        │
+│ permissions: YOLO mode                         │
+╰────────────────────────────────────────────────╯
+
+  Tip: [tui.keymap] in ~/.codex/config.toml lets you rebind supported shortcuts.
+
+⚠ MCP client for `node_repl` failed to start: MCP startup failed: No such file or directory (os error 2)
+
+⚠ MCP startup incomplete (failed: node_repl)
+
+
+› Explain this codebase
+
+  gpt-5.5 medium · /workspace

--- a/providers/workspaces/interactive-tmux/driver-rs/tests/pane_tail.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/tests/pane_tail.rs
@@ -73,7 +73,10 @@ fn pane_tail_short_returns_pane_verbatim() {
 
 #[test]
 fn pane_tail_long_truncates_to_last_n_lines() {
-    let pane: String = (0..200).map(|i| format!("row{i}")).collect::<Vec<_>>().join("\n");
+    let pane: String = (0..200)
+        .map(|i| format!("row{i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
     let tail = pane_tail(&pane, 50);
     let lines: Vec<&str> = tail.split('\n').collect();
     assert_eq!(lines.len(), 50);

--- a/providers/workspaces/interactive-tmux/driver-rs/tests/poll_resilience.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/tests/poll_resilience.rs
@@ -1,0 +1,124 @@
+//! Poll-resilience parity tests (Plan 1a, Task 4).
+//!
+//! Exercises the pure `itmux::workspace::classify_poll` step function that
+//! `await_completion`/`wait_for_started` use to decide, per poll, whether to
+//! keep waiting, treat the pane as captured, or bail out because the
+//! workspace target itself is dead. No docker daemon involved - every case
+//! feeds a synthetic `std::io::Result<String>` (the same shape
+//! `tmux::capture_pane` returns) straight into `classify_poll`.
+//!
+//! Parity source: `driver/interactive_tmux.py` `_wait_for_started`
+//! (PY:1962-1987), `await_completion` (PY:2110-2138), and
+//! `_container_death_reason` / `_CONTAINER_DEAD_STDERR_MARKERS`
+//! (PY:1637-1666).
+
+use std::io::{Error, ErrorKind, Result};
+
+use itmux::workspace::{classify_poll, PollStep};
+
+fn transient_timeout() -> Result<String> {
+    Err(Error::new(
+        ErrorKind::TimedOut,
+        "command timed out after 15s",
+    ))
+}
+
+fn transient_exec_failure() -> Result<String> {
+    // A generic docker exec failure whose stderr does not name a dead
+    // container/session - e.g. a one-off wedge. Must be retried, not fatal.
+    Err(Error::other(
+        "docker exec c1 tmux capture-pane failed (exit 1): unexpected error",
+    ))
+}
+
+fn ready_pane(text: &str) -> Result<String> {
+    Ok(text.to_string())
+}
+
+#[test]
+fn poll_sequence_transient_transient_ready_does_not_abort_on_first_error() {
+    // (a) capture sequence [transient_err, transient_err, ready_pane] ->
+    // classification never returns Dead, and the final capture is surfaced
+    // for the readiness predicate to evaluate. This is the resilience gap:
+    // a naive `?`-on-first-error loop would have aborted after step 1.
+    let sequence = [
+        transient_timeout(),
+        transient_exec_failure(),
+        ready_pane("agent is idle"),
+    ];
+
+    let mut captured: Option<String> = None;
+    for capture in sequence {
+        match classify_poll(capture) {
+            PollStep::Retry => continue,
+            PollStep::Captured(pane) => {
+                captured = Some(pane);
+            }
+            PollStep::Dead(reason) => panic!("unexpectedly classified as dead: {reason}"),
+        }
+    }
+
+    assert_eq!(captured.as_deref(), Some("agent is idle"));
+}
+
+#[test]
+fn timed_out_capture_is_always_transient() {
+    assert_eq!(classify_poll(transient_timeout()), PollStep::Retry);
+}
+
+#[test]
+fn generic_capture_failure_is_transient() {
+    assert_eq!(classify_poll(transient_exec_failure()), PollStep::Retry);
+}
+
+#[test]
+fn real_container_dead_markers_are_classified_as_dead() {
+    let cases = [
+        "docker exec c1 tmux capture-pane failed (exit 1): Error: No such container: c1",
+        "docker exec c1 tmux capture-pane failed (exit 1): container c1 is not running",
+        "docker exec c1 tmux capture-pane failed (exit 1): no server running on /tmp/tmux-0/default",
+        "docker exec c1 tmux capture-pane failed (exit 1): no such session: agents",
+        "docker exec c1 tmux capture-pane failed (exit 1): can't find session agents",
+    ];
+
+    for case in cases {
+        let step = classify_poll(Err(Error::other(case)));
+        match step {
+            PollStep::Dead(reason) => assert!(!reason.is_empty(), "empty reason for: {case}"),
+            other => panic!("expected Dead for {case:?}, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn docker_daemon_outage_strings_are_not_classified_as_container_dead() {
+    // (c) "cannot connect to the Docker daemon" must NOT be treated as
+    // container death - it is a transient daemon/socket outage, and the
+    // container is very likely still running once the daemon recovers.
+    // Treating it as death would abort a live workspace on a blip.
+    let daemon_outage_cases = [
+        "Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?",
+        "error connecting to docker socket: dial unix /var/run/docker.sock: connect: no such file or directory",
+    ];
+
+    for case in daemon_outage_cases {
+        let step = classify_poll(Err(Error::other(case)));
+        assert_eq!(
+            step,
+            PollStep::Retry,
+            "daemon-outage string wrongly classified as dead: {case}"
+        );
+    }
+}
+
+#[test]
+fn timeout_is_never_classified_as_dead_even_with_a_death_marker_in_the_message() {
+    // A `TimedOut` kind must short-circuit to transient regardless of
+    // message content - mirrors Python's `isinstance(exc, TimeoutExpired)`
+    // check running before any string matching (PY:1657-1658).
+    let step = classify_poll(Err(Error::new(
+        ErrorKind::TimedOut,
+        "no such container: timed out waiting for capture",
+    )));
+    assert_eq!(step, PollStep::Retry);
+}

--- a/providers/workspaces/interactive-tmux/driver-rs/tests/readiness.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/tests/readiness.rs
@@ -16,6 +16,10 @@ const CLAUDE_WELCOME: &str = include_str!("fixtures/claude/welcome_started.txt")
 const CODEX_READY: &str = include_str!("fixtures/codex/ready_post_turn.txt");
 const CODEX_WORKING: &str = include_str!("fixtures/codex/working.txt");
 const CODEX_IDLE_HINT: &str = include_str!("fixtures/codex/idle_hint_only.txt");
+/// Real `itmux start --agents codex` first-ready pane captured live from
+/// codex-cli 0.139.0 in the fat image (trust banner accepted, hooks modal
+/// dismissed, composer visible). Guards the actual start path predicate.
+const CODEX_FRESH_LAUNCH: &str = include_str!("fixtures/codex/ready_fresh_launch.txt");
 
 const GEMINI_READY: &str = include_str!("fixtures/gemini/ready_post_turn.txt");
 const GEMINI_THINKING: &str = include_str!("fixtures/gemini/thinking.txt");
@@ -89,6 +93,21 @@ fn codex_idle_with_hint_only_is_ready() {
 #[test]
 fn codex_empty_pane_is_not_ready() {
     assert!(!codex_is_ready(""));
+}
+
+#[test]
+fn codex_fresh_launch_pane_is_ready() {
+    // The real 0.139.0 first-ready pane after `itmux start --agents codex`:
+    // the composer shows `› Explain this codebase` and a `Tip:` line, and no
+    // `• Working` marker. Both the ready and started predicates must pass so
+    // start_workspace reports the codex agent ready (rc=0). Regression guard
+    // for the credential-staging fix that lets start_workspace reach this pane
+    // at all.
+    assert!(
+        codex_is_ready(CODEX_FRESH_LAUNCH),
+        "real 0.139.0 fresh-launch pane must satisfy codex_is_ready"
+    );
+    assert!(codex_is_started(CODEX_FRESH_LAUNCH));
 }
 
 #[test]

--- a/providers/workspaces/interactive-tmux/driver-rs/tests/send_literal.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/tests/send_literal.rs
@@ -1,0 +1,151 @@
+//! Regression tests for the paste-buffer fallback in `send_literal`.
+//!
+//! Mirrors the Python driver's `_tmux_send_literal` (PY:645-707): tmux's
+//! `send-keys -l` has a ~16KB cap and silently truncates larger payloads.
+//! Above `TMUX_SEND_KEYS_MAX_BYTES` (PY:91, `12_000`) the driver instead
+//! stages the payload into a tmux buffer via `load-buffer -` (stdin) and
+//! dispatches it with `paste-buffer`.
+//!
+//! These tests exercise the pure planning function only - no docker
+//! daemon involved - so they run in any environment.
+
+use itmux::tmux::{plan_send_literal, SendLiteralPlan, TMUX_SEND_KEYS_MAX_BYTES};
+
+const PANE: &str = "agents:0";
+
+#[test]
+fn small_payload_uses_send_keys() {
+    let text = "x".repeat(100);
+    match plan_send_literal(PANE, &text) {
+        SendLiteralPlan::SendKeys { pane, text: t } => {
+            assert_eq!(pane, PANE);
+            assert_eq!(t, text);
+        }
+        SendLiteralPlan::PasteBuffer { .. } => panic!("100-byte payload must use send-keys -l"),
+    }
+}
+
+#[test]
+fn large_payload_uses_paste_buffer() {
+    let text = "y".repeat(20 * 1024);
+    match plan_send_literal(PANE, &text) {
+        SendLiteralPlan::PasteBuffer {
+            pane,
+            buffer,
+            payload,
+        } => {
+            assert_eq!(pane, PANE);
+            assert_eq!(payload, text.as_bytes());
+            assert!(!buffer.is_empty(), "large path must mint a buffer name");
+        }
+        SendLiteralPlan::SendKeys { .. } => panic!("20KB payload must use paste-buffer"),
+    }
+}
+
+#[test]
+fn large_payload_plan_uses_bracketed_paste_and_named_buffer() {
+    let text = "y".repeat(20 * 1024);
+    let plan = plan_send_literal(PANE, &text);
+    let buffer = match &plan {
+        SendLiteralPlan::PasteBuffer { buffer, .. } => buffer.clone(),
+        SendLiteralPlan::SendKeys { .. } => panic!("20KB payload must use paste-buffer"),
+    };
+
+    // load-buffer stages the payload into the NAMED buffer via stdin (`-`).
+    let load = plan.load_buffer_args();
+    assert_eq!(
+        load,
+        vec![
+            "tmux".to_string(),
+            "load-buffer".to_string(),
+            "-b".to_string(),
+            buffer.clone(),
+            "-".to_string(),
+        ],
+    );
+
+    // paste-buffer MUST carry `-p` (bracketed paste) and `-b <name>`
+    // (named buffer), plus `-d` to delete it after paste. PY:698-702.
+    let paste = plan.paste_buffer_args();
+    assert!(
+        paste.iter().any(|a| a == "-p"),
+        "paste-buffer plan must include -p (bracketed paste): {paste:?}"
+    );
+    let b_pos = paste
+        .iter()
+        .position(|a| a == "-b")
+        .expect("paste-buffer plan must include -b");
+    assert_eq!(
+        paste.get(b_pos + 1),
+        Some(&buffer),
+        "-b must be followed by the minted buffer name"
+    );
+    assert!(
+        paste.iter().any(|a| a == "-d"),
+        "paste-buffer plan must include -d (delete buffer after paste): {paste:?}"
+    );
+    assert_eq!(
+        paste,
+        vec![
+            "tmux".to_string(),
+            "paste-buffer".to_string(),
+            "-p".to_string(),
+            "-b".to_string(),
+            buffer.clone(),
+            "-d".to_string(),
+            "-t".to_string(),
+            PANE.to_string(),
+        ],
+    );
+}
+
+#[test]
+fn buffer_names_are_unique_per_call() {
+    let text = "y".repeat(20 * 1024);
+    let a = match plan_send_literal(PANE, &text) {
+        SendLiteralPlan::PasteBuffer { buffer, .. } => buffer,
+        SendLiteralPlan::SendKeys { .. } => unreachable!(),
+    };
+    let b = match plan_send_literal(PANE, &text) {
+        SendLiteralPlan::PasteBuffer { buffer, .. } => buffer,
+        SendLiteralPlan::SendKeys { .. } => unreachable!(),
+    };
+    assert_ne!(a, b, "each large send must mint a distinct buffer name");
+}
+
+#[test]
+fn small_payload_plan_has_no_paste_buffer_args() {
+    let plan = plan_send_literal(PANE, "small");
+    assert!(plan.load_buffer_args().is_empty());
+    assert!(plan.paste_buffer_args().is_empty());
+}
+
+#[test]
+fn boundary_exactly_at_threshold_uses_send_keys() {
+    // PY:666 uses `<=` for the small-path check, so a payload of exactly
+    // `TMUX_SEND_KEYS_MAX_BYTES` bytes still takes the send-keys path.
+    let text = "z".repeat(TMUX_SEND_KEYS_MAX_BYTES);
+    match plan_send_literal(PANE, &text) {
+        SendLiteralPlan::SendKeys { .. } => {}
+        SendLiteralPlan::PasteBuffer { .. } => {
+            panic!("payload of exactly the threshold must use send-keys -l")
+        }
+    }
+}
+
+#[test]
+fn boundary_one_byte_over_threshold_uses_paste_buffer() {
+    let text = "z".repeat(TMUX_SEND_KEYS_MAX_BYTES + 1);
+    match plan_send_literal(PANE, &text) {
+        SendLiteralPlan::PasteBuffer { .. } => {}
+        SendLiteralPlan::SendKeys { .. } => {
+            panic!("payload one byte over the threshold must use paste-buffer")
+        }
+    }
+}
+
+#[test]
+fn threshold_constant_matches_python_parity() {
+    // PY:91 `TMUX_SEND_KEYS_MAX_BYTES = 12_000`.
+    assert_eq!(TMUX_SEND_KEYS_MAX_BYTES, 12_000);
+}

--- a/providers/workspaces/interactive-tmux/driver/interactive_tmux.py
+++ b/providers/workspaces/interactive-tmux/driver/interactive_tmux.py
@@ -1165,29 +1165,23 @@ class _CodexAdapter:
             raise FileNotFoundError(f"codex auth dir not found: {host_src}")
         dst_dir = ctx.host_throwaway_dir / "codex.dir"
         dst_dir.mkdir(parents=True, exist_ok=True)
-        # Copy the .codex/ tree but skip the live tmp/ subdir - codex races
-        # there (creates and deletes argv files during normal operation), so
-        # copytree against it sees vanished files. The auth lives in
-        # auth.json / config.toml / sessions/ at the top level. `plugins/` is
-        # a large plugin/dependency cache (node_modules), never auth, and
-        # staging it turns start_workspace into a multi-minute, thousands-of-
-        # exec crawl - skip it (node_modules/.git anywhere are skipped by the
-        # copytree ignore filter as defense in depth).
-        skip = {"tmp", "log", "logs", "plugins"}
-        for item in host_src.iterdir():
-            if item.name in skip:
-                continue
-            target = dst_dir / item.name
-            if item.is_dir():
-                shutil.copytree(
-                    item,
-                    target,
-                    dirs_exist_ok=True,
-                    ignore_dangling_symlinks=True,
-                    ignore=_ignore_uncopyable,
-                )
-            else:
-                shutil.copy2(item, target)
+        # Stage ONLY the codex auth/config surface via an allowlist. A modern
+        # `~/.codex` (codex-cli 0.139.0) mixes a few small credential/config
+        # files (`auth.json`, `config.toml`) with hundreds of megabytes of
+        # operational state under directories that vary by release: `.tmp/`,
+        # `sessions/`, `archived_sessions/`, `logs_2.sqlite*`, `computer-use/`,
+        # `plugins/`, `cache/`, etc. The old `{tmp, log, logs, plugins}`
+        # denylist missed all of those, turning start_workspace into a
+        # multi-minute, thousands-of-`docker exec` crawl that never completes
+        # (the startup-timeout bound covers only the post-launch readiness
+        # wait, not credential staging). An allowlist is the only stable fix:
+        # it can't regress when codex adds new state directories. Keep in sync
+        # with the Rust driver's `CODEX_AUTH_FILES`.
+        allow = ("auth.json", "config.toml", "config.json", "AGENTS.md")
+        for name in allow:
+            item = host_src / name
+            if item.is_file():
+                shutil.copy2(item, dst_dir / name)
         _chown_recursive(dst_dir, 1000, 1000)
         return {"codex_dir": (dst_dir, "/home/agent/.codex")}
 


### PR DESCRIPTION
Single consolidated feature PR for the Rust `itmux` driver work - the whole "make itmux the production driver for claude + codex" effort in one reviewable unit. **Supersedes the stacked PRs #231-#236 + #241** (closed in favor of this).

This is one of the three layers of the Workspace Standard: **itmux (Rust driver)**. The other two are #240 (Python contract) and APSS #88 (recipe standard).

## What's in it (10 commits, oldest first)
| Commit | What |
|---|---|
| `65b5ca8` | **DooD credential transfer** - docker-exec base64-over-stdin (no `-v` mounts) + chown/chmod securing. Fixes unauthenticated agents under docker-out-of-docker. |
| `492dbc5` | Bounded timeouts (15s/30s) on every docker/tmux exec. |
| `af5030b` | Await poll resilience + `container_dead` classification (daemon-outage not misclassified). |
| `9c41610` | >12KB paste-buffer path with bracketed-paste `-p` + named buffer (multiline prompts paste atomically). |
| `dc3f7e5` | (superseded by allowlist below) codex plugins skip. |
| `ea55a05` | Wire Rust into CI + justfile. |
| `fc193f1` | base64 known-vector tests (RFC 4648 + high-bit). |
| `993e079` | **Codex fix** - stage only codex auth surface via allowlist (root-caused a 785MB `~/.codex` staging hang). |
| `4e8ba53` | Codex readiness fixture. |
| `c1d5775` | Follow symlinks when staging codex auth (dotfile-manager `auth.json`/`config.toml`). |

## Validation
- **Live-validated on real Docker:** `itmux start --agents claude,codex --strict-startup` -> both ready (claude 639ms, codex 66ms), authenticated via the DooD cred transfer.
- **Dual-reviewed:** whole-stack Claude adversarial review (APPROVE) + codex cross-model pass (APPROVE) over the full `main...HEAD` delta.
- cargo test / clippy -D warnings / fmt all green.

## Known follow-up (from the standalone eval)
The claude adapter has a **send-race** (first keystrokes after launch can drop before input-readiness); fix incoming as a claude-adapter input-readiness gate (per-harness, generalizable). Tracked; not a blocker for review of the above.

Tracks okrs-o78 / okrs-51p.6 / okrs-51p.7.