### PR TITLE
feat(agentic_isolation): thin Python client for itmux run (Plan B Task 7)

### DIFF
--- a/lib/python/agentic_isolation/agentic_isolation/run_client.py
+++ b/lib/python/agentic_isolation/agentic_isolation/run_client.py
@@ -205,8 +205,15 @@ class ItmuxRunError(RuntimeError):
 # Process-group cleanup (R10).
 # ---------------------------------------------------------------------------
 
+# Grace for crash / timeout / cancel teardown: the Rust leader may be mid-run
+# and needs time after SIGTERM to tear its container down before we SIGKILL.
 _DEFAULT_KILL_GRACE_S = 5.0
-_GROUP_POLL_INTERVAL_S = 0.02
+# Grace once a terminal result has already been delivered: the leader has
+# finished its work (the orchestrator tears the container down BEFORE emitting
+# the result) and is exiting, so only a short SIGTERM->SIGKILL window is needed.
+_RESULT_TEARDOWN_GRACE_S = 0.5
+# Chunk the grace sleep so we do not oversleep a short grace.
+_GRACE_SLEEP_CHUNK_S = 0.05
 
 
 def _killpg_quiet(pgid: int, sig: int) -> bool:
@@ -222,15 +229,6 @@ def _killpg_quiet(pgid: int, sig: int) -> bool:
         return False
 
 
