### PR TITLE
docs(delegation): capture Claude review artifacts

### DIFF
--- a/plugins/delegation/.claude-plugin/plugin.json
+++ b/plugins/delegation/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "delegation",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Handing work off to other agents — autonomous `claude -p` and OpenAI Codex (`codex exec`) delegation, plus structured session-to-session handoff documents.",
   "author": {
     "name": "NeuralEmpowerment"

--- a/plugins/delegation/CHANGELOG.md
+++ b/plugins/delegation/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog - delegation plugin
 
+## 1.2.1 - 2026-07-15
+
+- Adds the structured, read-only Claude Code PR review recipe to
+  `delegating-to-claude-p`: capture `--output-format json` to a caller-owned
+  temporary artifact, validate the terminal result, extract `.result`, and
+  never treat blank output as approval. This provides a durable review/comment
+  handoff contract alongside the existing write-capable delegation recipe.
+
 ## 1.2.0 - 2026-06-08
 
 - Adds `delegating-to-codex` skill: the validated non-interactive `codex exec`

--- a/plugins/delegation/README.md
+++ b/plugins/delegation/README.md
@@ -12,7 +12,9 @@ other coding agents.
   reference grounded in real arc data (5 paired trials + 22 sub-experiments
   total, from the agentic-harness-lab v0.8.0 dogfood arc). The skill body is
   generic — it documents how `claude -p` actually behaves, not project-specific
-  conventions.
+  conventions. Includes a constrained, read-only PR review recipe that captures
+  Claude's terminal JSON result as a durable artifact for PR comments and
+  merge gates.
 
 - **`delegating-to-codex` skill** (under `skills/delegating-to-codex/`):
   The validated non-interactive `codex exec` invocation for handing a task to

--- a/plugins/delegation/skills/delegating-to-claude-p/SKILL.md
+++ b/plugins/delegation/skills/delegating-to-claude-p/SKILL.md
@@ -24,6 +24,40 @@ claude -p --verbose \
   "$TASK_PROMPT"
 ```
 
+## Read-only PR review with a durable result artifact
+
+For an independent code review, constrain Claude to read-only tools and write
+its machine-readable terminal result to a caller-owned temporary file. This is
+the reliable review contract: the wrapper reads `.result`, posts it to the PR
+if useful, and treats a missing or invalid artifact as a failed review -- never
+as approval.
+
+```sh
+review_json="/tmp/claude-pr-review-$(date +%s).json"
+
+claude -p \
+  --safe-mode \
+  --no-session-persistence \
+  --output-format json \
+  --tools 'Bash,Read,Glob,Grep' \
+  --permission-mode bypassPermissions \
+  --max-budget-usd 3 \
+  "Review the current branch against its merge base. Do not edit files.
+Return actionable findings ordered by severity with file:line references, or
+exactly NO MATERIAL FINDINGS." >"$review_json" 2>&1
+
+jq -e '.type == "result" and (.is_error | not)' "$review_json" >/dev/null
+jq -r '.result' "$review_json"
+```
+
+Use this review-specific form instead of the write-capable autonomous recipe
+above. `--safe-mode` disables project hooks, plugins, and project customisation;
+the explicit tool list lets Claude inspect the checkout without editing it.
+`--output-format json` gives the caller a single terminal artifact containing
+the conclusion, session ID, turns, and cost. For long reviews, poll the file
+until it becomes non-empty; do not launch duplicate reviewers or accept a
+blank file as a clean result.
+
 ### Per-flag rationale
 
 - **`--verbose` + `--output-format stream-json`** - required *together*. Text mode hides tool calls and is unscoreable (S7 footgun: stream-json with `--print` errors without `--verbose`). If you only set one, the transcript is useless for triage.
@@ -71,6 +105,8 @@ Use conventional commits. N commits total (Part 1 then Part 2 if applicable).
 | Hung past budget | macOS lacks `timeout`; no time-based bound | `--max-budget-usd` is the only hard cap |
 | Project-local skill never dispatched | `.claude/skills/` is NOT auto-enumerated in `-p` | Name the skill explicitly in the task prompt (bare unnamespaced name dispatches local files) |
 | `tee`-style epilogue lines break JSONL parsing | `echo ... | tee -a transcript.jsonl` writes plain text into JSONL | Write epilogue to a sibling `.txt` file (G-29) |
+| Review wrapper prints no usable conclusion | Text/stream output was not captured as a terminal artifact | Use the read-only JSON review recipe; require `.type == "result"`, then parse `.result` |
+| Review appears clean because its output file is blank | The subprocess is still running or failed before a terminal result | Poll for a non-empty valid JSON result; blank/invalid is a failed review, never approval |
 
 ## Recipe templates
 


### PR DESCRIPTION
## Summary

- add a constrained, read-only Claude Code PR-review recipe to the existing delegation skill
- capture `--output-format json` into a caller-owned temporary artifact and validate/extract `.result`
- document that blank or invalid output is a failed review, never approval
- bump the delegation plugin to 1.2.1

## Validation

- `git diff --check`
- manifest JSON and skill frontmatter checks
- `just qa` ran all uv-backed lint/test suites successfully, then hit an existing bare `pytest`/pyenv executable mismatch in the aggregate recipe; no code or test infrastructure changed by this documentation-only PR.