### PR TITLE
feat(itmux): .env credential loading for itmux run (fixes the stale-token 401)

### DIFF
--- a/lib/python/agentic_isolation/agentic_isolation/run_client.py
+++ b/lib/python/agentic_isolation/agentic_isolation/run_client.py
@@ -26,9 +26,12 @@ from __future__ import annotations
 import os
 import signal
 import subprocess
+import tempfile
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated, Literal
 
@@ -53,8 +56,70 @@ __all__ = [
     "ResultEvent",
     "AgentRunEvent",
     "ItmuxRunError",
+    "ItmuxRunRequest",
+    "build_run_argv",
     "run_agent",
 ]
+
+
+_ALLOWED_SECRET_KEYS: frozenset[str] = frozenset(
+    {"CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "CODEX_AUTH_FILE"}
+)
+
+
+@dataclass(frozen=True)
+class ItmuxRunRequest:
+    """Credential-safe input for building an ``itmux run`` command."""
+
+    recipe: Path
+    task: str
+    image: str | None = None
+    env_file: Path | None = None
+    credentials: Mapping[str, str] | None = None
+    allow_host_auth_fallback: bool = False
+
+
+def build_run_argv(request: ItmuxRunRequest, *, binary: str = "itmux") -> list[str]:
+    """Build argv without placing credential values in it."""
+
+    argv = [binary, "run", "--recipe", str(request.recipe), "--task", request.task]
+    if request.image is not None:
+        argv += ["--image", request.image]
+    if request.env_file is not None:
+        argv += ["--env-file", str(request.env_file)]
+    if request.allow_host_auth_fallback:
+        argv.append("--allow-host-auth-fallback")
+    argv += ["--json", "true"]
+    return argv
+
+
+def _render_env_file(credentials: Mapping[str, str]) -> str:
+    """Render allowlisted credentials as a shell-compatible private env file."""
+
+    lines: list[str] = []
+    for key, value in credentials.items():
+        if key in _ALLOWED_SECRET_KEYS:
+            escaped = value.replace("'", "'\\\\''")
+            lines.append(f"{key}='{escaped}'")
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+@contextmanager
+def _materialized_env_file(credentials: Mapping[str, str]) -> Iterator[Path]:
+    """Materialize credentials to a 0600 file and remove it after the run."""
+
+    fd, name = tempfile.mkstemp(prefix="itmux-run-creds-", suffix=".env")
+    path = Path(name)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(_render_env_file(credentials))
+        yield path
+    finally:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
 
 
 # ---------------------------------------------------------------------------
@@ -308,6 +373,9 @@ def run_agent(
     itmux_bin: str = "itmux",
     on_event: Callable[[AgentRunEvent], None] | None = None,
     timeout: float | None = None,
+    env_file: Path | None = None,
+    credentials: Mapping[str, str] | None = None,
+    allow_host_auth_fallback: bool = False,
 ) -> AgentRunResult:
     """Run a recipe via ``itmux run`` and return its terminal result.
 
@@ -328,12 +396,31 @@ def run_agent(
         ItmuxRunError: on non-zero exit with no result, unparseable output,
             a missing terminal result, or timeout.
     """
-    argv = [itmux_bin, "run", "--recipe", str(recipe), "--task", task]
-    if image is not None:
-        argv += ["--image", image]
-    # `--json` is a clap `ArgAction::Set` bool (default true): it REQUIRES an
-    # explicit value, so pass `--json true` rather than a bare `--json` flag.
-    argv += ["--json", "true"]
+    if credentials is not None and env_file is not None:
+        raise ValueError("set only one of env_file or credentials")
+    if credentials is not None:
+        with _materialized_env_file(credentials) as materialized:
+            return run_agent(
+                recipe,
+                task,
+                image=image,
+                itmux_bin=itmux_bin,
+                on_event=on_event,
+                timeout=timeout,
+                env_file=materialized,
+                allow_host_auth_fallback=allow_host_auth_fallback,
+            )
+
+    argv = build_run_argv(
+        ItmuxRunRequest(
+            recipe=recipe,
+            task=task,
+            image=image,
+            env_file=env_file,
+            allow_host_auth_fallback=allow_host_auth_fallback,
+        ),
+        binary=itmux_bin,
+    )
 
     # `start_new_session=True` -> os.setsid in the child: it leads a new process
     # group so cleanup can signal the whole tree (Rust + docker exec children).

--- a/lib/python/agentic_isolation/tests/test_run_client.py
+++ b/lib/python/agentic_isolation/tests/test_run_client.py
@@ -23,12 +23,16 @@ from agentic_isolation.run_client import (
     AgentRunEvent,
     AgentRunResult,
     ItmuxRunError,
+    ItmuxRunRequest,
     ResultEvent,
     SessionEndEvent,
     TokenUsageEvent,
     ToolEndEvent,
     ToolStartEvent,
+    _materialized_env_file,
+    _render_env_file,
     _terminate_process_group,
+    build_run_argv,
     parse_event,
     run_agent,
 )
@@ -506,3 +510,34 @@ def test_run_agent_breaks_on_result_without_waiting_for_eof(tmp_path: Path) -> N
     elapsed = time.time() - start
     assert result.result.summary == "ok"
     assert elapsed < 30, f"run_agent blocked waiting for EOF ({elapsed:.1f}s)"
+
+
+def test_build_run_argv_forwards_env_file_without_secret_values() -> None:
+    secret = "SECRET_SENTINEL_DO_NOT_LOG"
+    argv = build_run_argv(
+        ItmuxRunRequest(
+            recipe=Path("/recipes/reviewer"),
+            task="review",
+            env_file=Path("/private/run.env"),
+            allow_host_auth_fallback=True,
+        )
+    )
+    assert argv[argv.index("--env-file") + 1] == "/private/run.env"
+    assert "--allow-host-auth-fallback" in argv
+    assert secret not in argv
+
+
+def test_materialized_credentials_are_allowlisted_private_and_removed() -> None:
+    secret = "SECRET_SENTINEL_DO_NOT_LOG"
+    with _materialized_env_file(
+        {"CLAUDE_CODE_OAUTH_TOKEN": secret, "UNRELATED_KEY": "dropped"}
+    ) as path:
+        assert (path.stat().st_mode & 0o777) == 0o600
+        body = path.read_text(encoding="utf-8")
+        assert secret in body
+        assert "UNRELATED_KEY" not in body
+    assert not path.exists()
+
+
+def test_render_env_file_quotes_single_quotes() -> None:
+    assert _render_env_file({"ANTHROPIC_API_KEY": "ab'cd"}) == "ANTHROPIC_API_KEY='ab'\\\\''cd'\n"

--- a/providers/workspaces/interactive-tmux/README.md
+++ b/providers/workspaces/interactive-tmux/README.md
@@ -292,6 +292,101 @@ so they survive the tmux send-keys path.
 Codex and Gemini ignore `claude_plugin_dirs` (no equivalent CLI flag);
 the signature parity exists for future agent additions.
 
+## `itmux run` credentials: the `.env` secrets contract
+
+`itmux run` (the Rust driver's recipe-execution subcommand) loads run
+credentials from a `.env` file / process env and injects them into the
+container. This is the fix for the recurring **stale-file 401**: previously
+`itmux run` left its credentials empty and silently fell back to the host
+`$HOME/.claude/.credentials.json`, which on macOS expires within hours (the
+live token lives in the login Keychain, not that file). The scrape-the-Keychain
+workaround is retired - supply a fresh, long-lived credential instead.
+
+**Credentials live in the run / workspace layer, NEVER in the recipe.** A
+recipe directory describes the agent, skills, and system prompt; it must never
+carry tokens. The consumer supplies secrets at run time via `--env-file` or the
+process environment.
+
+### Recognized keys and precedence
+
+```dotenv
+# claude (preferred first)
+CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat-...   # preferred: 1-year token from `claude setup-token`
+# ANTHROPIC_API_KEY=sk-ant-...           # fallback: raw API key
+
+# codex (preferred first)
+CODEX_AUTH_FILE=~/.codex/auth.json       # preferred: its CONTENTS are staged as auth.json
+# OPENAI_API_KEY=sk-...                  # fallback: raw API key
+```
+
+- **claude:** `CLAUDE_CODE_OAUTH_TOKEN` (preferred) ELSE `ANTHROPIC_API_KEY`.
+  The OAuth token is injected as the container **env var**
+  `CLAUDE_CODE_OAUTH_TOKEN` (the sanctioned headless path) - NOT synthesized
+  into a `.credentials.json`. The driver still stages a seeded `~/.claude.json`
+  so the trust/onboarding dialogs are pre-accepted.
+- **codex:** `CODEX_AUTH_FILE` contents (preferred) ELSE `OPENAI_API_KEY`.
+- **Source precedence:** `--env-file <path>` > process env > (opt-in) host
+  fallback.
+
+The `.env` parser is intentionally narrow: `KEY=VALUE`, `#` comments,
+single/double quotes, blank lines. No variable expansion, no multiline, no
+`export`. Unsupported syntax is rejected with `file:line`.
+
+### Fail-fast, opt-in host fallback
+
+By default, if no `.env`/process-env credential is found for the recipe's
+agent, `itmux run` **fails fast** with an actionable error naming the missing
+var. Pass `--allow-host-auth-fallback` to re-enable the legacy host
+`$HOME/.<agent>` path (a warning naming the selected source PATH is printed -
+never token contents). Prefer `--env-file` / `CLAUDE_CODE_OAUTH_TOKEN`; the
+host file is often stale.
+
+```bash
+# fresh token, fail-fast default
+itmux run --recipe ./recipes/pr-reviewer --task "review PR #42" \
+  --env-file ./run.env
+
+# legacy host-file fallback (may be stale -> 401), opt-in
+itmux run --recipe ./recipes/pr-reviewer --task "review PR #42" \
+  --allow-host-auth-fallback
+```
+
+### How the secret reaches the pane (no argv leak)
+
+The secret VALUES never touch a `docker run`/`docker exec` argv or a `tmux`
+command line (argv is world-readable via `ps` / `/proc/<pid>/cmdline`).
+Instead, the driver stages a per-agent `0600` env file into the container over
+the existing base64-over-stdin transfer, then launches the harness pane through
+a wrapper that `source`s that file and `exec`s the CLI:
+
+```sh
+set -a; . /home/agent/.itmux-secret-env-claude; set +a; exec claude
+```
+
+`set -a` exports each `KEY='value'` line into the harness child's environment.
+The only artifacts that ever contain a raw secret are the in-memory run spec,
+the base64 stdin payload, and the in-container `0600` file. This invariant is
+pinned by `driver-rs/tests/secret_redaction.rs`.
+
+### Python passthrough
+
+`agentic_isolation.run_client` forwards `--env-file` to `itmux run` and never
+logs the value:
+
+```python
+from pathlib import Path
+from agentic_isolation.run_client import ItmuxRunRequest, run
+
+# Pass an existing .env by path...
+run(ItmuxRunRequest(recipe=Path("./recipes/pr-reviewer"), task="review",
+                    env_file=Path("./run.env")))
+
+# ...or an in-memory mapping (materialized to a private 0600 temp file whose
+# PATH - never its contents - is forwarded, then removed after the run):
+run(ItmuxRunRequest(recipe=Path("./recipes/pr-reviewer"), task="review",
+                    credentials={"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat-..."}))
+```
+
 ## Credentials are NEVER baked or committed
 
 `docker run` mounts throwaway host-side copies. The image contains zero

--- a/providers/workspaces/interactive-tmux/driver-rs/docs/contract/agent-run-spec.schema.json
+++ b/providers/workspaces/interactive-tmux/driver-rs/docs/contract/agent-run-spec.schema.json
@@ -12,7 +12,8 @@
       "description": "Per-harness credentials. Empty by default (no credentials configured).",
       "default": {
         "claude": null,
-        "codex": null
+        "codex": null,
+        "secret_env": {}
       },
       "allOf": [
         {
@@ -60,7 +61,7 @@
   "additionalProperties": false,
   "definitions": {
     "AgentRunCredentials": {
-      "description": "Per-harness credentials for the run. All fields optional - only the harnesses actually exercised by the recipe need credentials supplied.",
+      "description": "Per-harness credentials for the run. All fields optional - only the harnesses actually exercised by the recipe need credentials supplied.\n\n# Secrets travel here, never in argv (security-critical)\n\nEvery field on this struct carries credential MATERIAL (token contents, `auth.json` bytes, raw env-var values). The executor injects them into the container ONLY over the base64-over-stdin `docker exec` transfer and, at launch, via an in-container `0600` env file the harness pane `source`s before `exec`ing the CLI. No credential value ever reaches a `docker run`/`docker exec` argv or a `tmux` command line - argv is world-readable via `ps` / `/proc/<pid>/cmdline`; stdin and a `0600` file are not. The `secret_env` redaction test (`tests/secret_redaction.rs`) is the load- bearing guard for that invariant.",
       "type": "object",
       "properties": {
         "claude": {
@@ -84,6 +85,14 @@
               "type": "null"
             }
           ]
+        },
+        "secret_env": {
+          "description": "Generic, harness-neutral secret environment variables (R2). Populated by the `.env`/process-env loader with an ALLOWLISTED set of names only (`CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`). The executor routes each var to the relevant harness pane's sourced `0600` env file; values never touch argv. Empty by default. A `BTreeMap` so the serialized order is deterministic (stable schema round-trips).",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/providers/workspaces/interactive-tmux/driver-rs/src/adapter.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/adapter.rs
@@ -377,6 +377,31 @@ fn shell_quote(s: &str) -> String {
     }
 }
 
+/// Wrap a harness launch command so it sources a per-agent secret env file and
+/// then `exec`s the CLI (R1). The wrapper is:
+///
+/// ```sh
+/// set -a; . '<env_file>'; set +a; exec <harness_cmd>
+/// ```
+///
+/// `set -a` marks every assignment in the sourced file for export, so each
+/// `KEY='value'` line lands in the harness child's environment; `exec` replaces
+/// the shell so the pane IS the harness (no lingering parent shell). The secret
+/// VALUES live only inside `<env_file>` (a `0600` in-container file) - this
+/// command string carries only the file PATH and the harness command, NEVER a
+/// secret. That is the property `tests/secret_redaction.rs` pins.
+///
+/// SECURITY: this is why the OAuth path is an env var + sourced file rather
+/// than `docker exec -e VAR=value` or `tmux set-environment VAR value` - both
+/// of those put the secret in argv, which is world-readable via `ps` /
+/// `/proc/<pid>/cmdline`.
+pub fn launch_command_with_env(harness_cmd: &str, secret_env_file: &str) -> String {
+    format!(
+        "set -a; . {}; set +a; exec {harness_cmd}",
+        shell_quote(secret_env_file)
+    )
+}
+
 /// Launch the agent CLI in its tmux window and walk init gates.
 ///
 /// Per ANALYTICS.md §4:
@@ -387,31 +412,53 @@ fn shell_quote(s: &str) -> String {
 ///
 /// `claude_plugin_dirs` only affects the claude window; codex/gemini ignore
 /// it (no equivalent `--plugin-dir` flag).
+///
+/// `secret_env_file` (R1/R6): when `Some`, the harness is launched through the
+/// [`launch_command_with_env`] wrapper so it sources that in-container `0600`
+/// env file (secrets) before exec. When `None`, the byte-exact pre-secrets
+/// keystroke sequence is preserved (so smoke fixtures stay stable).
 pub fn launch_in_window(
     container: &str,
     agent: Agent,
     claude_plugin_dirs: &[std::path::PathBuf],
+    secret_env_file: Option<&str>,
 ) -> std::io::Result<()> {
     match agent {
         Agent::Claude => {
             let cmd = claude_launch_command(claude_plugin_dirs);
-            if claude_plugin_dirs.is_empty() {
-                // Bare `claude` + Enter — preserves the pre-plugins keystroke
-                // sequence exactly so the smoke fixtures stay byte-equal.
-                tmux::send_keys(container, agent.window(), &["claude", "Enter"])?;
-            } else {
-                // `claude --plugin-dir P1 --plugin-dir P2 ...` — sent literal
-                // so the spaces survive tmux's argument tokenizer; then Enter.
-                tmux::send_literal(container, agent.window(), &cmd)?;
-                tmux::send_keys(container, agent.window(), &["Enter"])?;
+            match secret_env_file {
+                None if claude_plugin_dirs.is_empty() => {
+                    // Bare `claude` + Enter — preserves the pre-plugins,
+                    // pre-secrets keystroke sequence exactly.
+                    tmux::send_keys(container, agent.window(), &["claude", "Enter"])?;
+                }
+                None => {
+                    // `claude --plugin-dir P1 ...` — sent literal so spaces
+                    // survive tmux's tokenizer; then Enter.
+                    tmux::send_literal(container, agent.window(), &cmd)?;
+                    tmux::send_keys(container, agent.window(), &["Enter"])?;
+                }
+                Some(env_file) => {
+                    // Source the 0600 env file (CLAUDE_CODE_OAUTH_TOKEN /
+                    // ANTHROPIC_API_KEY) then exec claude.
+                    let wrapped = launch_command_with_env(&cmd, env_file);
+                    tmux::send_literal(container, agent.window(), &wrapped)?;
+                    tmux::send_keys(container, agent.window(), &["Enter"])?;
+                }
             }
         }
         Agent::Codex => {
-            tmux::send_keys(
-                container,
-                agent.window(),
-                &["codex --no-alt-screen", "Enter"],
-            )?;
+            let base = "codex --no-alt-screen";
+            match secret_env_file {
+                None => {
+                    tmux::send_keys(container, agent.window(), &[base, "Enter"])?;
+                }
+                Some(env_file) => {
+                    let wrapped = launch_command_with_env(base, env_file);
+                    tmux::send_literal(container, agent.window(), &wrapped)?;
+                    tmux::send_keys(container, agent.window(), &["Enter"])?;
+                }
+            }
             thread::sleep(Duration::from_secs(2));
             tmux::send_keys(container, agent.window(), &["1", "Enter"])?;
             thread::sleep(Duration::from_secs(1));
@@ -419,7 +466,16 @@ pub fn launch_in_window(
             thread::sleep(Duration::from_secs(1));
         }
         Agent::Gemini => {
-            tmux::send_keys(container, agent.window(), &["gemini", "Enter"])?;
+            match secret_env_file {
+                None => {
+                    tmux::send_keys(container, agent.window(), &["gemini", "Enter"])?;
+                }
+                Some(env_file) => {
+                    let wrapped = launch_command_with_env("gemini", env_file);
+                    tmux::send_literal(container, agent.window(), &wrapped)?;
+                    tmux::send_keys(container, agent.window(), &["Enter"])?;
+                }
+            }
             thread::sleep(Duration::from_secs(1));
         }
     }

--- a/providers/workspaces/interactive-tmux/driver-rs/src/auth.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/auth.rs
@@ -91,6 +91,14 @@ pub struct AuthContext {
     /// at an unrelated path - see `StartOptions::host_claude_dotjson` and
     /// the DooD discussion in `_default_claude_dotjson_from_env` (Python).
     pub host_claude_dotjson: Option<PathBuf>,
+    /// When `true`, claude staging omits `.credentials.json` and stages ONLY
+    /// the seeded `.claude.json` (trust/onboarding). Used by `itmux run`'s
+    /// OAuth env-var path (R1/R8): the token is injected as the
+    /// `CLAUDE_CODE_OAUTH_TOKEN` env var via `secret_env`, so synthesizing a
+    /// `.credentials.json` (and shipping a possibly-stale one) is both
+    /// unnecessary and the 401 hazard we are removing. Default `false` keeps
+    /// the `itmux start` behaviour (stage `.credentials.json`) unchanged.
+    pub claude_omit_credentials: bool,
 }
 
 /// Best-effort chmod on the LOCAL staging copy (defense in depth only - the
@@ -199,23 +207,36 @@ pub fn prepare_claude(host_src: &Path, ctx: &AuthContext) -> Result<PreparedAuth
             format!("claude auth dir not found: {}", host_src.display()),
         ));
     }
-    let creds = host_src.join(".credentials.json");
-    if !creds.is_file() {
-        return Err(Error::new(
-            ErrorKind::NotFound,
-            format!(
-                "claude .credentials.json missing under {}; cannot mount Max-plan auth",
-                host_src.display()
-            ),
-        ));
-    }
 
-    // Throwaway ~/.claude/ - copy only .credentials.json (no session history).
-    let dst_dir = ctx.throwaway_dir.join("claude.dir");
-    fs::create_dir_all(&dst_dir)?;
-    let dst_creds = dst_dir.join(".credentials.json");
-    copy_file(&creds, &dst_creds)?;
-    chmod_file(&dst_creds, 0o600);
+    // OAuth env-var mode (R1/R8): stage ONLY the seeded `.claude.json`
+    // (trust/onboarding). The token arrives as the `CLAUDE_CODE_OAUTH_TOKEN`
+    // env var via `secret_env`, so `.credentials.json` is neither required nor
+    // staged (staging a stale one is the recurring 401 we are eliminating).
+    let dotjson_only = ctx.claude_omit_credentials;
+
+    let mut mounts: Vec<StagedPath> = Vec::new();
+    if !dotjson_only {
+        let creds = host_src.join(".credentials.json");
+        if !creds.is_file() {
+            return Err(Error::new(
+                ErrorKind::NotFound,
+                format!(
+                    "claude .credentials.json missing under {}; cannot mount Max-plan auth",
+                    host_src.display()
+                ),
+            ));
+        }
+        // Throwaway ~/.claude/ - copy only .credentials.json (no session history).
+        let dst_dir = ctx.throwaway_dir.join("claude.dir");
+        fs::create_dir_all(&dst_dir)?;
+        let dst_creds = dst_dir.join(".credentials.json");
+        copy_file(&creds, &dst_creds)?;
+        chmod_file(&dst_creds, 0o600);
+        mounts.push(StagedPath {
+            host: dst_dir,
+            container: "/home/agent/.claude".to_string(),
+        });
+    }
 
     // Throwaway ~/.claude.json - synthesised regardless of host presence.
     // Resolution order (caller > sibling > nothing): if the caller passed
@@ -233,17 +254,12 @@ pub fn prepare_claude(host_src: &Path, ctx: &AuthContext) -> Result<PreparedAuth
     let seeded = build_seeded_claude_dotjson(&dotjson_src, &ctx.workdir);
     fs::write(&dotjson_dst, serde_json::to_vec_pretty(&seeded)?)?;
     chmod_file(&dotjson_dst, 0o600);
+    mounts.push(StagedPath {
+        host: dotjson_dst,
+        container: "/home/agent/.claude.json".to_string(),
+    });
 
-    Ok(PreparedAuth(vec![
-        StagedPath {
-            host: dst_dir,
-            container: "/home/agent/.claude".to_string(),
-        },
-        StagedPath {
-            host: dotjson_dst,
-            container: "/home/agent/.claude.json".to_string(),
-        },
-    ]))
+    Ok(PreparedAuth(mounts))
 }
 
 // ---------------------------------------------------------------------------

--- a/providers/workspaces/interactive-tmux/driver-rs/src/main.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/main.rs
@@ -132,6 +132,19 @@ enum Cmd {
         /// (never a downstream `Duration::from_secs_f64` panic).
         #[arg(long, value_parser = parse_positive_timeout)]
         timeout: Option<f64>,
+        /// Path to a `.env` file supplying run credentials (highest precedence,
+        /// above process env). Recognized keys: `CLAUDE_CODE_OAUTH_TOKEN`
+        /// (preferred) / `ANTHROPIC_API_KEY` for claude; `CODEX_AUTH_FILE`
+        /// (preferred) / `OPENAI_API_KEY` for codex. Only the PATH is ever on
+        /// argv - the secret values travel via stdin + an in-container 0600 file.
+        #[arg(long)]
+        env_file: Option<PathBuf>,
+        /// Re-enable the legacy host `$HOME/.<agent>` credential fallback when no
+        /// `.env`/process-env credentials are found. Off by default (fail fast).
+        /// The host `.credentials.json` is often stale (-> 401); prefer
+        /// `--env-file` / `CLAUDE_CODE_OAUTH_TOKEN`.
+        #[arg(long, default_value_t = false)]
+        allow_host_auth_fallback: bool,
     },
 }
 
@@ -514,8 +527,25 @@ fn handle_run(
     json: bool,
     result_file: Option<PathBuf>,
     timeout: Option<f64>,
+    env_file: Option<PathBuf>,
+    allow_host_auth_fallback: bool,
 ) -> ExitCode {
-    let spec = build_run_spec(recipe, task, timeout);
+    // Load run credentials from --env-file / process env (R1-R4). This is the
+    // fix for the stale-file 401: the run spec now carries fresh credentials
+    // instead of leaving `credentials` empty and falling back to the host
+    // `$HOME/.claude` file. Secret VALUES never reach argv here - `env_file` is
+    // a PATH; the values load into the spec and, later, an in-container 0600
+    // file. A load failure (unreadable/malformed) is fatal and human-only on
+    // stderr (never echoes a secret).
+    let credentials = match itmux::run::secret_env::load_credentials(env_file.as_deref()) {
+        Ok(creds) => creds,
+        Err(err) => {
+            eprintln!("[itmux run] {err}");
+            return ExitCode::from(2);
+        }
+    };
+    let mut spec = build_run_spec(recipe, task, timeout);
+    spec.credentials = credentials;
     let run_id = generate_run_id();
     let cancel = CancelToken::new();
 
@@ -541,7 +571,14 @@ fn handle_run(
         }
     };
 
-    let run_result = run_orchestrated(&spec, &image, &run_id, &cancel, &mut emit);
+    let run_result = run_orchestrated(
+        &spec,
+        &image,
+        &run_id,
+        &cancel,
+        allow_host_auth_fallback,
+        &mut emit,
+    );
 
     // Stop the signal watcher before handling the result (best-effort).
     #[cfg(unix)]
@@ -646,7 +683,18 @@ fn main() -> ExitCode {
             json,
             result_file,
             timeout,
-        } => handle_run(recipe, task, image, json, result_file, timeout),
+            env_file,
+            allow_host_auth_fallback,
+        } => handle_run(
+            recipe,
+            task,
+            image,
+            json,
+            result_file,
+            timeout,
+            env_file,
+            allow_host_auth_fallback,
+        ),
     }
 }
 
@@ -663,7 +711,6 @@ mod tests {
         );
         let limits = spec.limits.expect("timeout should populate limits");
         assert_eq!(limits.timeout_s, Some(12.5));
-        // Only the timeout is set; the token budget stays unset.
         assert_eq!(limits.token_budget, None);
     }
 