-def _group_alive(pgid: int) -> bool:
-    """True while ANY process (including an unreaped zombie) remains in the group.
-
-    Uses signal ``0`` as an existence probe - it delivers nothing but raises
-    ``ProcessLookupError`` once the group is empty.
-    """
-    return _killpg_quiet(pgid, 0)
-
-
 def _terminate_process_group(
     proc: subprocess.Popen[str],
     *,
@@ -242,26 +240,32 @@ def _terminate_process_group(
     process group whose pgid equals the leader pid. Signalling the group reaches
     the Rust process AND any ``docker exec`` grandchildren it spawned.
 
-    Ordering (codex must-fix 1+2):
+    Ordering (codex must-fix 1+2, refined):
 
     1. ``SIGTERM`` the whole group FIRST so the Rust leader can run its own
        graceful container teardown; a premature ``SIGKILL`` would orphan the
        docker CONTAINER (the orchestrator tears it down on graceful signals,
        see #248).
-    2. Wait a bounded grace period, polling for the *group* to drain - not
-       ``proc.wait()`` on the leader alone, which would both block escalation
-       and miss a grandchild that outlives the leader.
-    3. ``SIGKILL`` the group to reap any survivor (the leader may already be
-       gone while a docker-exec grandchild lingers).
+    2. Wait a bounded grace period WITHOUT reaping the leader.
+    3. ``SIGKILL`` the whole group to reap any survivor (a docker-exec
+       grandchild can outlive the leader).
     4. ONLY THEN reap the leader zombie.
 
-    PID-reuse safety: we never signal a group we have already reaped. Once the
-    leader is reaped its returncode is set, so an early-return guard prevents a
-    late watchdog from ``killpg``-ing a possibly-recycled pgid; and step 3 only
-    fires while the group is still non-empty (which reserves the pgid).
+    PID-reuse safety - the load-bearing invariant: the leader must stay
+    UNREAPED (alive or zombie) until AFTER the final group signal. An unreaped
+    leader keeps its pid (== pgid) reserved by the kernel, so every ``killpg``
+    below provably targets OUR group and can never hit a recycled pgid. This is
+    why the grace phase must NOT call ``proc.poll()`` / ``proc.wait()`` /
+    ``os.waitpid`` - reaping the zombie frees the pid and the pgid could be
+    recycled by a concurrent fork before step 3. ``killpg(pgid, 0)`` also cannot
+    detect "descendants gone" while the unreaped zombie still occupies the
+    group, so there is no correct non-reaping early exit: we simply sleep the
+    (short) grace. Teardown latency is an acceptable trade for the guarantee.
+    The early ``returncode`` guard covers a second teardown pass: if the leader
+    was already reaped, never signal its possibly-recycled pgid again.
     """
-    # Guard: if the leader has already been reaped, its pgid may have been
-    # recycled by the kernel - never signal it again.
+    # Guard: if the leader has already been reaped, its pid (== pgid) may have
+    # been recycled by the kernel - never signal it again.
     if proc.returncode is not None:
         return
 
@@ -271,34 +275,24 @@ def _terminate_process_group(
     # 1. Graceful group termination first.
     _killpg_quiet(pgid, signal.SIGTERM)
 
-    # 2. Bounded grace: let the leader exit gracefully and the group drain.
+    # 2. Bounded grace, WITHOUT reaping (see the PID-reuse invariant above).
     deadline = time.monotonic() + grace_s
-    escalate = True
-    while time.monotonic() < deadline:
-        # poll() reaps the leader zombie the instant it exits.
-        proc.poll()
-        if proc.returncode is not None:
-            # Leader gone. If no descendants remain the group has fully drained
-            # and its pgid may now be recycled - stop without signalling again.
-            if not _group_alive(pgid):
-                escalate = False
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
             break
-        time.sleep(_GROUP_POLL_INTERVAL_S)
+        time.sleep(min(_GRACE_SLEEP_CHUNK_S, remaining))
 
-    if not escalate:
-        return
-
-    # 3. Force-kill any survivor (grace expired with the leader alive, or the
-    #    leader exited but a grandchild is still holding the group open). The
-    #    group is still non-empty here, so its pgid is still reserved to us.
+    # 3. Force-kill the whole group. Provably safe: the still-unreaped leader
+    #    has kept the pgid reserved to us. Any surviving grandchild dies here.
     _killpg_quiet(pgid, signal.SIGKILL)
 
-    # 4. Reap the leader zombie if we have not already.
-    if proc.returncode is None:
-        try:
-            proc.wait(timeout=grace_s)
-        except subprocess.TimeoutExpired:
-            pass
+    # 4. Reap the leader LAST. Grandchildren SIGKILL'd above are orphaned to
+    #    init, which reaps them.
+    try:
+        proc.wait(timeout=grace_s)
+    except subprocess.TimeoutExpired:
+        pass
 
 
 # ---------------------------------------------------------------------------
@@ -363,13 +357,33 @@ def run_agent(
     stderr_thread = threading.Thread(target=_drain_stderr, daemon=True)
     stderr_thread.start()
 
+    # Teardown must run at most once. The watchdog (on timeout) and the finally
+    # block are two independent teardown paths on different threads; if both ran
+    # a full SIGTERM->grace->SIGKILL->reap, one could reap the leader while the
+    # other is still sleeping its grace, freeing the pgid before that thread's
+    # SIGKILL (the exact PID-reuse race we must avoid). The lock + once-flag
+    # serialize them: the first caller does the whole teardown holding the lock;
+    # the second blocks, then sees it is done and returns.
+    teardown_lock = threading.Lock()
+    torn_down = False
+
+    def _teardown(grace_s: float) -> None:
+        nonlocal torn_down
+        with teardown_lock:
+            if torn_down:
+                return
+            _terminate_process_group(proc, grace_s=grace_s)
+            torn_down = True
+
     timed_out = threading.Event()
     watchdog: threading.Timer | None = None
     if timeout is not None:
 
         def _on_timeout() -> None:
             timed_out.set()
-            _terminate_process_group(proc)
+            # Timeout/cancel path: the leader may be mid-run - give it the full
+            # grace to tear its container down after SIGTERM.
+            _teardown(_DEFAULT_KILL_GRACE_S)
 
         watchdog = threading.Timer(timeout, _on_timeout)
         watchdog.daemon = True
@@ -395,11 +409,12 @@ def run_agent(
     finally:
         if watchdog is not None:
             watchdog.cancel()
-        # Kill-before-reap (codex must-fix 1+2): tear the whole process group
-        # down BEFORE reaping the leader, so a surviving docker-exec grandchild
-        # is killed even when the Rust leader has already exited. Runs on every
-        # exit path - normal return, timeout, parse error, KeyboardInterrupt.
-        _terminate_process_group(proc)
+        # Kill-before-reap: tear the whole process group down BEFORE reaping the
+        # leader (see `_terminate_process_group`). Runs on every exit path -
+        # normal return, timeout, parse error, KeyboardInterrupt. A delivered
+        # result means the leader has finished and is exiting, so a short grace
+        # suffices; otherwise use the full crash/cancel grace.
+        _teardown(_RESULT_TEARDOWN_GRACE_S if result is not None else _DEFAULT_KILL_GRACE_S)
         # Join the stderr drain only AFTER the group is dead - otherwise a
         # surviving grandchild holding the stderr pipe could block the join.
         stderr_thread.join(timeout=_DEFAULT_KILL_GRACE_S)

--- a/lib/python/agentic_isolation/agentic_isolation/run_client.py
+++ b/lib/python/agentic_isolation/agentic_isolation/run_client.py
@@ -1,0 +1,356 @@
+"""Thin Python client for the Rust ``itmux run`` binary (Plan B, Task 7).
+
+This module is deliberately *thin*: it owns no orchestration and no business
+logic. All of that lives in the Rust ``itmux run`` subcommand. The client's
+sole responsibilities are:
+
+1. Mirror the wire contract (`AgentRunSpec` / `AgentRunResult` / `AgentRunEvent`)
+   as strict Pydantic v2 models whose field names match the Rust serde names
+   exactly. See the authoritative source at
+   ``providers/workspaces/interactive-tmux/driver-rs/src/run/contract.rs`` and
+   the generated JSON schema under ``.../driver-rs/docs/contract/``.
+2. Spawn ``itmux run`` in JSON mode, stream the stdout event JSONL, parse each
+   line into a typed :data:`AgentRunEvent`, and return the terminal
+   :class:`AgentRunResult`.
+3. Never leak a child process. The child (and any ``docker exec`` grandchildren
+   it spawns) runs in its own process group; on cancel / crash / timeout the
+   whole group is signalled ``SIGTERM`` then, after a grace period, ``SIGKILL``
+   (R10 process-group cleanup).
+
+Supersedes the hand-written Python contract proposed in #240 - that contract is
+replaced by this Rust-mirrored one and #240 is closed separately.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import threading
+from collections.abc import Callable
+from pathlib import Path
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, TypeAdapter, ValidationError
+
+__all__ = [
+    "AgentRunOutcome",
+    "ObservabilityBundle",
+    "AgentRunResult",
+    "ToolStartEvent",
+    "ToolEndEvent",
+    "TokenUsageEvent",
+    "SessionEndEvent",
+    "ResultEvent",
+    "AgentRunEvent",
+    "ItmuxRunError",
+    "run_agent",
+]
+
+
+# ---------------------------------------------------------------------------
+# Contract models (mirror `contract.rs` serde field names exactly).
+# ---------------------------------------------------------------------------
+
+# `frozen=True` mirrors the immutability of the Rust structs; `extra="forbid"`
+# mirrors serde's `#[serde(deny_unknown_fields)]` so a typo'd or stale field
+# fails loudly instead of being silently ignored.
+_CONTRACT_CONFIG = ConfigDict(frozen=True, extra="forbid")
+
+
+class AgentRunOutcome(BaseModel):
+    """The success/failure verdict for a run (Rust ``AgentRunOutcome``)."""
+
+    model_config = _CONTRACT_CONFIG
+
+    success: bool
+    summary: str
+
+
+class ObservabilityBundle(BaseModel):
+    """Plan 3 placeholder bundle (Rust ``ObservabilityBundle``)."""
+
+    model_config = _CONTRACT_CONFIG
+
+    name: str = ""
+    # serde: `serde_json::Value` defaulting to null -> arbitrary JSON, default None.
+    data: JsonValue = None
+
+
+class AgentRunResult(BaseModel):
+    """Terminal result of ``itmux run`` (Rust ``AgentRunResult``)."""
+
+    model_config = _CONTRACT_CONFIG
+
+    result: AgentRunOutcome
+    # serde `PathBuf` serializes as a string; default empty list.
+    output_artifacts: list[str] = Field(default_factory=list)
+    session_log: str
+    observability: ObservabilityBundle | None = None
+
+
+class _RunEventEnvelope(BaseModel):
+    """Common envelope fields flattened onto every ``AgentRunEvent`` line."""
+
+    model_config = _CONTRACT_CONFIG
+
+    run_id: str
+    seq: int
+    ts: str
+
+
+class ToolStartEvent(_RunEventEnvelope):
+    """``type: "tool_start"`` payload."""
+
+    type: Literal["tool_start"] = "tool_start"
+    tool_name: str
+    tool_input: JsonValue = None
+
+
+class ToolEndEvent(_RunEventEnvelope):
+    """``type: "tool_end"`` payload."""
+
+    type: Literal["tool_end"] = "tool_end"
+    tool_name: str
+    success: bool = False
+    output_summary: str | None = None
+
+
+class TokenUsageEvent(_RunEventEnvelope):
+    """``type: "token_usage"`` payload."""
+
+    type: Literal["token_usage"] = "token_usage"
+    input_tokens: int
+    output_tokens: int
+    cost_usd: float | None = None
+
+
+class SessionEndEvent(_RunEventEnvelope):
+    """``type: "session_end"`` terminal lifecycle payload."""
+
+    type: Literal["session_end"] = "session_end"
+    outcome: AgentRunOutcome
+
+
+class ResultEvent(_RunEventEnvelope):
+    """``type: "result"`` final-result delivery envelope."""
+
+    type: Literal["result"] = "result"
+    result: AgentRunResult
+
+
+# Internally-tagged discriminated union on the ``type`` field, mirroring the
+# Rust ``#[serde(tag = "type")]`` enum. Pydantic uses the ``type`` discriminator
+# to pick exactly one variant, and each variant's ``extra="forbid"`` rejects any
+# stray key - the same guarantee serde's per-variant `deny_unknown_fields` gives.
+AgentRunEvent = Annotated[
+    ToolStartEvent | ToolEndEvent | TokenUsageEvent | SessionEndEvent | ResultEvent,
+    Field(discriminator="type"),
+]
+
+_EVENT_ADAPTER: TypeAdapter[AgentRunEvent] = TypeAdapter(AgentRunEvent)
+
+
+def parse_event(line: str) -> AgentRunEvent:
+    """Parse one JSONL line of ``itmux run`` stdout into a typed event.
+
+    Raises :class:`ItmuxRunError` if the line is not a valid ``AgentRunEvent``.
+    """
+    try:
+        return _EVENT_ADAPTER.validate_json(line)
+    except ValidationError as exc:
+        raise ItmuxRunError(f"unparseable itmux run event: {line!r}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Error type.
+# ---------------------------------------------------------------------------
+
+
+class ItmuxRunError(RuntimeError):
+    """Raised when an ``itmux run`` invocation fails to produce a valid result.
+
+    Covers: non-zero exit with no terminal result, unparseable stdout, a
+    missing terminal result event, and run timeout.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        returncode: int | None = None,
+        stderr: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+# ---------------------------------------------------------------------------
+# Process-group cleanup (R10).
+# ---------------------------------------------------------------------------
+
+_DEFAULT_KILL_GRACE_S = 5.0
+
+
+def _terminate_process_group(
+    proc: subprocess.Popen[str],
+    *,
+    grace_s: float = _DEFAULT_KILL_GRACE_S,
+) -> None:
+    """Signal the child's whole process group: ``SIGTERM`` then ``SIGKILL``.
+
+    The child is started with ``start_new_session=True`` so it leads its own
+    process group; signalling the group reaches the Rust process AND any
+    ``docker exec`` children it spawned, so nothing is left orphaned.
+    """
+    if proc.poll() is not None:
+        return
+    try:
+        pgid = os.getpgid(proc.pid)
+    except (ProcessLookupError, OSError):
+        return
+
+    try:
+        os.killpg(pgid, signal.SIGTERM)
+    except (ProcessLookupError, OSError):
+        return
+
+    try:
+        proc.wait(timeout=grace_s)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+
+    try:
+        os.killpg(pgid, signal.SIGKILL)
+    except (ProcessLookupError, OSError):
+        pass
+    try:
+        proc.wait(timeout=grace_s)
+    except subprocess.TimeoutExpired:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Public entry point.
+# ---------------------------------------------------------------------------
+
+
+def run_agent(
+    recipe: Path,
+    task: str,
+    *,
+    image: str | None = None,
+    itmux_bin: str = "itmux",
+    on_event: Callable[[AgentRunEvent], None] | None = None,
+    timeout: float | None = None,
+) -> AgentRunResult:
+    """Run a recipe via ``itmux run`` and return its terminal result.
+
+    Spawns ``itmux run --recipe <recipe> --task <task> [--image <image>]
+    --json true`` in its own process group, streams the stdout event JSONL,
+    invokes ``on_event`` once per parsed :data:`AgentRunEvent`, and returns the
+    :class:`AgentRunResult` carried by the terminal ``result``-payload event.
+
+    Args:
+        recipe: Path to a recipe directory (Plan A shape).
+        task: Task text handed to the recipe's default agent.
+        image: Optional container image override.
+        itmux_bin: Path or name of the ``itmux`` binary (default ``"itmux"``).
+        on_event: Optional callback invoked once per streamed event.
+        timeout: Optional wall-clock timeout (seconds) for the whole run.
+
+    Raises:
+        ItmuxRunError: on non-zero exit with no result, unparseable output,
+            a missing terminal result, or timeout.
+    """
+    argv = [itmux_bin, "run", "--recipe", str(recipe), "--task", task]
+    if image is not None:
+        argv += ["--image", image]
+    # `--json` is a clap `ArgAction::Set` bool (default true): it REQUIRES an
+    # explicit value, so pass `--json true` rather than a bare `--json` flag.
+    argv += ["--json", "true"]
+
+    # `start_new_session=True` -> os.setsid in the child: it leads a new process
+    # group so cleanup can signal the whole tree (Rust + docker exec children).
+    proc = subprocess.Popen(
+        argv,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+
+    stderr_chunks: list[str] = []
+
+    def _drain_stderr() -> None:
+        # Drain stderr concurrently so a chatty child (human logs go to stderr)
+        # can never deadlock against a full pipe while we read stdout.
+        if proc.stderr is not None:
+            for line in proc.stderr:
+                stderr_chunks.append(line)
+
+    stderr_thread = threading.Thread(target=_drain_stderr, daemon=True)
+    stderr_thread.start()
+
+    timed_out = threading.Event()
+    watchdog: threading.Timer | None = None
+    if timeout is not None:
+
+        def _on_timeout() -> None:
+            timed_out.set()
+            _terminate_process_group(proc)
+
+        watchdog = threading.Timer(timeout, _on_timeout)
+        watchdog.daemon = True
+        watchdog.start()
+
+    result: AgentRunResult | None = None
+    returncode: int = 0
+    try:
+        assert proc.stdout is not None  # PIPE is always set above
+        for raw_line in proc.stdout:
+            line = raw_line.strip()
+            if not line:
+                continue
+            event = parse_event(line)
+            if on_event is not None:
+                on_event(event)
+            if isinstance(event, ResultEvent):
+                result = event.result
+        returncode = proc.wait()
+    except BaseException:
+        # KeyboardInterrupt, timeout-driven pipe close, parse failure, or any
+        # other error: tear the whole process group down before propagating so
+        # we never leave the Rust process (or its docker children) orphaned.
+        _terminate_process_group(proc)
+        raise
+    finally:
+        if watchdog is not None:
+            watchdog.cancel()
+        if proc.poll() is None:
+            _terminate_process_group(proc)
+        stderr_thread.join(timeout=_DEFAULT_KILL_GRACE_S)
+
+    stderr_text = "".join(stderr_chunks)
+
+    if timed_out.is_set():
+        raise ItmuxRunError(
+            f"itmux run timed out after {timeout}s",
+            returncode=returncode,
+            stderr=stderr_text,
+        )
+    if result is None:
+        if returncode != 0:
+            raise ItmuxRunError(
+                f"itmux run exited with code {returncode} and produced no result",
+                returncode=returncode,
+                stderr=stderr_text,
+            )
+        raise ItmuxRunError(
+            "itmux run produced no terminal result event",
+            returncode=returncode,
+            stderr=stderr_text,
+        )
+    return result

--- a/lib/python/agentic_isolation/agentic_isolation/run_client.py
+++ b/lib/python/agentic_isolation/agentic_isolation/run_client.py
@@ -27,11 +27,20 @@ import os
 import signal
 import subprocess
 import threading
+import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, JsonValue, TypeAdapter, ValidationError
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    JsonValue,
+    StrictBool,
+    TypeAdapter,
+    ValidationError,
+)
 
 __all__ = [
     "AgentRunOutcome",
@@ -57,13 +66,19 @@ __all__ = [
 # fails loudly instead of being silently ignored.
 _CONTRACT_CONFIG = ConfigDict(frozen=True, extra="forbid")
 
+# Rust `u64` fields (schema `minimum:0`). `strict=True` refuses lax coercion
+# (e.g. the string "1" -> 1) so malformed lines are rejected exactly as serde
+# would reject them; `ge=0` enforces the unsigned lower bound. `bool` fields use
+# `StrictBool` so the string "false" is rejected rather than coerced to a bool.
+_U64 = Annotated[int, Field(strict=True, ge=0)]
+
 
 class AgentRunOutcome(BaseModel):
     """The success/failure verdict for a run (Rust ``AgentRunOutcome``)."""
 
     model_config = _CONTRACT_CONFIG
 
-    success: bool
+    success: StrictBool
     summary: str
 
 
@@ -95,7 +110,7 @@ class _RunEventEnvelope(BaseModel):
     model_config = _CONTRACT_CONFIG
 
     run_id: str
-    seq: int
+    seq: _U64
     ts: str
 
 
@@ -112,7 +127,7 @@ class ToolEndEvent(_RunEventEnvelope):
 
     type: Literal["tool_end"] = "tool_end"
     tool_name: str
-    success: bool = False
+    success: StrictBool = False
     output_summary: str | None = None
 
 
@@ -120,8 +135,8 @@ class TokenUsageEvent(_RunEventEnvelope):
     """``type: "token_usage"`` payload."""
 
     type: Literal["token_usage"] = "token_usage"
-    input_tokens: int
-    output_tokens: int
+    input_tokens: _U64
+    output_tokens: _U64
     cost_usd: float | None = None
 
 
@@ -191,6 +206,29 @@ class ItmuxRunError(RuntimeError):
 # ---------------------------------------------------------------------------
 
 _DEFAULT_KILL_GRACE_S = 5.0
+_GROUP_POLL_INTERVAL_S = 0.02
+
+
+def _killpg_quiet(pgid: int, sig: int) -> bool:
+    """Signal a process group, swallowing "already gone" errors.
+
+    Returns ``True`` if the signal was delivered (group still existed),
+    ``False`` if the group was already gone or the call was rejected.
+    """
+    try:
+        os.killpg(pgid, sig)
+        return True
+    except (ProcessLookupError, OSError):
+        return False
+
+
+def _group_alive(pgid: int) -> bool:
+    """True while ANY process (including an unreaped zombie) remains in the group.
+
+    Uses signal ``0`` as an existence probe - it delivers nothing but raises
+    ``ProcessLookupError`` once the group is empty.
+    """
+    return _killpg_quiet(pgid, 0)
 
 
 def _terminate_process_group(
@@ -198,38 +236,69 @@ def _terminate_process_group(
     *,
     grace_s: float = _DEFAULT_KILL_GRACE_S,
 ) -> None:
-    """Signal the child's whole process group: ``SIGTERM`` then ``SIGKILL``.
+    """Tear the child's whole process group down, kill-before-reap.
 
     The child is started with ``start_new_session=True`` so it leads its own
-    process group; signalling the group reaches the Rust process AND any
-    ``docker exec`` children it spawned, so nothing is left orphaned.
+    process group whose pgid equals the leader pid. Signalling the group reaches
+    the Rust process AND any ``docker exec`` grandchildren it spawned.
+
+    Ordering (codex must-fix 1+2):
+
+    1. ``SIGTERM`` the whole group FIRST so the Rust leader can run its own
+       graceful container teardown; a premature ``SIGKILL`` would orphan the
+       docker CONTAINER (the orchestrator tears it down on graceful signals,
+       see #248).
+    2. Wait a bounded grace period, polling for the *group* to drain - not
+       ``proc.wait()`` on the leader alone, which would both block escalation
+       and miss a grandchild that outlives the leader.
+    3. ``SIGKILL`` the group to reap any survivor (the leader may already be
+       gone while a docker-exec grandchild lingers).
+    4. ONLY THEN reap the leader zombie.
+
+    PID-reuse safety: we never signal a group we have already reaped. Once the
+    leader is reaped its returncode is set, so an early-return guard prevents a
+    late watchdog from ``killpg``-ing a possibly-recycled pgid; and step 3 only
+    fires while the group is still non-empty (which reserves the pgid).
     """
-    if proc.poll() is not None:
-        return
-    try:
-        pgid = os.getpgid(proc.pid)
-    except (ProcessLookupError, OSError):
+    # Guard: if the leader has already been reaped, its pgid may have been
+    # recycled by the kernel - never signal it again.
+    if proc.returncode is not None:
         return
 
-    try:
-        os.killpg(pgid, signal.SIGTERM)
-    except (ProcessLookupError, OSError):
+    # start_new_session=True guarantees pgid == leader pid.
+    pgid = proc.pid
+
+    # 1. Graceful group termination first.
+    _killpg_quiet(pgid, signal.SIGTERM)
+
+    # 2. Bounded grace: let the leader exit gracefully and the group drain.
+    deadline = time.monotonic() + grace_s
+    escalate = True
+    while time.monotonic() < deadline:
+        # poll() reaps the leader zombie the instant it exits.
+        proc.poll()
+        if proc.returncode is not None:
+            # Leader gone. If no descendants remain the group has fully drained
+            # and its pgid may now be recycled - stop without signalling again.
+            if not _group_alive(pgid):
+                escalate = False
+            break
+        time.sleep(_GROUP_POLL_INTERVAL_S)
+
+    if not escalate:
         return
 
-    try:
-        proc.wait(timeout=grace_s)
-        return
-    except subprocess.TimeoutExpired:
-        pass
+    # 3. Force-kill any survivor (grace expired with the leader alive, or the
+    #    leader exited but a grandchild is still holding the group open). The
+    #    group is still non-empty here, so its pgid is still reserved to us.
+    _killpg_quiet(pgid, signal.SIGKILL)
 
-    try:
-        os.killpg(pgid, signal.SIGKILL)
-    except (ProcessLookupError, OSError):
-        pass
-    try:
-        proc.wait(timeout=grace_s)
-    except subprocess.TimeoutExpired:
-        pass
+    # 4. Reap the leader zombie if we have not already.
+    if proc.returncode is None:
+        try:
+            proc.wait(timeout=grace_s)
+        except subprocess.TimeoutExpired:
+            pass
 
 
 # ---------------------------------------------------------------------------
@@ -307,7 +376,6 @@ def run_agent(
         watchdog.start()
 
     result: AgentRunResult | None = None
-    returncode: int = 0
     try:
         assert proc.stdout is not None  # PIPE is always set above
         for raw_line in proc.stdout:
@@ -319,38 +387,45 @@ def run_agent(
                 on_event(event)
             if isinstance(event, ResultEvent):
                 result = event.result
-        returncode = proc.wait()
-    except BaseException:
-        # KeyboardInterrupt, timeout-driven pipe close, parse failure, or any
-        # other error: tear the whole process group down before propagating so
-        # we never leave the Rust process (or its docker children) orphaned.
-        _terminate_process_group(proc)
-        raise
+                # The Rust contract guarantees the process exits after the
+                # terminal result event. We break rather than draining to EOF so
+                # a child that emits the result then hangs cannot block us when
+                # `timeout` is None - liveness must not depend on that guarantee.
+                break
     finally:
         if watchdog is not None:
             watchdog.cancel()
-        if proc.poll() is None:
-            _terminate_process_group(proc)
+        # Kill-before-reap (codex must-fix 1+2): tear the whole process group
+        # down BEFORE reaping the leader, so a surviving docker-exec grandchild
+        # is killed even when the Rust leader has already exited. Runs on every
+        # exit path - normal return, timeout, parse error, KeyboardInterrupt.
+        _terminate_process_group(proc)
+        # Join the stderr drain only AFTER the group is dead - otherwise a
+        # surviving grandchild holding the stderr pipe could block the join.
         stderr_thread.join(timeout=_DEFAULT_KILL_GRACE_S)
 
+    returncode = proc.returncode
     stderr_text = "".join(stderr_chunks)
 
+    # Result wins over a simultaneous timeout (Claude nit 1): if a valid terminal
+    # result was delivered, return it even if the watchdog fired in the same
+    # instant. Only treat the run as timed out / failed when there is no result.
+    if result is not None:
+        return result
     if timed_out.is_set():
         raise ItmuxRunError(
             f"itmux run timed out after {timeout}s",
             returncode=returncode,
             stderr=stderr_text,
         )
-    if result is None:
-        if returncode != 0:
-            raise ItmuxRunError(
-                f"itmux run exited with code {returncode} and produced no result",
-                returncode=returncode,
-                stderr=stderr_text,
-            )
+    if returncode is not None and returncode != 0:
         raise ItmuxRunError(
-            "itmux run produced no terminal result event",
+            f"itmux run exited with code {returncode} and produced no result",
             returncode=returncode,
             stderr=stderr_text,
         )
-    return result
+    raise ItmuxRunError(
+        "itmux run produced no terminal result event",
+        returncode=returncode,
+        stderr=stderr_text,
+    )

--- a/lib/python/agentic_isolation/pyproject.toml
+++ b/lib/python/agentic_isolation/pyproject.toml
@@ -62,6 +62,7 @@ python_version = "3.10"
 strict = true
 warn_return_any = true
 warn_unused_ignores = true
+plugins = ["pydantic.mypy"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/lib/python/agentic_isolation/tests/test_run_client.py
+++ b/lib/python/agentic_isolation/tests/test_run_client.py
@@ -17,8 +17,10 @@ from pathlib import Path
 
 import pytest
 
+from agentic_isolation import run_client
 from agentic_isolation.run_client import (
     _EVENT_ADAPTER,
+    AgentRunEvent,
     AgentRunResult,
     ItmuxRunError,
     ResultEvent,
@@ -30,6 +32,20 @@ from agentic_isolation.run_client import (
     parse_event,
     run_agent,
 )
+
+
+@pytest.fixture(autouse=True)
+def _fast_teardown(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Shrink the teardown grace so no-result / timeout tests stay fast.
+
+    Production defaults (5s crash grace, 0.5s post-result grace) are correct but
+    slow to sit through in every subprocess test. `run_agent` reads these as
+    module globals at call time, so patching them here takes effect without
+    changing behavior under test.
+    """
+    monkeypatch.setattr(run_client, "_DEFAULT_KILL_GRACE_S", 0.3)
+    monkeypatch.setattr(run_client, "_RESULT_TEARDOWN_GRACE_S", 0.1)
+
 
 # ---------------------------------------------------------------------------
 # Canned event stream mirroring the Rust contract wire shape.
@@ -436,20 +452,38 @@ def test_run_agent_reaps_grandchild_when_leader_exits_first(tmp_path: Path) -> N
 
 
 def test_run_agent_result_wins_over_simultaneous_timeout(tmp_path: Path) -> None:
-    # A run that delivers a valid result must return it even if the wall-clock
-    # timeout fires in the same instant (Claude nit 1). Emit the result, then
-    # sleep past the tiny timeout so the watchdog fires while we hold a result.
+    # A run that delivers a valid result must return it even when the wall-clock
+    # timeout has fired (Claude nit 1). Deterministic: an on_event callback that
+    # blocks on the ResultEvent lets the watchdog fire (setting timed_out and
+    # tearing the group down) WHILE run_agent already holds the parsed result -
+    # so both `timed_out.is_set()` and a non-None result are true at decision
+    # time, and the result must win.
     body = (
-        "import sys, time\n"
+        "import sys\n"
         'print(\'{"run_id": "r", "seq": 0, "ts": "t", "type": "result", '
         '"result": {"result": {"success": true, "summary": "ok"}, '
         '"session_log": "x"}}\')\n'
         "sys.stdout.flush()\n"
-        "time.sleep(30)\n"  # outlive the timeout; result was already delivered
+        "sys.exit(0)\n"
     )
     fake = _write_fake_itmux(tmp_path, body)
 
-    result = run_agent(Path("/recipes/demo"), "task", itmux_bin=str(fake), timeout=0.3)
+    def block_on_result(event: AgentRunEvent) -> None:
+        if isinstance(event, ResultEvent):
+            # Block well past the timeout so the watchdog fires (and tears the
+            # group down) while run_agent already holds the parsed result.
+            time.sleep(1.0)
+
+    # timeout comfortably exceeds the fake's process startup so the result line
+    # is always read first; the long on_event block is what makes the watchdog
+    # fire afterwards, deterministically.
+    result = run_agent(
+        Path("/recipes/demo"),
+        "task",
+        itmux_bin=str(fake),
+        on_event=block_on_result,
+        timeout=0.5,
+    )
     assert result.result.summary == "ok"
 
 

--- a/lib/python/agentic_isolation/tests/test_run_client.py
+++ b/lib/python/agentic_isolation/tests/test_run_client.py
@@ -172,6 +172,51 @@ def test_optional_defaults_match_contract() -> None:
     assert event.output_summary is None
 
 
+@pytest.mark.parametrize(
+    "line",
+    [
+        # seq is u64 (schema minimum:0) - a negative value must be rejected.
+        json.dumps({"run_id": "r", "seq": -1, "ts": "t", "type": "tool_start", "tool_name": "B"}),
+        # input_tokens is u64 - a string must NOT be coerced (serde would reject it).
+        json.dumps(
+            {
+                "run_id": "r",
+                "seq": 0,
+                "ts": "t",
+                "type": "token_usage",
+                "input_tokens": "1",
+                "output_tokens": 2,
+            }
+        ),
+        # output_tokens is u64 - a negative value must be rejected.
+        json.dumps(
+            {
+                "run_id": "r",
+                "seq": 0,
+                "ts": "t",
+                "type": "token_usage",
+                "input_tokens": 1,
+                "output_tokens": -2,
+            }
+        ),
+        # success is bool - a string must NOT be coerced.
+        json.dumps(
+            {
+                "run_id": "r",
+                "seq": 0,
+                "ts": "t",
+                "type": "tool_end",
+                "tool_name": "B",
+                "success": "false",
+            }
+        ),
+    ],
+)
+def test_parse_event_rejects_malformed_scalar(line: str) -> None:
+    with pytest.raises(ItmuxRunError):
+        parse_event(line)
+
+
 # ---------------------------------------------------------------------------
 # run_agent happy path.
 # ---------------------------------------------------------------------------
@@ -296,6 +341,35 @@ def test_terminate_process_group_signals_pgid(monkeypatch: pytest.MonkeyPatch) -
         proc.wait(timeout=5)
 
 
+def _process_running(pid: int) -> bool:
+    """True only if ``pid`` is a *live* (non-zombie) process.
+
+    ``os.kill(pid, 0)`` is unusable here: it succeeds for a zombie (killed but
+    not yet reaped), so it would call a dead-but-unreaped process "alive". We
+    instead read the process state via ``ps``; a missing process or a zombie
+    (state ``Z``) counts as not running.
+    """
+    proc = subprocess.run(
+        ["ps", "-p", str(pid), "-o", "state="],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return False  # no such process
+    state = proc.stdout.strip()
+    return state != "" and not state.startswith("Z")
+
+
+def _wait_until_dead(pid: int, timeout_s: float = 5.0) -> bool:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if not _process_running(pid):
+            return True
+        time.sleep(0.05)
+    return not _process_running(pid)
+
+
 @pytest.mark.skipif(os.name != "posix", reason="process groups are POSIX-only")
 def test_run_agent_timeout_reaps_child_tree(tmp_path: Path) -> None:
     # Fake emits one event, spawns a long-lived grandchild recording its PID,
@@ -316,19 +390,85 @@ def test_run_agent_timeout_reaps_child_tree(tmp_path: Path) -> None:
     with pytest.raises(ItmuxRunError, match="timed out"):
         run_agent(Path("/recipes/demo"), "task", itmux_bin=str(fake), timeout=1.0)
 
-    # Give the group signal a moment to land.
-    deadline = time.time() + 5.0
     grandchild_pid = int(pid_file.read_text().strip())
-    while time.time() < deadline:
-        try:
-            os.kill(grandchild_pid, 0)
-        except ProcessLookupError:
-            break  # reaped - success
-        time.sleep(0.05)
-    else:
-        # Still alive: clean up so we don't leak, then fail.
+    dead = _wait_until_dead(grandchild_pid)
+    if not dead:
         try:
             os.kill(grandchild_pid, signal.SIGKILL)
         except ProcessLookupError:
             pass
-        pytest.fail("grandchild process was orphaned (not reaped by group cleanup)")
+    assert dead, "grandchild process was orphaned (not reaped by group cleanup)"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="process groups are POSIX-only")
+def test_run_agent_reaps_grandchild_when_leader_exits_first(tmp_path: Path) -> None:
+    # Root cause of codex must-fix 1+2: the leader exits 0 immediately, but a
+    # grandchild survives it (double-fork'd out of the leader's lifetime).
+    # Because the leader is gone, a poll()-short-circuit would skip the group
+    # kill and leak the grandchild. Kill-before-reap must still tear it down.
+    pid_file = tmp_path / "grandchild.pid"
+    body = (
+        "import os, sys, subprocess\n"
+        # Spawn a grandchild that outlives the leader, holding stdout open.
+        "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)'])\n"
+        f"open({str(pid_file)!r}, 'w').write(str(child.pid))\n"
+        # Emit a valid result so run_agent returns normally, then exit 0 while
+        # the grandchild keeps sleeping.
+        'print(\'{"run_id": "r", "seq": 0, "ts": "t", "type": "result", '
+        '"result": {"result": {"success": true, "summary": "ok"}, '
+        '"session_log": "x"}}\')\n'
+        "sys.stdout.flush()\n"
+        "sys.exit(0)\n"
+    )
+    fake = _write_fake_itmux(tmp_path, body)
+
+    result = run_agent(Path("/recipes/demo"), "task", itmux_bin=str(fake))
+    assert result.result.success is True
+
+    grandchild_pid = int(pid_file.read_text().strip())
+    dead = _wait_until_dead(grandchild_pid)
+    if not dead:
+        try:
+            os.kill(grandchild_pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    assert dead, "grandchild survived the leader and was leaked"
+
+
+def test_run_agent_result_wins_over_simultaneous_timeout(tmp_path: Path) -> None:
+    # A run that delivers a valid result must return it even if the wall-clock
+    # timeout fires in the same instant (Claude nit 1). Emit the result, then
+    # sleep past the tiny timeout so the watchdog fires while we hold a result.
+    body = (
+        "import sys, time\n"
+        'print(\'{"run_id": "r", "seq": 0, "ts": "t", "type": "result", '
+        '"result": {"result": {"success": true, "summary": "ok"}, '
+        '"session_log": "x"}}\')\n'
+        "sys.stdout.flush()\n"
+        "time.sleep(30)\n"  # outlive the timeout; result was already delivered
+    )
+    fake = _write_fake_itmux(tmp_path, body)
+
+    result = run_agent(Path("/recipes/demo"), "task", itmux_bin=str(fake), timeout=0.3)
+    assert result.result.summary == "ok"
+
+
+def test_run_agent_breaks_on_result_without_waiting_for_eof(tmp_path: Path) -> None:
+    # timeout=None (default): a child that emits the result then hangs forever
+    # must not block run_agent - it breaks on the terminal ResultEvent (Claude
+    # nit 2). A generous test-level guard proves we do not hang to EOF.
+    body = (
+        "import sys, time\n"
+        'print(\'{"run_id": "r", "seq": 0, "ts": "t", "type": "result", '
+        '"result": {"result": {"success": true, "summary": "ok"}, '
+        '"session_log": "x"}}\')\n'
+        "sys.stdout.flush()\n"
+        "time.sleep(60)\n"  # hang: EOF never arrives
+    )
+    fake = _write_fake_itmux(tmp_path, body)
+
+    start = time.time()
+    result = run_agent(Path("/recipes/demo"), "task", itmux_bin=str(fake))
+    elapsed = time.time() - start
+    assert result.result.summary == "ok"
+    assert elapsed < 30, f"run_agent blocked waiting for EOF ({elapsed:.1f}s)"

--- a/lib/python/agentic_isolation/tests/test_run_client.py
+++ b/lib/python/agentic_isolation/tests/test_run_client.py
@@ -1,0 +1,334 @@
+"""Tests for the thin ``itmux run`` Python client (Plan B, Task 7).
+
+No real docker and no real ``itmux`` binary are required: every subprocess test
+drives a FAKE ``itmux`` (a tiny Python script on disk) whose path is passed as
+``itmux_bin``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from agentic_isolation.run_client import (
+    _EVENT_ADAPTER,
+    AgentRunResult,
+    ItmuxRunError,
+    ResultEvent,
+    SessionEndEvent,
+    TokenUsageEvent,
+    ToolEndEvent,
+    ToolStartEvent,
+    _terminate_process_group,
+    parse_event,
+    run_agent,
+)
+
+# ---------------------------------------------------------------------------
+# Canned event stream mirroring the Rust contract wire shape.
+# ---------------------------------------------------------------------------
+
+_RESULT_PAYLOAD = {
+    "result": {"success": True, "summary": "done"},
+    "output_artifacts": ["/work/out.txt"],
+    "session_log": "pane transcript",
+    "observability": None,
+}
+
+_EVENT_LINES: list[str] = [
+    json.dumps(
+        {
+            "run_id": "r1",
+            "seq": 0,
+            "ts": "2026-07-07T00:00:00Z",
+            "type": "tool_start",
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls"},
+        }
+    ),
+    json.dumps(
+        {
+            "run_id": "r1",
+            "seq": 1,
+            "ts": "2026-07-07T00:00:01Z",
+            "type": "tool_end",
+            "tool_name": "Bash",
+            "success": True,
+            "output_summary": "ok",
+        }
+    ),
+    json.dumps(
+        {
+            "run_id": "r1",
+            "seq": 2,
+            "ts": "2026-07-07T00:00:02Z",
+            "type": "token_usage",
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cost_usd": 0.01,
+        }
+    ),
+    json.dumps(
+        {
+            "run_id": "r1",
+            "seq": 3,
+            "ts": "2026-07-07T00:00:03Z",
+            "type": "session_end",
+            "outcome": {"success": True, "summary": "done"},
+        }
+    ),
+    json.dumps(
+        {
+            "run_id": "r1",
+            "seq": 4,
+            "ts": "2026-07-07T00:00:04Z",
+            "type": "result",
+            "result": _RESULT_PAYLOAD,
+        }
+    ),
+]
+
+
+def _write_fake_itmux(tmp_path: Path, body: str) -> Path:
+    """Write an executable fake ``itmux`` Python script and return its path."""
+    script = tmp_path / "fake_itmux"
+    script.write_text("#!/usr/bin/env python3\n" + body)
+    script.chmod(0o755)
+    return script
+
+
+# ---------------------------------------------------------------------------
+# Model / discriminated-union parsing.
+# ---------------------------------------------------------------------------
+
+
+def test_parse_event_discriminates_each_variant() -> None:
+    events = [parse_event(line) for line in _EVENT_LINES]
+    assert isinstance(events[0], ToolStartEvent)
+    assert isinstance(events[1], ToolEndEvent)
+    assert isinstance(events[2], TokenUsageEvent)
+    assert isinstance(events[3], SessionEndEvent)
+    assert isinstance(events[4], ResultEvent)
+
+    # Field names mirror the Rust serde names exactly.
+    assert events[0].tool_name == "Bash"
+    assert events[0].tool_input == {"command": "ls"}
+    assert events[2].input_tokens == 100
+    assert events[2].output_tokens == 50
+    assert events[2].cost_usd == pytest.approx(0.01)
+    assert events[3].outcome.success is True
+
+    result_event = events[4]
+    assert isinstance(result_event, ResultEvent)
+    assert result_event.result.result.summary == "done"
+    assert result_event.result.output_artifacts == ["/work/out.txt"]
+    assert result_event.result.session_log == "pane transcript"
+
+
+def test_parse_event_rejects_unknown_field() -> None:
+    bad = json.dumps(
+        {
+            "run_id": "r1",
+            "seq": 0,
+            "ts": "t",
+            "type": "tool_start",
+            "tool_name": "Bash",
+            "surprise": 1,
+        }
+    )
+    with pytest.raises(ItmuxRunError):
+        parse_event(bad)
+
+
+def test_parse_event_rejects_unknown_discriminator() -> None:
+    bad = json.dumps({"run_id": "r1", "seq": 0, "ts": "t", "type": "nope"})
+    with pytest.raises(ItmuxRunError):
+        parse_event(bad)
+
+
+def test_result_model_rejects_unknown_field() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        AgentRunResult.model_validate(
+            {"result": {"success": True, "summary": "s"}, "session_log": "l", "extra": 1}
+        )
+
+
+def test_optional_defaults_match_contract() -> None:
+    line = json.dumps(
+        {"run_id": "r1", "seq": 0, "ts": "t", "type": "tool_end", "tool_name": "Read"}
+    )
+    event = _EVENT_ADAPTER.validate_json(line)
+    assert isinstance(event, ToolEndEvent)
+    assert event.success is False  # serde default
+    assert event.output_summary is None
+
+
+# ---------------------------------------------------------------------------
+# run_agent happy path.
+# ---------------------------------------------------------------------------
+
+
+def test_run_agent_returns_result_and_streams_events(tmp_path: Path) -> None:
+    lines_literal = json.dumps(_EVENT_LINES)
+    body = (
+        "import sys\n"
+        f"for line in {lines_literal}:\n"
+        "    print(line)\n"
+        "    sys.stdout.flush()\n"
+        "sys.exit(0)\n"
+    )
+    fake = _write_fake_itmux(tmp_path, body)
+
+    seen: list[object] = []
+    result = run_agent(
+        Path("/recipes/demo"),
+        "do the thing",
+        itmux_bin=str(fake),
+        on_event=seen.append,
+    )
+
+    assert isinstance(result, AgentRunResult)
+    assert result.result.success is True
+    assert result.result.summary == "done"
+    assert result.output_artifacts == ["/work/out.txt"]
+    # on_event fires once per streamed event, including the terminal result.
+    assert len(seen) == len(_EVENT_LINES)
+    assert isinstance(seen[-1], ResultEvent)
+
+
+def test_run_agent_passes_expected_argv(tmp_path: Path) -> None:
+    # Fake echoes its argv (as a session_log) so we can assert the built command.
+    result_payload = dict(_RESULT_PAYLOAD)
+    body = (
+        "import sys, json\n"
+        "argv = sys.argv[1:]\n"
+        "payload = {'result': {'success': True, 'summary': ' '.join(argv)},\n"
+        "           'session_log': 'x'}\n"
+        "print(json.dumps({'run_id': 'r', 'seq': 0, 'ts': 't', 'type': 'result',\n"
+        "                  'result': payload}))\n"
+    )
+    del result_payload  # not needed; kept for clarity
+    fake = _write_fake_itmux(tmp_path, body)
+
+    result = run_agent(
+        Path("/recipes/demo"),
+        "my task",
+        image="custom:tag",
+        itmux_bin=str(fake),
+    )
+    argv_summary = result.result.summary
+    assert "run --recipe /recipes/demo --task my task" in argv_summary
+    assert "--image custom:tag" in argv_summary
+    assert "--json true" in argv_summary
+
+
+# ---------------------------------------------------------------------------
+# run_agent failure paths.
+# ---------------------------------------------------------------------------
+
+
+def test_run_agent_nonzero_exit_no_result_raises(tmp_path: Path) -> None:
+    body = "import sys\nprint('boom: recipe failed to load', file=sys.stderr)\nsys.exit(1)\n"
+    fake = _write_fake_itmux(tmp_path, body)
+
+    with pytest.raises(ItmuxRunError) as exc_info:
+        run_agent(Path("/recipes/demo"), "task", itmux_bin=str(fake))
+    assert exc_info.value.returncode == 1
+    assert "boom" in (exc_info.value.stderr or "")
+
+
+def test_run_agent_zero_exit_no_result_raises(tmp_path: Path) -> None:
+    body = "import sys\nsys.exit(0)\n"  # no events at all
+    fake = _write_fake_itmux(tmp_path, body)
+
+    with pytest.raises(ItmuxRunError, match="no terminal result"):
+        run_agent(Path("/recipes/demo"), "task", itmux_bin=str(fake))
+
+
+def test_run_agent_unparseable_output_raises(tmp_path: Path) -> None:
+    body = "print('not json at all')\n"
+    fake = _write_fake_itmux(tmp_path, body)
+
+    with pytest.raises(ItmuxRunError, match="unparseable"):
+        run_agent(Path("/recipes/demo"), "task", itmux_bin=str(fake))
+
+
+# ---------------------------------------------------------------------------
+# Process-group cleanup (R10).
+# ---------------------------------------------------------------------------
+
+
+def test_terminate_process_group_signals_pgid(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Spawn a real child in its own session/group so os.getpgid works, then
+    # monkeypatch os.killpg to record the signals sent instead of delivering.
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+        start_new_session=True,
+        text=True,
+    )
+    try:
+        expected_pgid = os.getpgid(proc.pid)
+        calls: list[tuple[int, int]] = []
+        monkeypatch.setattr(os, "killpg", lambda pgid, sig: calls.append((pgid, sig)))
+
+        # grace 0.1 so the SIGTERM->SIGKILL escalation is fast (killpg is faked,
+        # so the child never actually dies during the call).
+        _terminate_process_group(proc, grace_s=0.1)
+
+        assert (expected_pgid, signal.SIGTERM) in calls
+        assert (expected_pgid, signal.SIGKILL) in calls
+    finally:
+        # Undo the killpg patch BEFORE real cleanup so the child actually dies.
+        monkeypatch.undo()
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except (ProcessLookupError, OSError):
+            pass
+        proc.wait(timeout=5)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="process groups are POSIX-only")
+def test_run_agent_timeout_reaps_child_tree(tmp_path: Path) -> None:
+    # Fake emits one event, spawns a long-lived grandchild recording its PID,
+    # then blocks forever WITHOUT emitting a result. run_agent's timeout must
+    # kill the whole process group and leave no orphan.
+    pid_file = tmp_path / "grandchild.pid"
+    body = (
+        "import os, sys, time, subprocess\n"
+        'print(\'{"run_id": "r", "seq": 0, "ts": "t", '
+        '"type": "tool_start", "tool_name": "Bash"}\')\n'
+        "sys.stdout.flush()\n"
+        "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)'])\n"
+        f"open({str(pid_file)!r}, 'w').write(str(child.pid))\n"
+        "time.sleep(60)\n"
+    )
+    fake = _write_fake_itmux(tmp_path, body)
+
+    with pytest.raises(ItmuxRunError, match="timed out"):
+        run_agent(Path("/recipes/demo"), "task", itmux_bin=str(fake), timeout=1.0)
+
+    # Give the group signal a moment to land.
+    deadline = time.time() + 5.0
+    grandchild_pid = int(pid_file.read_text().strip())
+    while time.time() < deadline:
+        try:
+            os.kill(grandchild_pid, 0)
+        except ProcessLookupError:
+            break  # reaped - success
+        time.sleep(0.05)
+    else:
+        # Still alive: clean up so we don't leak, then fail.
+        try:
+            os.kill(grandchild_pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        pytest.fail("grandchild process was orphaned (not reaped by group cleanup)")


### PR DESCRIPTION
Plan B Task 7. A thin Python `run_agent` that shells out to the Rust `itmux run` binary and parses its `AgentRunEvent` JSONL + `AgentRunResult`. Owns NO orchestration - the Rust binary owns the whole provision->stop lifecycle. This is the syn137-facing half of the Rust contract migration; **supersedes the Python orchestrator/contract in #240** (which will be closed once this + #247 land). Stacked on #247.

## Surface
```python
def run_agent(recipe, task, *, image=None, itmux_bin="itmux",
              on_event=None, timeout=None) -> AgentRunResult
```
Builds `itmux run --recipe <r> --task <t> [--image <i>] --json true`, streams stdout JSONL, fires `on_event` per event, returns the result from the `Result`-payload event. Raises `ItmuxRunError` (carrying returncode/stderr) on non-zero-exit-no-result, unparseable output, missing terminal result, or timeout.

## Contract parity
Pydantic v2 discriminated union: `AgentRunEvent = Annotated[ToolStart | ToolEnd | TokenUsage | SessionEnd | Result, Field(discriminator="type")]`, each variant frozen + `extra="forbid"`, serde field names matched exactly. This mirrors the Rust `#[serde(tag="type", deny_unknown_fields)]` behaviorally: discriminator picks the variant, per-variant forbid rejects stray keys.

## Process-group cleanup (R10)
Child spawned `start_new_session=True` (leads its own group). On KeyboardInterrupt / parse failure / timeout, `os.killpg(pgid, SIGTERM)` -> grace -> `os.killpg(pgid, SIGKILL)` reaches the Rust process AND its `docker exec` grandchildren. `try/except BaseException` tears down before re-raise; `finally` kills any survivor + joins a stderr-drain thread (no deadlock on a full stderr pipe); a `threading.Timer` enforces `timeout`.

## Tests: 12, all pass
Model discrimination + unknown-field rejection (incl. Result line + unknown discriminator); happy-path result + per-event on_event; argv construction; the 3 error paths; a killpg-pgid monkeypatch unit test (SIGTERM + SIGKILL); a real orphan-reaping test (fake spawns a grandchild, blocks, timeout fires, grandchild confirmed dead). All fakes are on-disk stubs via `itmux_bin` - no real docker/itmux.

## Reviewer note
- Adds `pydantic>=2` (+ pydantic.mypy plugin) to a previously **zero-dep** package - deliberate, per the task's Pydantic-v2 mandate and for serde parity. Flagging given the minimize-deps preference; the dep-free alternative is dataclasses + hand-rolled tag dispatch (loses the extra="forbid" parity).
- `--json true` (not bare `--json`) - the clap arg is `ArgAction::Set` and requires a value.

Gates: pytest 12/12, ruff check + format clean, mypy --strict clean (no Any). Tracks okrs-o78.