@@ -674,8 +721,6 @@ mod tests {
 
     #[test]
     fn parse_positive_timeout_rejects_non_positive_and_non_finite() {
-        // Each of these would reach Duration::from_secs_f64 and panic if it
-        // slipped through - the parser must reject them cleanly instead.
         for bad in ["-1", "0", "NaN", "inf", "-inf", "not-a-number"] {
             assert!(
                 parse_positive_timeout(bad).is_err(),
@@ -686,8 +731,6 @@ mod tests {
 
     #[test]
     fn build_run_spec_without_timeout_leaves_limits_none() {
-        // Omitting --timeout must not change existing behaviour: no limits, so
-        // the orchestrator's default await bound applies.
         let spec = build_run_spec(
             PathBuf::from("/recipes/hello"),
             "do the thing".to_string(),

--- a/providers/workspaces/interactive-tmux/driver-rs/src/main.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/main.rs
@@ -520,6 +520,7 @@ fn install_signal_watcher(
     Some((handle, join))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn handle_run(
     recipe: PathBuf,
     task: String,

--- a/providers/workspaces/interactive-tmux/driver-rs/src/run/contract.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/run/contract.rs
@@ -29,6 +29,7 @@
 //! deserialized. See `agent_run_event_rejects_unknown_top_level_field` in
 //! `tests/contract_json.rs` for the behavioral proof.
 
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use schemars::JsonSchema;
@@ -63,6 +64,18 @@ pub struct AgentRunSpec {
 
 /// Per-harness credentials for the run. All fields optional - only the
 /// harnesses actually exercised by the recipe need credentials supplied.
+///
+/// # Secrets travel here, never in argv (security-critical)
+///
+/// Every field on this struct carries credential MATERIAL (token contents,
+/// `auth.json` bytes, raw env-var values). The executor injects them into the
+/// container ONLY over the base64-over-stdin `docker exec` transfer and, at
+/// launch, via an in-container `0600` env file the harness pane `source`s
+/// before `exec`ing the CLI. No credential value ever reaches a `docker
+/// run`/`docker exec` argv or a `tmux` command line - argv is world-readable
+/// via `ps` / `/proc/<pid>/cmdline`; stdin and a `0600` file are not. The
+/// `secret_env` redaction test (`tests/secret_redaction.rs`) is the load-
+/// bearing guard for that invariant.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct AgentRunCredentials {
@@ -70,6 +83,14 @@ pub struct AgentRunCredentials {
     pub claude: Option<ClaudeCredentials>,
     #[serde(default)]
     pub codex: Option<CodexCredentials>,
+    /// Generic, harness-neutral secret environment variables (R2). Populated
+    /// by the `.env`/process-env loader with an ALLOWLISTED set of names only
+    /// (`CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`). The
+    /// executor routes each var to the relevant harness pane's sourced `0600`
+    /// env file; values never touch argv. Empty by default. A `BTreeMap` so the
+    /// serialized order is deterministic (stable schema round-trips).
+    #[serde(default)]
+    pub secret_env: BTreeMap<String, String>,
 }
 
 /// Claude Code credentials. `oauth_token` is the token CONTENTS, not a path.

--- a/providers/workspaces/interactive-tmux/driver-rs/src/run/mod.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/run/mod.rs
@@ -7,4 +7,5 @@
 pub mod contract;
 pub mod orchestrator;
 pub mod recipe_loader;
+pub mod secret_env;
 pub mod workspace_executor;

--- a/providers/workspaces/interactive-tmux/driver-rs/src/run/secret_env.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/run/secret_env.rs
@@ -1,0 +1,578 @@
+//! `.env` / process-env credential loading for `itmux run`, plus the
+//! per-harness routing that decides which secret env vars reach which pane.
+//!
+//! # Why this exists (the stale-file 401)
+//!
+//! Before this module, `itmux run` built its run spec with empty
+//! `credentials`, so the executor always fell back to the host `$HOME/.claude`
+//! file. On macOS that `.credentials.json` expires within hours (the live
+//! token lives in the Keychain), so `itmux run` recurringly 401'd. This loader
+//! populates `AgentRunCredentials` from a `.env` file / process env so a fresh,
+//! long-lived credential (a `claude setup-token` OAuth token, or an API key) is
+//! injected instead.
+//!
+//! # Security model (R1/R5)
+//!
+//! The loaded secret VALUES flow only into `AgentRunCredentials` in memory and,
+//! from there, into a `0600` env file the harness pane `source`s at launch (via
+//! the base64-over-stdin `docker exec` transfer). They NEVER reach a `docker
+//! run`/`docker exec` argv or a `tmux` command line. The only artifacts that
+//! ever contain a raw secret are this in-memory struct, the base64 stdin
+//! payload, and the in-container `0600` file. See `tests/secret_redaction.rs`.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use crate::adapter::Agent;
+use crate::run::contract::{AgentRunCredentials, CodexCredentials};
+
+/// Preferred Claude credential env var: a long-lived OAuth token from
+/// `claude setup-token`, consumed by Claude Code as an env var (NOT a
+/// synthesized `.credentials.json`).
+pub const CLAUDE_OAUTH_ENV: &str = "CLAUDE_CODE_OAUTH_TOKEN";
+/// Fallback Claude credential env var: a raw Anthropic API key.
+pub const ANTHROPIC_API_KEY_ENV: &str = "ANTHROPIC_API_KEY";
+/// Fallback Codex credential env var: a raw OpenAI API key.
+pub const OPENAI_API_KEY_ENV: &str = "OPENAI_API_KEY";
+/// Path (NOT a secret value) pointing at a Codex `auth.json`. Its CONTENTS are
+/// read and staged as a file; the path itself is not injected as an env var.
+pub const CODEX_AUTH_FILE_ENV: &str = "CODEX_AUTH_FILE";
+
+/// The ONLY env-var names the loader will ever read as secret values (R2). A
+/// strict allowlist so an unrelated env var (or a typo) can never be swept into
+/// the container.
+pub const ALLOWED_SECRET_ENV: [&str; 3] =
+    [CLAUDE_OAUTH_ENV, ANTHROPIC_API_KEY_ENV, OPENAI_API_KEY_ENV];
+
+// ---------------------------------------------------------------------------
+// `.env` parser (R4): KEY=VALUE, `#` comments, single/double quotes, blanks.
+// No variable expansion, no multiline, no `export`. Unsupported syntax is
+// rejected with filename + line number.
+
+/// A `.env` parse failure carrying the file and 1-based line number (R4). The
+/// message NEVER contains a secret value - only structural context.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnvParseError {
+    pub file: String,
+    pub line: usize,
+    pub message: String,
+}
+
+impl fmt::Display for EnvParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}: {}", self.file, self.line, self.message)
+    }
+}
+
+impl std::error::Error for EnvParseError {}
+
+fn parse_err(file: &str, line: usize, message: impl Into<String>) -> EnvParseError {
+    EnvParseError {
+        file: file.to_string(),
+        line,
+        message: message.into(),
+    }
+}
+
+/// A valid shell/env variable name: `[A-Za-z_][A-Za-z0-9_]*`.
+fn is_valid_key(key: &str) -> bool {
+    let mut chars = key.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Parse a single `VALUE` token. Single/double quoted values are taken
+/// literally (NO expansion, NO escape processing besides quote stripping);
+/// unquoted values are used verbatim. A value that opens a quote but does not
+/// close it on the same line is rejected (no multiline support, R4).
+fn parse_value(raw: &str) -> Result<String, String> {
+    let bytes = raw.as_bytes();
+    if let Some(&first) = bytes.first() {
+        if first == b'"' || first == b'\'' {
+            if raw.len() >= 2 && bytes[raw.len() - 1] == first {
+                return Ok(raw[1..raw.len() - 1].to_string());
+            }
+            let kind = if first == b'"' { "double" } else { "single" };
+            return Err(format!(
+                "unterminated {kind} quote (multiline values are not supported)"
+            ));
+        }
+    }
+    Ok(raw.to_string())
+}
+
+/// Parse `.env` file `contents` (R4). `filename` is used only for error
+/// context. Later duplicate keys overwrite earlier ones.
+pub fn parse_env_file(
+    contents: &str,
+    filename: &str,
+) -> Result<BTreeMap<String, String>, EnvParseError> {
+    let mut out = BTreeMap::new();
+    for (idx, raw_line) in contents.lines().enumerate() {
+        let line_no = idx + 1;
+        // `lines()` strips `\n`; strip a trailing `\r` for CRLF files too.
+        let line = raw_line.strip_suffix('\r').unwrap_or(raw_line);
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        if trimmed == "export" || trimmed.starts_with("export ") || trimmed.starts_with("export\t")
+        {
+            return Err(parse_err(
+                filename,
+                line_no,
+                "`export` syntax is not supported; use a bare KEY=VALUE line",
+            ));
+        }
+        let Some(eq) = trimmed.find('=') else {
+            return Err(parse_err(
+                filename,
+                line_no,
+                "expected KEY=VALUE (no '=' found)",
+            ));
+        };
+        let key = trimmed[..eq].trim();
+        let value_raw = trimmed[eq + 1..].trim();
+        if !is_valid_key(key) {
+            return Err(parse_err(
+                filename,
+                line_no,
+                format!("invalid variable name '{key}'; expected [A-Za-z_][A-Za-z0-9_]*"),
+            ));
+        }
+        let value = parse_value(value_raw).map_err(|m| parse_err(filename, line_no, m))?;
+        out.insert(key.to_string(), value);
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// Credential loading (source precedence: --env-file > process env).
+
+/// Failure loading credentials. Messages NEVER contain a secret value.
+#[derive(Debug)]
+pub enum LoadCredentialsError {
+    /// The `--env-file` path could not be read.
+    EnvFileRead { path: String, source: io::Error },
+    /// The `.env` file parsed with a syntax error (R4).
+    Parse(EnvParseError),
+    /// `CODEX_AUTH_FILE` was set but its target could not be read.
+    CodexAuthRead { path: String, source: io::Error },
+}
+
+impl fmt::Display for LoadCredentialsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EnvFileRead { path, source } => {
+                write!(f, "failed to read --env-file '{path}': {source}")
+            }
+            Self::Parse(e) => write!(f, "failed to parse --env-file: {e}"),
+            Self::CodexAuthRead { path, source } => {
+                write!(f, "failed to read CODEX_AUTH_FILE '{path}': {source}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for LoadCredentialsError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::EnvFileRead { source, .. } | Self::CodexAuthRead { source, .. } => Some(source),
+            Self::Parse(e) => Some(e),
+        }
+    }
+}
+
+/// Expand a leading `~/` (or bare `~`) against `$HOME`. Only the leading tilde
+/// is expanded - this is a path convenience, NOT `.env` variable expansion.
+fn expand_tilde(path: &str) -> PathBuf {
+    if path == "~" {
+        if let Some(home) = std::env::var_os("HOME") {
+            return PathBuf::from(home);
+        }
+    } else if let Some(rest) = path.strip_prefix("~/") {
+        if let Some(home) = std::env::var_os("HOME") {
+            return PathBuf::from(home).join(rest);
+        }
+    }
+    PathBuf::from(path)
+}
+
+/// Load `AgentRunCredentials` from an optional `.env` file overlaid on process
+/// env (precedence: `--env-file` > process env). Populates `secret_env` with
+/// the ALLOWLISTED names present, and `codex.auth_json` from `CODEX_AUTH_FILE`
+/// contents when that path is set. Does NOT fail on "no credentials" - the
+/// per-agent fail-fast (R3) lives in the executor, which knows which harness
+/// the recipe runs. Fails only on unreadable / malformed inputs.
+pub fn load_credentials(
+    env_file: Option<&Path>,
+) -> Result<AgentRunCredentials, LoadCredentialsError> {
+    let mut env_file_map = BTreeMap::new();
+    if let Some(path) = env_file {
+        let contents =
+            std::fs::read_to_string(path).map_err(|e| LoadCredentialsError::EnvFileRead {
+                path: path.display().to_string(),
+                source: e,
+            })?;
+        env_file_map = parse_env_file(&contents, &path.display().to_string())
+            .map_err(LoadCredentialsError::Parse)?;
+    }
+    resolve_credentials(&env_file_map, &|name| std::env::var(name).ok(), &|path| {
+        std::fs::read_to_string(expand_tilde(path))
+    })
+}
+
+/// Pure credential resolver, factored out so unit tests can inject the process
+/// env and file reads deterministically (never touching real global env).
+///
+/// `env_file_map` takes precedence over `get_env`. `read_file` reads a
+/// `CODEX_AUTH_FILE` path's contents.
+fn resolve_credentials(
+    env_file_map: &BTreeMap<String, String>,
+    get_env: &dyn Fn(&str) -> Option<String>,
+    read_file: &dyn Fn(&str) -> io::Result<String>,
+) -> Result<AgentRunCredentials, LoadCredentialsError> {
+    let resolve = |name: &str| -> Option<String> {
+        env_file_map
+            .get(name)
+            .cloned()
+            .or_else(|| get_env(name))
+            .filter(|v| !v.is_empty())
+    };
+
+    let mut secret_env = BTreeMap::new();
+    for name in ALLOWED_SECRET_ENV {
+        if let Some(value) = resolve(name) {
+            secret_env.insert(name.to_string(), value);
+        }
+    }
+
+    let codex = match resolve(CODEX_AUTH_FILE_ENV) {
+        Some(path) => {
+            let contents = read_file(&path)
+                .map_err(|source| LoadCredentialsError::CodexAuthRead { path, source })?;
+            Some(CodexCredentials {
+                auth_json: contents,
+            })
+        }
+        None => None,
+    };
+
+    Ok(AgentRunCredentials {
+        claude: None,
+        codex,
+        secret_env,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Per-harness routing (R2): which secrets reach which pane.
+
+/// The secrets destined for one harness pane. `env` vars are sourced from a
+/// `0600` env file before the CLI launches; `codex_auth_json` (codex only) is
+/// staged as a file the CLI reads.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AgentLaunchSecrets {
+    pub env: BTreeMap<String, String>,
+    pub codex_auth_json: Option<String>,
+}
+
+impl AgentLaunchSecrets {
+    pub fn is_empty(&self) -> bool {
+        self.env.is_empty() && self.codex_auth_json.is_none()
+    }
+}
+
+/// Route `creds` to the secrets for `agent` (R2), applying the confirmed
+/// preferred/fallback + compat precedence (R8):
+///
+/// * claude: `secret_env[CLAUDE_CODE_OAUTH_TOKEN]` (preferred) ELSE the legacy
+///   `claude.oauth_token` (translated to that SAME env var - no
+///   `.credentials.json` synthesis, R1) ELSE `secret_env[ANTHROPIC_API_KEY]`.
+/// * codex: `codex.auth_json` file contents (preferred - covers `CODEX_AUTH_FILE`
+///   and the legacy field) ELSE `secret_env[OPENAI_API_KEY]`.
+/// * gemini: nothing (no allowlisted secret var).
+pub fn resolve_agent_secrets(agent: Agent, creds: &AgentRunCredentials) -> AgentLaunchSecrets {
+    let mut out = AgentLaunchSecrets::default();
+    match agent {
+        Agent::Claude => {
+            if let Some(token) = creds.secret_env.get(CLAUDE_OAUTH_ENV) {
+                out.env.insert(CLAUDE_OAUTH_ENV.to_string(), token.clone());
+            } else if let Some(claude) = &creds.claude {
+                out.env
+                    .insert(CLAUDE_OAUTH_ENV.to_string(), claude.oauth_token.clone());
+            } else if let Some(key) = creds.secret_env.get(ANTHROPIC_API_KEY_ENV) {
+                out.env
+                    .insert(ANTHROPIC_API_KEY_ENV.to_string(), key.clone());
+            }
+        }
+        Agent::Codex => {
+            if let Some(codex) = &creds.codex {
+                out.codex_auth_json = Some(codex.auth_json.clone());
+            } else if let Some(key) = creds.secret_env.get(OPENAI_API_KEY_ENV) {
+                out.env.insert(OPENAI_API_KEY_ENV.to_string(), key.clone());
+            }
+        }
+        Agent::Gemini => {}
+    }
+    out
+}
+
+/// The actionable fail-fast message (R3) when a harness has NO credentials and
+/// host fallback is not enabled. Names the missing var(s) and points at
+/// `--env-file` / `--allow-host-auth-fallback`. Contains no secret value.
+pub fn missing_credentials_message(agent: Agent) -> String {
+    match agent {
+        Agent::Claude => format!(
+            "no Claude credentials found. Set {CLAUDE_OAUTH_ENV} (preferred; from `claude \
+             setup-token`) or {ANTHROPIC_API_KEY_ENV} in your environment or an --env-file, or \
+             pass --allow-host-auth-fallback to use the host $HOME/.claude file (may be stale -> \
+             401)."
+        ),
+        Agent::Codex => format!(
+            "no Codex credentials found. Set {CODEX_AUTH_FILE_ENV} (preferred; path to auth.json) \
+             or {OPENAI_API_KEY_ENV} in your environment or an --env-file, or pass \
+             --allow-host-auth-fallback to use the host $HOME/.codex file."
+        ),
+        Agent::Gemini => "no Gemini credentials configured for itmux run. Set them in your \
+             environment or an --env-file, or pass --allow-host-auth-fallback to use the host \
+             $HOME/.gemini file."
+            .to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Env-file body rendering (the sourced 0600 file).
+
+/// Shell single-quote a value (close-escape-reopen), so a secret containing any
+/// character survives `. <file>` sourcing intact.
+fn single_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// Render the body of the sourced `0600` env file: one `KEY='value'` line per
+/// entry (deterministic order via the `BTreeMap`). The launch wrapper runs
+/// `set -a; . <file>; set +a; exec <cmd>`, so `set -a` exports every KEY into
+/// the harness child's environment. This body is the ONLY launch-side artifact
+/// that contains raw secret values; it is written `0600` and removed on
+/// teardown. NEVER log it.
+pub fn render_env_file(env: &BTreeMap<String, String>) -> String {
+    let mut out = String::new();
+    for (key, value) in env {
+        out.push_str(key);
+        out.push('=');
+        out.push_str(&single_quote(value));
+        out.push('\n');
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_basic_key_value_comments_and_blanks() {
+        let src = "\
+# a comment
+CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat-abc
+
+ANTHROPIC_API_KEY=sk-ant-123   # not a comment: taken verbatim
+";
+        let map = parse_env_file(src, ".env").unwrap();
+        assert_eq!(map.get(CLAUDE_OAUTH_ENV).unwrap(), "sk-ant-oat-abc");
+        // Trailing text after the value is NOT treated as an inline comment
+        // (narrow parser): the whole remainder is the value.
+        assert_eq!(
+            map.get(ANTHROPIC_API_KEY_ENV).unwrap(),
+            "sk-ant-123   # not a comment: taken verbatim"
+        );
+    }
+
+    #[test]
+    fn strips_single_and_double_quotes_without_expansion() {
+        let src = "A=\"sk-$NOTEXPANDED\"\nB='literal value with spaces'\n";
+        let map = parse_env_file(src, ".env").unwrap();
+        assert_eq!(map.get("A").unwrap(), "sk-$NOTEXPANDED");
+        assert_eq!(map.get("B").unwrap(), "literal value with spaces");
+    }
+
+    #[test]
+    fn rejects_export_with_file_and_line() {
+        let src = "OK=1\nexport FOO=bar\n";
+        let err = parse_env_file(src, "creds.env").unwrap_err();
+        assert_eq!(err.file, "creds.env");
+        assert_eq!(err.line, 2);
+        assert!(err.to_string().contains("creds.env:2:"), "{err}");
+        assert!(err.message.contains("export"), "{err}");
+    }
+
+    #[test]
+    fn rejects_missing_equals_with_line_number() {
+        let src = "GOOD=1\nBADLINE\n";
+        let err = parse_env_file(src, ".env").unwrap_err();
+        assert_eq!(err.line, 2);
+        assert!(err.message.contains("KEY=VALUE"), "{err}");
+    }
+
+    #[test]
+    fn rejects_unterminated_quote() {
+        let src = "A='unterminated\n";
+        let err = parse_env_file(src, ".env").unwrap_err();
+        assert_eq!(err.line, 1);
+        assert!(err.message.contains("unterminated"), "{err}");
+    }
+
+    #[test]
+    fn rejects_invalid_key() {
+        let err = parse_env_file("1BAD=x\n", ".env").unwrap_err();
+        assert!(err.message.contains("invalid variable name"), "{err}");
+    }
+
+    #[test]
+    fn env_file_present_populates_allowlisted_secret_env_only() {
+        let env_file = BTreeMap::from([
+            (CLAUDE_OAUTH_ENV.to_string(), "sk-ant-oat-file".to_string()),
+            // A non-allowlisted name in the file is IGNORED.
+            ("RANDOM_SECRET".to_string(), "nope".to_string()),
+        ]);
+        let creds = resolve_credentials(&env_file, &|_| None, &|_| {
+            Err(io::Error::other("no codex file"))
+        })
+        .unwrap();
+        assert_eq!(
+            creds.secret_env.get(CLAUDE_OAUTH_ENV).unwrap(),
+            "sk-ant-oat-file"
+        );
+        assert!(!creds.secret_env.contains_key("RANDOM_SECRET"));
+        assert!(creds.codex.is_none());
+    }
+
+    #[test]
+    fn process_env_used_when_no_env_file() {
+        let creds = resolve_credentials(
+            &BTreeMap::new(),
+            &|name| (name == OPENAI_API_KEY_ENV).then(|| "sk-openai-proc".to_string()),
+            &|_| Err(io::Error::other("unused")),
+        )
+        .unwrap();
+        assert_eq!(
+            creds.secret_env.get(OPENAI_API_KEY_ENV).unwrap(),
+            "sk-openai-proc"
+        );
+    }
+
+    #[test]
+    fn env_file_overrides_process_env() {
+        let env_file = BTreeMap::from([(CLAUDE_OAUTH_ENV.to_string(), "from-file".to_string())]);
+        let creds = resolve_credentials(
+            &env_file,
+            &|name| (name == CLAUDE_OAUTH_ENV).then(|| "from-process".to_string()),
+            &|_| Err(io::Error::other("unused")),
+        )
+        .unwrap();
+        assert_eq!(creds.secret_env.get(CLAUDE_OAUTH_ENV).unwrap(), "from-file");
+    }
+
+    #[test]
+    fn codex_auth_file_contents_read_into_auth_json() {
+        let env_file = BTreeMap::from([(
+            CODEX_AUTH_FILE_ENV.to_string(),
+            "/path/to/auth.json".to_string(),
+        )]);
+        let creds = resolve_credentials(&env_file, &|_| None, &|path| {
+            assert_eq!(path, "/path/to/auth.json");
+            Ok(r#"{"token":"codex-abc"}"#.to_string())
+        })
+        .unwrap();
+        assert_eq!(creds.codex.unwrap().auth_json, r#"{"token":"codex-abc"}"#);
+    }
+
+    #[test]
+    fn claude_prefers_oauth_over_api_key_and_legacy_field() {
+        // secret_env OAuth beats both the API key AND the legacy oauth_token.
+        let creds = AgentRunCredentials {
+            claude: Some(crate::run::contract::ClaudeCredentials {
+                oauth_token: "legacy".to_string(),
+            }),
+            codex: None,
+            secret_env: BTreeMap::from([
+                (CLAUDE_OAUTH_ENV.to_string(), "preferred-oauth".to_string()),
+                (ANTHROPIC_API_KEY_ENV.to_string(), "api-key".to_string()),
+            ]),
+        };
+        let secrets = resolve_agent_secrets(Agent::Claude, &creds);
+        assert_eq!(
+            secrets.env.get(CLAUDE_OAUTH_ENV).unwrap(),
+            "preferred-oauth"
+        );
+        assert!(!secrets.env.contains_key(ANTHROPIC_API_KEY_ENV));
+    }
+
+    #[test]
+    fn claude_legacy_oauth_token_becomes_env_var_not_credentials_file() {
+        // R1/R8: legacy claude.oauth_token is translated to the env var.
+        let creds = AgentRunCredentials {
+            claude: Some(crate::run::contract::ClaudeCredentials {
+                oauth_token: "legacy-oauth".to_string(),
+            }),
+            codex: None,
+            secret_env: BTreeMap::new(),
+        };
+        let secrets = resolve_agent_secrets(Agent::Claude, &creds);
+        assert_eq!(secrets.env.get(CLAUDE_OAUTH_ENV).unwrap(), "legacy-oauth");
+    }
+
+    #[test]
+    fn claude_falls_back_to_api_key() {
+        let creds = AgentRunCredentials {
+            claude: None,
+            codex: None,
+            secret_env: BTreeMap::from([(
+                ANTHROPIC_API_KEY_ENV.to_string(),
+                "sk-ant-key".to_string(),
+            )]),
+        };
+        let secrets = resolve_agent_secrets(Agent::Claude, &creds);
+        assert_eq!(
+            secrets.env.get(ANTHROPIC_API_KEY_ENV).unwrap(),
+            "sk-ant-key"
+        );
+    }
+
+    #[test]
+    fn codex_prefers_auth_json_over_openai_key() {
+        let creds = AgentRunCredentials {
+            claude: None,
+            codex: Some(CodexCredentials {
+                auth_json: "{}".to_string(),
+            }),
+            secret_env: BTreeMap::from([(OPENAI_API_KEY_ENV.to_string(), "sk-openai".to_string())]),
+        };
+        let secrets = resolve_agent_secrets(Agent::Codex, &creds);
+        assert_eq!(secrets.codex_auth_json.as_deref(), Some("{}"));
+        assert!(secrets.env.is_empty());
+    }
+
+    #[test]
+    fn none_yields_empty_secrets_and_fail_fast_message() {
+        let creds = AgentRunCredentials::default();
+        assert!(resolve_agent_secrets(Agent::Claude, &creds).is_empty());
+        let msg = missing_credentials_message(Agent::Claude);
+        assert!(msg.contains(CLAUDE_OAUTH_ENV), "{msg}");
+        assert!(msg.contains("--env-file"), "{msg}");
+        assert!(msg.contains("--allow-host-auth-fallback"), "{msg}");
+    }
+
+    #[test]
+    fn render_env_file_single_quotes_values() {
+        let env = BTreeMap::from([(CLAUDE_OAUTH_ENV.to_string(), "sk-ant-'quote".to_string())]);
+        let body = render_env_file(&env);
+        assert_eq!(body, "CLAUDE_CODE_OAUTH_TOKEN='sk-ant-'\\''quote'\n");
+    }
+}

--- a/providers/workspaces/interactive-tmux/driver-rs/src/run/workspace_executor.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/run/workspace_executor.rs
@@ -311,7 +311,9 @@ fn resolve_launch_credentials(
             // Fallback: `OPENAI_API_KEY` sourced as an env var (no file).
             let host_auth = if let Some(auth_json) = secrets.codex_auth_json {
                 let dir = fresh_cred_dir("codex")?;
-                fs::write(dir.join("auth.json"), auth_json.as_bytes())?;
+                // Create the auth.json 0600 at creation (atomic, no brief 0644
+                // window) - it carries the codex token (PR #254 review).
+                crate::workspace::write_private_file(&dir.join("auth.json"), auth_json.as_bytes())?;
                 cred_tmp_dirs.push(dir.clone());
                 Some(dir)
             } else {
@@ -355,20 +357,16 @@ fn env_host_auth(override_env: &str, home_subdir: &str) -> Option<PathBuf> {
     candidate.is_dir().then_some(candidate)
 }
 
-/// Create a fresh 0700 temp dir under the system temp dir for credential
-/// materialisation.
+/// Create a fresh temp dir under the system temp dir for credential
+/// materialisation, with mode 0700 set ATOMICALLY at creation (no brief 0755
+/// window) - it holds staged secret files (PR #254 review).
 fn fresh_cred_dir(agent: &str) -> io::Result<PathBuf> {
     let base = std::env::temp_dir();
     let mut path = base.join(format!("itmux-run-cred-{agent}-{}", unique_suffix()));
     while path.exists() {
         path = base.join(format!("itmux-run-cred-{agent}-{}", unique_suffix()));
     }
-    fs::create_dir_all(&path)?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o700));
-    }
+    crate::workspace::create_private_dir(&path)?;
     Ok(path)
 }
 

--- a/providers/workspaces/interactive-tmux/driver-rs/src/run/workspace_executor.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/run/workspace_executor.rs
@@ -6,7 +6,7 @@
 //! here: mapping the recipe's default agent onto `StartOptions`, materialising
 //! per-harness credentials, and the (placeholder) outcome detection.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::io;
 use std::path::PathBuf;
@@ -18,6 +18,7 @@ use crate::result::AwaitResult;
 use crate::run::contract::{AgentRunEvent, AgentRunOutcome, AgentRunResult, AgentRunSpec};
 use crate::run::orchestrator::{run_core, CancelToken, RunExecutor};
 use crate::run::recipe_loader::{load_execution_plan, RecipeExecutionPlan};
+use crate::run::secret_env::{missing_credentials_message, resolve_agent_secrets};
 use crate::tmux;
 use crate::workspace::{StartOptions, Workspace, DEFAULT_STARTUP_TIMEOUT_S};
 
@@ -45,6 +46,12 @@ pub struct WorkspaceExecutor {
     submit_text: String,
     host_auth: HashMap<Agent, Option<PathBuf>>,
     host_claude_dotjson: Option<PathBuf>,
+    /// Per-agent secret env vars (OAuth token / API keys) to inject via the
+    /// sourced `0600` env-file launch wrapper (R1/R2). Never in argv.
+    secret_env: HashMap<Agent, BTreeMap<String, String>>,
+    /// Claude OAuth env-var mode: stage `.claude.json` only, no
+    /// `.credentials.json` (R1/R8).
+    claude_omit_credentials: bool,
     startup_timeout_s: f64,
     /// Temp dirs holding credentials materialised from the spec; removed on
     /// teardown so inline credential material never lingers on disk.
@@ -52,18 +59,34 @@ pub struct WorkspaceExecutor {
 }
 
 impl WorkspaceExecutor {
-    /// Build an executor from a spec + its loaded plan. Materialises any inline
-    /// credentials (contract carries CONTENTS, not paths) into the on-disk
-    /// shapes `crate::auth` expects, or falls back to the environment-resolved
-    /// host auth (`ITMUX_<AGENT>_HOME` / `$HOME/.<agent>`) when the spec omits
-    /// them.
-    pub fn new(spec: &AgentRunSpec, plan: &RecipeExecutionPlan, image: &str) -> io::Result<Self> {
+    /// Build an executor from a spec + its loaded plan.
+    ///
+    /// Resolves the default agent's credentials (R1-R3): secrets from
+    /// `spec.credentials` (populated by the `.env`/process-env loader) are
+    /// routed to the harness as env vars (OAuth token / API key) injected via a
+    /// sourced `0600` env file, or - for codex - an `auth.json` staged file.
+    /// When the agent has NO credentials and `allow_host_fallback` is false,
+    /// this FAILS FAST with an actionable error (R3); with the flag it falls
+    /// back to the host `$HOME/.<agent>` dir (warned, path only - never token
+    /// contents).
+    pub fn new(
+        spec: &AgentRunSpec,
+        plan: &RecipeExecutionPlan,
+        image: &str,
+        allow_host_fallback: bool,
+    ) -> io::Result<Self> {
         let agent = plan.agent;
         let mut cred_tmp_dirs = Vec::new();
-        let mut host_auth: HashMap<Agent, Option<PathBuf>> = HashMap::new();
 
-        let auth_path = materialise_host_auth(spec, agent, &mut cred_tmp_dirs)?;
-        host_auth.insert(agent, auth_path);
+        let wiring =
+            resolve_launch_credentials(spec, agent, allow_host_fallback, &mut cred_tmp_dirs)?;
+
+        let mut host_auth: HashMap<Agent, Option<PathBuf>> = HashMap::new();
+        host_auth.insert(agent, wiring.host_auth);
+        let mut secret_env: HashMap<Agent, BTreeMap<String, String>> = HashMap::new();
+        if !wiring.secret_env.is_empty() {
+            secret_env.insert(agent, wiring.secret_env);
+        }
 
         let name = sanitize_name(&plan.recipe_name);
         let container_name = format!("interactive-tmux-{name}-{}", unique_suffix());
@@ -75,7 +98,9 @@ impl WorkspaceExecutor {
             plan: plan.clone(),
             submit_text: plan.submit_text.clone(),
             host_auth,
-            host_claude_dotjson: None,
+            host_claude_dotjson: resolve_host_claude_dotjson(),
+            secret_env,
+            claude_omit_credentials: wiring.claude_omit_credentials,
             startup_timeout_s: DEFAULT_STARTUP_TIMEOUT_S,
             cred_tmp_dirs,
         })
@@ -107,6 +132,8 @@ impl RunExecutor for WorkspaceExecutor {
         opts.host_auth = self.host_auth.clone();
         opts.host_claude_dotjson = self.host_claude_dotjson.clone();
         opts.claude_plugin_dirs = self.plan.claude_plugin_dirs.clone();
+        opts.secret_env = self.secret_env.clone();
+        opts.claude_omit_credentials = self.claude_omit_credentials;
         opts.strict_startup = true;
         opts.startup_timeout_s = self.startup_timeout_s;
 
@@ -201,47 +228,120 @@ impl RunExecutor for WorkspaceExecutor {
     }
 }
 
-/// Resolve the host-auth path for `agent`: materialise inline spec credentials
-/// when present, else fall back to the environment (`ITMUX_<AGENT>_HOME` or
-/// `$HOME/.<agent>`), matching the `start` subcommand's resolution.
-fn materialise_host_auth(
+/// How the executor wires one agent's credentials into `StartOptions`.
+struct CredentialWiring {
+    /// Host auth dir to stage (claude trust `.claude.json`, codex `auth.json`),
+    /// or `None` when the agent is enabled purely via `secret_env`.
+    host_auth: Option<PathBuf>,
+    /// Secret env vars (OAuth token / API key) to source at launch.
+    secret_env: BTreeMap<String, String>,
+    /// Claude OAuth env-var mode: stage `.claude.json` only (R1/R8).
+    claude_omit_credentials: bool,
+}
+
+/// Resolve credentials for `agent` from `spec` (R1-R3).
+///
+/// Precedence (per user + R8): env-var/file secrets from `spec.credentials`
+/// (populated by the `.env`/process-env loader) are preferred. When the agent
+/// has NO credentials: with `allow_host_fallback` we fall back to the host
+/// `$HOME/.<agent>` dir (warned to stderr - PATH only, never token contents);
+/// without it we FAIL FAST with an actionable error naming the missing var.
+fn resolve_launch_credentials(
     spec: &AgentRunSpec,
     agent: Agent,
+    allow_host_fallback: bool,
     cred_tmp_dirs: &mut Vec<PathBuf>,
-) -> io::Result<Option<PathBuf>> {
+) -> io::Result<CredentialWiring> {
+    let secrets = resolve_agent_secrets(agent, &spec.credentials);
+
+    if secrets.is_empty() {
+        if allow_host_fallback {
+            let (override_env, subdir) = match agent {
+                Agent::Claude => ("ITMUX_CLAUDE_HOME", ".claude"),
+                Agent::Codex => ("ITMUX_CODEX_HOME", ".codex"),
+                Agent::Gemini => ("ITMUX_GEMINI_HOME", ".gemini"),
+            };
+            let host = env_host_auth(override_env, subdir);
+            match &host {
+                Some(path) => eprintln!(
+                    "[itmux run] --allow-host-auth-fallback: using host auth dir {} for {} \
+                     (may be stale -> 401)",
+                    path.display(),
+                    agent.as_str()
+                ),
+                None => eprintln!(
+                    "[itmux run] --allow-host-auth-fallback: no host auth dir found for {}",
+                    agent.as_str()
+                ),
+            }
+            return Ok(CredentialWiring {
+                host_auth: host,
+                secret_env: BTreeMap::new(),
+                claude_omit_credentials: false,
+            });
+        }
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            missing_credentials_message(agent),
+        ));
+    }
+
     match agent {
         Agent::Claude => {
-            if let Some(claude) = &spec.credentials.claude {
-                let dir = fresh_cred_dir("claude")?;
-                // `.credentials.json` shape mirrors a Max-plan credentials file
-                // (`claudeAiOauth.accessToken`), per the interactive-tmux
-                // manifest. The exact schema is validated by the live run
-                // (Task 8); the contract supplies the token contents only.
-                let creds = serde_json::json!({
-                    "claudeAiOauth": { "accessToken": claude.oauth_token }
-                });
-                fs::write(
-                    dir.join(".credentials.json"),
-                    serde_json::to_vec_pretty(&creds)?,
-                )?;
-                cred_tmp_dirs.push(dir.clone());
-                Ok(Some(dir))
-            } else {
-                Ok(env_host_auth("ITMUX_CLAUDE_HOME", ".claude"))
-            }
+            // OAuth env-var mode (R1): stage the seeded `.claude.json` for
+            // trust/onboarding, but NO `.credentials.json`. Use the real host
+            // `.claude` dir when it exists (so `oauthAccount` can pass through);
+            // otherwise a fresh empty dir so `.claude.json` is still synthesized.
+            let host = match env_host_auth("ITMUX_CLAUDE_HOME", ".claude") {
+                Some(path) => path,
+                None => {
+                    let dir = fresh_cred_dir("claude-trust")?;
+                    cred_tmp_dirs.push(dir.clone());
+                    dir
+                }
+            };
+            Ok(CredentialWiring {
+                host_auth: Some(host),
+                secret_env: secrets.env,
+                claude_omit_credentials: true,
+            })
         }
         Agent::Codex => {
-            if let Some(codex) = &spec.credentials.codex {
+            // Preferred: stage `auth.json` (from CODEX_AUTH_FILE / legacy field).
+            // Fallback: `OPENAI_API_KEY` sourced as an env var (no file).
+            let host_auth = if let Some(auth_json) = secrets.codex_auth_json {
                 let dir = fresh_cred_dir("codex")?;
-                fs::write(dir.join("auth.json"), codex.auth_json.as_bytes())?;
+                fs::write(dir.join("auth.json"), auth_json.as_bytes())?;
                 cred_tmp_dirs.push(dir.clone());
-                Ok(Some(dir))
+                Some(dir)
             } else {
-                Ok(env_host_auth("ITMUX_CODEX_HOME", ".codex"))
-            }
+                None
+            };
+            Ok(CredentialWiring {
+                host_auth,
+                secret_env: secrets.env,
+                claude_omit_credentials: false,
+            })
         }
-        Agent::Gemini => Ok(env_host_auth("ITMUX_GEMINI_HOME", ".gemini")),
+        Agent::Gemini => Ok(CredentialWiring {
+            host_auth: env_host_auth("ITMUX_GEMINI_HOME", ".gemini"),
+            secret_env: secrets.env,
+            claude_omit_credentials: false,
+        }),
     }
+}
+
+/// Resolve `~/.claude.json` for the trust/onboarding synthesis, honoring
+/// `ITMUX_CLAUDE_JSON` first, then `$HOME/.claude.json`. Mirrors the `start`
+/// subcommand's `default_host_claude_dotjson`.
+fn resolve_host_claude_dotjson() -> Option<PathBuf> {
+    if let Some(explicit) = std::env::var_os("ITMUX_CLAUDE_JSON") {
+        let path = PathBuf::from(explicit);
+        return path.is_file().then_some(path);
+    }
+    let home = std::env::var_os("HOME").map(PathBuf::from)?;
+    let path = home.join(".claude.json");
+    path.is_file().then_some(path)
 }
 
 /// Environment-resolved host auth dir: `$<override_env>` if set, else
@@ -356,6 +456,7 @@ pub fn run(
     image: &str,
     run_id: &str,
     cancel: &CancelToken,
+    allow_host_fallback: bool,
     emit: &mut dyn FnMut(&AgentRunEvent),
 ) -> io::Result<AgentRunResult> {
     let plan = load_execution_plan(spec).map_err(|e| io::Error::other(e.to_string()))?;
@@ -364,7 +465,7 @@ pub fn run(
         .as_ref()
         .and_then(|l| l.timeout_s)
         .map(Duration::from_secs_f64);
-    let mut executor = WorkspaceExecutor::new(spec, &plan, image)?;
+    let mut executor = WorkspaceExecutor::new(spec, &plan, image, allow_host_fallback)?;
     let mut now = now_rfc3339;
     Ok(run_core(
         run_id,

--- a/providers/workspaces/interactive-tmux/driver-rs/src/workspace.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/workspace.rs
@@ -4,7 +4,7 @@
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::io::{Error, ErrorKind, Result};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -121,6 +121,53 @@ fn random_suffix() -> String {
     #[allow(clippy::cast_possible_truncation)]
     let low = (mix & 0xFFFF_FFFF) as u64;
     format!("{low:08x}")
+}
+
+/// Create `path` as a fresh directory with mode `0700` set ATOMICALLY at
+/// creation (via `mkdir(mode)`), so it is never briefly world-traversable
+/// (`0755`) before a follow-up `chmod`. This matters because the dir holds
+/// staged secret material (the `0600` secret env files). Fails if `path`
+/// already exists (callers pass a freshly-minted unique path).
+pub(crate) fn create_private_dir(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        std::fs::DirBuilder::new().mode(0o700).create(path)
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::create_dir(path)
+    }
+}
+
+/// Create `path` as a fresh file with mode `0600` set ATOMICALLY at creation
+/// (via `open(O_CREAT | O_EXCL, 0600)`) and write `contents`, so the file is
+/// never briefly world-readable (`0644`) before a follow-up `chmod` - closing
+/// the local-read window on secret material (PR #254 review). `create_new`
+/// guarantees this process is the creator; callers pass a path inside a fresh
+/// `0700` dir, so there is no pre-existing file to clobber.
+pub(crate) fn write_private_file(path: &Path, contents: &[u8]) -> Result<()> {
+    use std::io::Write;
+    let mut file = {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(0o600)
+                .open(path)?
+        }
+        #[cfg(not(unix))]
+        {
+            std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(path)?
+        }
+    };
+    file.write_all(contents)?;
+    Ok(())
 }
 
 /// Build the `docker run` argv for a bare, credential-free container:
@@ -275,7 +322,9 @@ impl Workspace {
                     random_suffix()
                 ));
             }
-            fs::create_dir_all(&path)?;
+            // Create the throwaway dir 0700 at creation (it holds the staged
+            // 0600 secret env files) - no brief world-traversable window.
+            create_private_dir(&path)?;
             path
         };
 
@@ -334,10 +383,10 @@ impl Workspace {
                 auth::stage_into_container(&container, prepared)?;
             }
 
-            // Stage per-agent secret env files (R1). Each is written to a
-            // throwaway host file (0600) and transferred via the SAME
-            // base64-over-stdin path as credentials - the values never touch
-            // argv. The in-container file is re-secured to 0600 by
+            // Stage per-agent secret env files (R1). Each is created 0600 at
+            // creation (atomic, no brief 0644 window) and transferred via the
+            // SAME base64-over-stdin path as credentials - the values never
+            // touch argv. The in-container file is re-secured to 0600 by
             // `secure_path_plan`. Record the container path so the launch step
             // sources it.
             let mut secret_env_files: HashMap<Agent, String> = HashMap::new();
@@ -347,17 +396,18 @@ impl Workspace {
                 };
                 let container_path = format!("/home/agent/.itmux-secret-env-{}", agent.as_str());
                 let host_file = throwaway.join(format!("secret-env-{}", agent.as_str()));
-                fs::write(&host_file, secret_env::render_env_file(env))?;
-                #[cfg(unix)]
-                {
-                    use std::os::unix::fs::PermissionsExt;
-                    let _ = fs::set_permissions(&host_file, fs::Permissions::from_mode(0o600));
-                }
+                write_private_file(&host_file, secret_env::render_env_file(env).as_bytes())?;
                 let staged = PreparedAuth(vec![StagedPath {
-                    host: host_file,
+                    host: host_file.clone(),
                     container: container_path.clone(),
                 }]);
                 auth::stage_into_container(&container, &staged)?;
+                // Secret hygiene: the container now holds its own 0600 copy, so
+                // remove the host copy immediately rather than waiting for
+                // teardown - the plaintext secret should linger on the host for
+                // the shortest possible time. Best-effort; teardown's
+                // `remove_dir_all(throwaway)` is the fallback.
+                let _ = fs::remove_file(&host_file);
                 secret_env_files.insert(agent, container_path);
             }
             Ok((enabled, secret_env_files))
@@ -651,5 +701,61 @@ impl Workspace {
     pub fn load_from_registry(name: &str) -> Result<Self> {
         let rec = registry::load(name)?;
         Self::from_record(&rec)
+    }
+}
+
+#[cfg(all(test, unix))]
+mod secret_mode_tests {
+    //! PR #254 review: the mode guarantee on host-side secret files/dirs must
+    //! be load-bearing. These drive the REAL creation helpers used by
+    //! `Workspace::start` (factored out so they are testable without docker)
+    //! and assert the mode is restrictive AT creation.
+
+    use super::{create_private_dir, write_private_file};
+    use std::os::unix::fs::PermissionsExt;
+
+    fn unique_base(tag: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "itmux-secret-mode-{tag}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    #[test]
+    fn private_dir_is_0700_and_private_file_is_0600() {
+        let dir = unique_base("dir");
+        create_private_dir(&dir).expect("create 0700 dir");
+        let dir_mode = std::fs::metadata(&dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(dir_mode, 0o700, "throwaway dir must be 0700 at creation");
+
+        // A staged secret env file inside it - the exact path shape
+        // `Workspace::start` uses.
+        let file = dir.join("secret-env-claude");
+        write_private_file(&file, b"CLAUDE_CODE_OAUTH_TOKEN='tok'\n").expect("write 0600 file");
+        let file_mode = std::fs::metadata(&file).unwrap().permissions().mode() & 0o777;
+        assert_eq!(file_mode, 0o600, "secret env file must be 0600 at creation");
+        assert_eq!(
+            std::fs::read_to_string(&file).unwrap(),
+            "CLAUDE_CODE_OAUTH_TOKEN='tok'\n"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn write_private_file_refuses_to_clobber_existing() {
+        let dir = unique_base("clobber");
+        create_private_dir(&dir).unwrap();
+        let file = dir.join("secret");
+        write_private_file(&file, b"first").unwrap();
+        // create_new(true): a second create must fail rather than truncate a
+        // file whose mode we did not set.
+        let err = write_private_file(&file, b"second").unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/providers/workspaces/interactive-tmux/driver-rs/src/workspace.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/src/workspace.rs
@@ -1,7 +1,7 @@
 //! Workspace lifecycle: `docker run`, tmux bootstrap, per-agent launch +
 //! readiness gating, public primitives (send/await/capture/exec/stop).
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::io::{Error, ErrorKind, Result};
 use std::path::PathBuf;
@@ -10,9 +10,10 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::adapter::{self, Agent};
-use crate::auth::{self, AuthContext, PreparedAuth};
+use crate::auth::{self, AuthContext, PreparedAuth, StagedPath};
 use crate::registry::{self, WorkspaceRecord};
 use crate::result::AwaitResult;
+use crate::run::secret_env;
 use crate::tmux;
 
 pub const DEFAULT_IMAGE: &str = "agentic-workspace-interactive-tmux:latest";
@@ -53,6 +54,18 @@ pub struct StartOptions {
     /// to best-effort reap an orphan on hard-cancel, #248) set this to a
     /// pre-computed unique name. It MUST be unique per workspace.
     pub container_name: Option<String>,
+    /// Per-agent secret environment variables (R1/R2). For each agent with a
+    /// non-empty map, `start` stages a `0600` env file into the container over
+    /// the base64-over-stdin transfer and launches that agent's pane through a
+    /// wrapper that `source`s it (see `adapter::launch_command_with_env`). The
+    /// values NEVER reach argv. An agent with only `secret_env` (no `host_auth`)
+    /// still counts as enabled. Empty by default.
+    pub secret_env: HashMap<Agent, BTreeMap<String, String>>,
+    /// When `true`, the claude auth staging omits `.credentials.json` and stages
+    /// ONLY the seeded `.claude.json` (trust/onboarding). Used by the OAuth env
+    /// var path (R1/R8): the token is injected via `secret_env`
+    /// (`CLAUDE_CODE_OAUTH_TOKEN`), never synthesized into a `.credentials.json`.
+    pub claude_omit_credentials: bool,
 }
 
 impl StartOptions {
@@ -68,6 +81,8 @@ impl StartOptions {
             host_claude_dotjson: None,
             claude_plugin_dirs: Vec::new(),
             container_name: None,
+            secret_env: HashMap::new(),
+            claude_omit_credentials: false,
         }
     }
 }
@@ -87,6 +102,11 @@ pub struct Workspace {
     /// `Workspace::start` from `StartOptions::claude_plugin_dirs`;
     /// consumed by `bootstrap_tmux_and_launch`.
     pub claude_plugin_dirs: Vec<PathBuf>,
+    /// Per-agent container-side path of the staged `0600` secret env file
+    /// (R1/R6). Populated by `Workspace::start` after the file is transferred;
+    /// consumed by `bootstrap_tmux_and_launch` to launch the pane through the
+    /// source-and-exec wrapper. NEVER contains a secret value - only the path.
+    pub secret_env_files: HashMap<Agent, String>,
 }
 
 fn random_suffix() -> String {
@@ -227,10 +247,11 @@ fn run_capture(cmd: Command, what: &str) -> Result<Output> {
 impl Workspace {
     #[allow(clippy::needless_pass_by_value)]
     pub fn start(opts: StartOptions) -> Result<Self> {
-        if opts.host_auth.values().all(Option::is_none) {
+        let has_any_secret_env = opts.secret_env.values().any(|m| !m.is_empty());
+        if opts.host_auth.values().all(Option::is_none) && !has_any_secret_env {
             return Err(Error::new(
                 ErrorKind::InvalidInput,
-                "start_workspace called with no enabled agents (host_auth empty)",
+                "start_workspace called with no enabled agents (no host_auth and no secret_env)",
             ));
         }
 
@@ -262,6 +283,7 @@ impl Workspace {
             workdir: opts.workdir.clone(),
             throwaway_dir: throwaway.clone(),
             host_claude_dotjson: opts.host_claude_dotjson.clone(),
+            claude_omit_credentials: opts.claude_omit_credentials,
         };
 
         // Everything between creating `throwaway` and the Workspace taking
@@ -269,25 +291,31 @@ impl Workspace {
         // must clean up the staged credential copies on failure; otherwise
         // a failed `docker run` (or a bad host auth dir) leaks auth
         // material under the temp dir.
-        let provision = (|| -> Result<Vec<Agent>> {
+        let provision = (|| -> Result<(Vec<Agent>, HashMap<Agent, String>)> {
             let mut enabled: Vec<Agent> = Vec::new();
             let mut prepared_by_agent: Vec<PreparedAuth> = Vec::new();
             for agent in adapter::AGENTS {
-                let Some(Some(src)) = opts.host_auth.get(&agent) else {
-                    continue;
+                let host_src = opts.host_auth.get(&agent).cloned().flatten();
+                let has_secret_env = opts.secret_env.get(&agent).is_some_and(|m| !m.is_empty());
+                let prepared = match host_src.as_ref() {
+                    Some(src) => auth::prepare(agent, src, &auth_ctx)?,
+                    None => PreparedAuth::default(),
                 };
-                let prepared = auth::prepare(agent, src, &auth_ctx)?;
-                if prepared.is_empty() {
+                // An agent is enabled if it has staged credential files OR a
+                // non-empty secret env (the OAuth/API-key env-var path, R1/R2).
+                if prepared.is_empty() && !has_secret_env {
                     continue;
                 }
                 enabled.push(agent);
-                prepared_by_agent.push(prepared);
+                if !prepared.is_empty() {
+                    prepared_by_agent.push(prepared);
+                }
             }
 
             if enabled.is_empty() {
                 return Err(Error::new(
                     ErrorKind::InvalidInput,
-                    "start_workspace called with no enabled agents (host_auth empty)",
+                    "start_workspace called with no enabled agents (no host_auth and no secret_env)",
                 ));
             }
 
@@ -305,10 +333,37 @@ impl Workspace {
             for prepared in &prepared_by_agent {
                 auth::stage_into_container(&container, prepared)?;
             }
-            Ok(enabled)
+
+            // Stage per-agent secret env files (R1). Each is written to a
+            // throwaway host file (0600) and transferred via the SAME
+            // base64-over-stdin path as credentials - the values never touch
+            // argv. The in-container file is re-secured to 0600 by
+            // `secure_path_plan`. Record the container path so the launch step
+            // sources it.
+            let mut secret_env_files: HashMap<Agent, String> = HashMap::new();
+            for &agent in &enabled {
+                let Some(env) = opts.secret_env.get(&agent).filter(|m| !m.is_empty()) else {
+                    continue;
+                };
+                let container_path = format!("/home/agent/.itmux-secret-env-{}", agent.as_str());
+                let host_file = throwaway.join(format!("secret-env-{}", agent.as_str()));
+                fs::write(&host_file, secret_env::render_env_file(env))?;
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    let _ = fs::set_permissions(&host_file, fs::Permissions::from_mode(0o600));
+                }
+                let staged = PreparedAuth(vec![StagedPath {
+                    host: host_file,
+                    container: container_path.clone(),
+                }]);
+                auth::stage_into_container(&container, &staged)?;
+                secret_env_files.insert(agent, container_path);
+            }
+            Ok((enabled, secret_env_files))
         })();
-        let enabled = match provision {
-            Ok(enabled) => enabled,
+        let (enabled, secret_env_files) = match provision {
+            Ok(result) => result,
             Err(e) => {
                 // Best-effort: `docker run -d` (or the credential transfer
                 // that follows it) can fail after the container is
@@ -333,6 +388,7 @@ impl Workspace {
             enabled_agents: enabled,
             startup_status: HashMap::new(),
             claude_plugin_dirs: opts.claude_plugin_dirs.clone(),
+            secret_env_files,
         };
         if let Err(e) = ws.bootstrap_tmux_and_launch(opts.startup_timeout_s, opts.strict_startup) {
             let _ = ws.stop();
@@ -355,7 +411,8 @@ impl Workspace {
 
         let plugin_dirs = self.claude_plugin_dirs.clone();
         for &agent in &self.enabled_agents.clone() {
-            adapter::launch_in_window(&self.container, agent, &plugin_dirs)?;
+            let secret_env_file = self.secret_env_files.get(&agent).map(String::as_str);
+            adapter::launch_in_window(&self.container, agent, &plugin_dirs, secret_env_file)?;
             let result = self.wait_for_started(agent, startup_timeout_s);
             self.startup_status.insert(agent, result);
         }
@@ -581,6 +638,9 @@ impl Workspace {
             // re-launches via load_from_registry don't accidentally drop
             // or duplicate plugin flags.
             claude_plugin_dirs: Vec::new(),
+            // Secret env files are staged at start time and not persisted in
+            // the registry (the launch already happened by the time we save).
+            secret_env_files: HashMap::new(),
         })
     }
 

--- a/providers/workspaces/interactive-tmux/driver-rs/tests/auth_parity.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/tests/auth_parity.rs
@@ -34,6 +34,7 @@ fn claude_seeds_synthetic_dotjson_when_host_missing() {
         workdir: "/workspace".to_string(),
         throwaway_dir: throwaway.clone(),
         host_claude_dotjson: None,
+        claude_omit_credentials: false,
     };
 
     let mounts = prepare(Agent::Claude, &claude_dir, &ctx).unwrap();
@@ -76,6 +77,7 @@ fn claude_seeds_carry_oauth_account_through_when_host_present() {
         workdir: "/workspace".to_string(),
         throwaway_dir: throwaway.clone(),
         host_claude_dotjson: None,
+        claude_omit_credentials: false,
     };
     let mounts = prepare(Agent::Claude, &claude_dir, &ctx).unwrap();
     let dotjson_mount = mounts
@@ -112,6 +114,7 @@ fn claude_honors_explicit_dotjson_override_dood_case() {
         workdir: "/workspace".to_string(),
         throwaway_dir: throwaway.clone(),
         host_claude_dotjson: Some(dotjson_path.clone()),
+        claude_omit_credentials: false,
     };
 
     let mounts = prepare(Agent::Claude, &claude_dir, &ctx).unwrap();
@@ -136,6 +139,7 @@ fn claude_rejects_missing_credentials_file() {
         workdir: "/workspace".to_string(),
         throwaway_dir: tmp("claude-throwaway-bad"),
         host_claude_dotjson: None,
+        claude_omit_credentials: false,
     };
     let err = prepare(Agent::Claude, &claude_dir, &ctx).unwrap_err();
     assert!(err.to_string().contains(".credentials.json"));
@@ -150,6 +154,7 @@ fn gemini_patches_folder_trust_in_settings() {
         workdir: "/workspace".to_string(),
         throwaway_dir: throwaway.clone(),
         host_claude_dotjson: None,
+        claude_omit_credentials: false,
     };
     let mounts = prepare(Agent::Gemini, &host, &ctx).unwrap();
     assert_eq!(mounts.len(), 1);
@@ -187,6 +192,7 @@ fn codex_stages_only_the_auth_allowlist() {
         workdir: "/workspace".to_string(),
         throwaway_dir: tmp("codex-throwaway"),
         host_claude_dotjson: None,
+        claude_omit_credentials: false,
     };
     let mounts = prepare(Agent::Codex, &host, &ctx).unwrap();
     assert_eq!(mounts.len(), 1);
@@ -240,6 +246,7 @@ fn codex_stages_symlinked_auth_files() {
         workdir: "/workspace".to_string(),
         throwaway_dir: tmp("codex-symlink-throwaway"),
         host_claude_dotjson: None,
+        claude_omit_credentials: false,
     };
     let mounts = prepare(Agent::Codex, &host, &ctx).unwrap();
     let dst = &mounts[0].host;

--- a/providers/workspaces/interactive-tmux/driver-rs/tests/contract_json.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/tests/contract_json.rs
@@ -50,6 +50,13 @@ fn agent_run_spec_round_trips_full() {
             codex: Some(CodexCredentials {
                 auth_json: r#"{"token":"xyz"}"#.to_string(),
             }),
+            secret_env: std::collections::BTreeMap::from([
+                (
+                    "CLAUDE_CODE_OAUTH_TOKEN".to_string(),
+                    "sk-ant-oat-abc".to_string(),
+                ),
+                ("OPENAI_API_KEY".to_string(), "sk-openai-xyz".to_string()),
+            ]),
         },
         observability: vec![ObservabilityExporter {
             name: "otel".to_string(),
@@ -99,12 +106,42 @@ fn agent_run_credentials_round_trip_and_reject_unknown_field() {
             oauth_token: "tok".to_string(),
         }),
         codex: None,
+        secret_env: std::collections::BTreeMap::new(),
     };
     roundtrip(&creds);
 
     let json = r#"{"claude": {"oauth_token": "tok"}, "gemini": {}}"#;
     let err = serde_json::from_str::<AgentRunCredentials>(json).unwrap_err();
     assert!(err.to_string().contains("gemini"), "err: {err}");
+}
+
+#[test]
+fn agent_run_credentials_carry_secret_env_and_round_trip() {
+    // R2/R7/R8: `secret_env` is a defaulted, serde-stable generic secret map.
+    // It defaults to empty (compat: old JSON with no `secret_env` still loads)
+    // and round-trips deterministically (BTreeMap ordering).
+    let json = r#"{"claude": {"oauth_token": "tok"}}"#;
+    let creds: AgentRunCredentials = serde_json::from_str(json).expect("secret_env defaults empty");
+    assert!(creds.secret_env.is_empty(), "secret_env defaults to empty");
+
+    let with_env = AgentRunCredentials {
+        claude: None,
+        codex: None,
+        secret_env: std::collections::BTreeMap::from([
+            ("ANTHROPIC_API_KEY".to_string(), "sk-ant-123".to_string()),
+            (
+                "CLAUDE_CODE_OAUTH_TOKEN".to_string(),
+                "sk-ant-oat-456".to_string(),
+            ),
+        ]),
+    };
+    roundtrip(&with_env);
+    let value = serde_json::to_value(&with_env).unwrap();
+    assert_eq!(value["secret_env"]["ANTHROPIC_API_KEY"], "sk-ant-123");
+    assert_eq!(
+        value["secret_env"]["CLAUDE_CODE_OAUTH_TOKEN"],
+        "sk-ant-oat-456"
+    );
 }
 
 #[test]

--- a/providers/workspaces/interactive-tmux/driver-rs/tests/cred_transfer.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/tests/cred_transfer.rs
@@ -218,6 +218,7 @@ fn gemini_stages_only_durable_auth_and_config_files() {
         workdir: "/workspace".to_string(),
         throwaway_dir: tmp("gemini-throwaway"),
         host_claude_dotjson: None,
+        claude_omit_credentials: false,
     };
     let prepared = prepare(Agent::Gemini, &gemini_dir, &ctx).unwrap();
     let staged = prepared.first().expect("Gemini has one staged directory");

--- a/providers/workspaces/interactive-tmux/driver-rs/tests/cred_transfer.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/tests/cred_transfer.rs
@@ -69,6 +69,7 @@ fn prepare_yields_staged_destination_paths_not_mount_bind_args() {
         workdir: "/workspace".to_string(),
         throwaway_dir: tmp("claude-throwaway"),
         host_claude_dotjson: None,
+        claude_omit_credentials: false,
     };
 
     let prepared = prepare(Agent::Claude, &claude_dir, &ctx).unwrap();
@@ -150,6 +151,7 @@ fn plan_for_prepared_claude_auth_includes_transfer_and_secure_steps_for_every_st
         workdir: "/workspace".to_string(),
         throwaway_dir: tmp("claude-throwaway-2"),
         host_claude_dotjson: None,
+        claude_omit_credentials: false,
     };
     let prepared = prepare(Agent::Claude, &claude_dir, &ctx).unwrap();
 
@@ -183,6 +185,7 @@ fn stage_into_container_without_docker_fails_cleanly_not_via_v_mount() {
         workdir: "/workspace".to_string(),
         throwaway_dir: tmp("claude-throwaway-3"),
         host_claude_dotjson: None,
+        claude_omit_credentials: false,
     };
     let prepared = prepare(Agent::Claude, &claude_dir, &ctx).unwrap();
 

--- a/providers/workspaces/interactive-tmux/driver-rs/tests/secret_redaction.rs
+++ b/providers/workspaces/interactive-tmux/driver-rs/tests/secret_redaction.rs
@@ -1,0 +1,232 @@
+//! R5 (load-bearing security test): a run credential secret must travel ONLY
+//! via the stdin transfer or the in-container `0600` env file -> child env. It
+//! must NEVER appear in:
+//!
+//! * a constructed `docker run` / `docker exec` argv,
+//! * a tmux command label / args (the redacted error label),
+//! * an error / fail-fast message string,
+//! * a serialized `AgentRunEvent` JSONL line,
+//! * an `AgentRunResult` / `session_log`,
+//! * the launch wrapper command string sent to the pane.
+//!
+//! A leaked secret is a critical bug, so these assertions are intentionally
+//! exhaustive over every host-side artifact this crate constructs from the
+//! credential material. The secret is allowed to appear in exactly two places:
+//! the in-memory `AgentRunCredentials` (which never serializes to stdout) and
+//! the base64-encoded stdin payload of the credential transfer (which is not
+//! argv).
+
+use std::collections::BTreeMap;
+
+use itmux::adapter::{launch_command_with_env, Agent};
+use itmux::auth::{plan_for_staged_path, secure_path_plan, write_bytes_plan, StagedPath};
+use itmux::run::contract::{AgentRunCredentials, AgentRunEvent, AgentRunOutcome, AgentRunResult};
+use itmux::run::secret_env::{
+    missing_credentials_message, render_env_file, resolve_agent_secrets, ANTHROPIC_API_KEY_ENV,
+    CLAUDE_OAUTH_ENV, OPENAI_API_KEY_ENV,
+};
+
+/// Distinctive sentinel values seeded as the "secrets". If any of these strings
+/// escapes into an argv/label/error/event, the test fails.
+const SENTINEL_CLAUDE: &str = "SECRET_SENTINEL_CLAUDE_sk_ant_oat_DO_NOT_LEAK";
+const SENTINEL_ANTHROPIC: &str = "SECRET_SENTINEL_ANTHROPIC_sk_ant_DO_NOT_LEAK";
+const SENTINEL_OPENAI: &str = "SECRET_SENTINEL_OPENAI_sk_DO_NOT_LEAK";
+
+const ALL_SENTINELS: [&str; 3] = [SENTINEL_CLAUDE, SENTINEL_ANTHROPIC, SENTINEL_OPENAI];
+
+fn assert_no_sentinel(haystack: &str, context: &str) {
+    for sentinel in ALL_SENTINELS {
+        assert!(
+            !haystack.contains(sentinel),
+            "secret sentinel leaked into {context}: {haystack}"
+        );
+    }
+}
+
+fn creds_with_all_sentinels() -> AgentRunCredentials {
+    AgentRunCredentials {
+        claude: None,
+        codex: None,
+        secret_env: BTreeMap::from([
+            (CLAUDE_OAUTH_ENV.to_string(), SENTINEL_CLAUDE.to_string()),
+            (
+                ANTHROPIC_API_KEY_ENV.to_string(),
+                SENTINEL_ANTHROPIC.to_string(),
+            ),
+            (OPENAI_API_KEY_ENV.to_string(), SENTINEL_OPENAI.to_string()),
+        ]),
+    }
+}
+
+#[test]
+fn render_env_file_is_the_carrier_of_the_secret() {
+    // Sanity: the sourced 0600 file IS allowed to contain the secret - it is
+    // one of the only two sanctioned carriers. If it did NOT, the injection
+    // would be broken. (claude routing prefers OAuth over the API key.)
+    let secrets = resolve_agent_secrets(Agent::Claude, &creds_with_all_sentinels());
+    let body = render_env_file(&secrets.env);
+    assert!(
+        body.contains(SENTINEL_CLAUDE),
+        "the 0600 env file must carry the token: {body}"
+    );
+    // Preferred/fallback: OAuth chosen, API key NOT included for claude.
+    assert!(
+        !body.contains(SENTINEL_ANTHROPIC),
+        "api key leaked as fallback when oauth present: {body}"
+    );
+}
+
+#[test]
+fn launch_wrapper_command_has_no_secret() {
+    // The command string sent to the pane carries only the env-file PATH + the
+    // harness command - never the secret.
+    let wrapped = launch_command_with_env(
+        "claude --plugin-dir /opt/skills",
+        "/home/agent/.itmux-secret-env-claude",
+    );
+    assert_no_sentinel(&wrapped, "launch wrapper command");
+    assert!(
+        wrapped.contains("exec claude"),
+        "wrapper must exec the harness: {wrapped}"
+    );
+    assert!(
+        wrapped.contains(". "),
+        "wrapper must source the env file: {wrapped}"
+    );
+}
+
+#[test]
+fn credential_transfer_plan_keeps_secret_out_of_every_argv() {
+    // The env file is staged over the SAME base64-over-stdin transfer as
+    // credentials. Assert: no ExecStep argv contains a sentinel; the secret
+    // rides ONLY in stdin (base64, so not even the plaintext sentinel appears).
+    let secrets = resolve_agent_secrets(Agent::Claude, &creds_with_all_sentinels());
+    let body = render_env_file(&secrets.env);
+    let container_path = "/home/agent/.itmux-secret-env-claude";
+
+    let steps = write_bytes_plan(container_path, body.as_bytes());
+    let mut stdin_carries_it = false;
+    for step in &steps {
+        let argv = step.argv.join(" ");
+        assert_no_sentinel(&argv, "docker exec argv (write_bytes_plan)");
+        if let Some(stdin) = &step.stdin {
+            // The stdin payload is base64; the raw sentinel must NOT appear as
+            // plaintext even there (defense: it is encoded).
+            let stdin_str = String::from_utf8_lossy(stdin);
+            assert_no_sentinel(
+                &stdin_str,
+                "docker exec stdin (must be base64, not plaintext)",
+            );
+            // But base64-decoding it MUST recover the secret (it is the carrier).
+            if base64_decode(&stdin_str)
+                .map(|d| String::from_utf8_lossy(&d).contains(SENTINEL_CLAUDE))
+                .unwrap_or(false)
+            {
+                stdin_carries_it = true;
+            }
+        }
+    }
+    assert!(
+        stdin_carries_it,
+        "the secret must ride in the base64 stdin payload (its only argv-free carrier)"
+    );
+
+    // The trailing secure step (chown/chmod 0600) also never names the secret.
+    let secure = secure_path_plan(container_path, false);
+    assert_no_sentinel(&secure.argv.join(" "), "secure_path_plan argv");
+}
+
+#[test]
+fn full_staged_path_plan_never_leaks_into_argv() {
+    // End-to-end through the real staging entry point used by Workspace::start:
+    // write the env file to a temp path, build the plan, and assert argv purity.
+    let dir = std::env::temp_dir().join(format!(
+        "itmux-secret-redaction-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let secrets = resolve_agent_secrets(Agent::Codex, &creds_with_all_sentinels());
+    let body = render_env_file(&secrets.env);
+    assert!(
+        body.contains(SENTINEL_OPENAI),
+        "codex routes OPENAI_API_KEY: {body}"
+    );
+    let host_file = dir.join("secret-env-codex");
+    std::fs::write(&host_file, &body).unwrap();
+
+    let staged = StagedPath {
+        host: host_file,
+        container: "/home/agent/.itmux-secret-env-codex".to_string(),
+    };
+    for step in plan_for_staged_path(&staged).unwrap() {
+        assert_no_sentinel(&step.argv.join(" "), "plan_for_staged_path argv");
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn fail_fast_and_events_and_results_never_contain_secrets() {
+    // Fail-fast messages name the missing VAR, never a value.
+    for agent in [Agent::Claude, Agent::Codex, Agent::Gemini] {
+        assert_no_sentinel(&missing_credentials_message(agent), "fail-fast message");
+    }
+
+    // A serialized event line never carries a secret (events are telemetry, not
+    // credentials).
+    let event = AgentRunEvent::result(
+        "run-1",
+        0,
+        "2026-07-07T00:00:00Z",
+        AgentRunResult {
+            result: AgentRunOutcome {
+                success: true,
+                summary: "done".to_string(),
+            },
+            output_artifacts: vec![],
+            session_log: "pane transcript with no secrets".to_string(),
+            observability: None,
+        },
+    );
+    let line = serde_json::to_string(&event).unwrap();
+    assert_no_sentinel(&line, "serialized AgentRunEvent JSONL");
+}
+
+/// Minimal std-only base64 decoder for the redaction test (the encoder lives in
+/// `auth`; decoding happens in-container in production, so the crate ships no
+/// decoder - we add one here purely to PROVE the stdin payload is the carrier).
+fn base64_decode(s: &str) -> Option<Vec<u8>> {
+    fn val(c: u8) -> Option<u8> {
+        match c {
+            b'A'..=b'Z' => Some(c - b'A'),
+            b'a'..=b'z' => Some(c - b'a' + 26),
+            b'0'..=b'9' => Some(c - b'0' + 52),
+            b'+' => Some(62),
+            b'/' => Some(63),
+            _ => None,
+        }
+    }
+    let bytes: Vec<u8> = s.bytes().filter(|b| !b.is_ascii_whitespace()).collect();
+    let mut out = Vec::new();
+    for chunk in bytes.chunks(4) {
+        let c0 = val(chunk[0])?;
+        let c1 = val(*chunk.get(1)?)?;
+        out.push((c0 << 2) | (c1 >> 4));
+        if let Some(&b2) = chunk.get(2) {
+            if b2 != b'=' {
+                let c2 = val(b2)?;
+                out.push(((c1 & 0x0F) << 4) | (c2 >> 2));
+                if let Some(&b3) = chunk.get(3) {
+                    if b3 != b'=' {
+                        let c3 = val(b3)?;
+                        out.push(((c2 & 0x03) << 6) | c3);
+                    }
+                }
+            }
+        }
+    }
+    Some(out)
+}


### PR DESCRIPTION
Populates `AgentRunSpec.credentials` from a `.env`/process env so `itmux run` injects subscription (OAuth / auth.json) or API-key credentials via the secure DooD path - instead of `credentials: Default::default()` silently falling back to the stale host `$HOME/.claude` file (**the recurring 401 root cause**, confirmed live in EXP-08: the on-disk creds expire in hours; the live token is in the macOS Keychain). Codex plan-reviewed (8 revisions R1-R8 folded in). Stacked on #247.

## Secrets contract (consumer-supplied; NEVER in the recipe)
```dotenv
CLAUDE_CODE_OAUTH_TOKEN=...   # preferred (1yr from `claude setup-token`)
# ANTHROPIC_API_KEY=...       # fallback
CODEX_AUTH_FILE=~/.codex/auth.json   # preferred (contents materialized in-container)
# OPENAI_API_KEY=...          # fallback
```
`itmux run --env-file <path>` (else process env). Precedence: env-file > process env > (opt-in) `--allow-host-auth-fallback`.

## Injection - no secret ever touches argv (R1/R5)
- claude OAuth injected as the container env var `CLAUDE_CODE_OAUTH_TOKEN`, NOT a synthesized `.credentials.json`.
- Per-agent `0600` env-file staged over the existing base64-over-stdin `docker exec` transfer; pane launched via `set -a; . '/home/agent/.itmux-secret-env-<agent>'; set +a; exec <harness>` (only the file PATH + harness name on the command line).
- **No `docker exec -e VAR=value`, no `tmux set-environment`** (both leak to argv).
- `claude_omit_credentials`: in OAuth mode, stage ONLY the `.claude.json` trust marker, never a `.credentials.json` - so a stale host file can't re-cause the 401.

## Hardening
- **Redaction test** (`tests/secret_redaction.rs`, load-bearing): 3 sentinels asserted absent from every docker argv, the launch wrapper, all error strings, and serialized `AgentRunEvent`s; positively confirms the two sanctioned carriers (rendered env-file body + base64 stdin, decoded in-test).
- **Fail-fast default** with actionable error; `--allow-host-auth-fallback` re-enables the legacy path and warns with the source PATH only (never contents).
- `secret_env: BTreeMap` (defaulted, serde-stable, allowlisted names); legacy `claude.oauth_token`/`codex.auth_json` kept (compat, R8); schema regenerated.
- Thin Python client gains `--env-file` passthrough.

Gates: cargo test 169 pass, clippy -D warnings clean, fmt clean, R8 neutrality guard holds; python pytest 6 / ruff / mypy --strict clean. Fixes the stale-token 401 permanently; retires the Keychain-scrape workaround. Tracks okrs-51p.7.